### PR TITLE
Adds convergence and shear profile

### DIFF
--- a/jaxtronomy/LensModel/Profiles/convergence.py
+++ b/jaxtronomy/LensModel/Profiles/convergence.py
@@ -1,0 +1,66 @@
+__author__ = "sibirrer"
+
+import jaxtronomy.Util.param_util as param_util
+from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
+from jax import jit
+
+__all__ = ["Convergence"]
+
+
+class Convergence(LensProfileBase):
+    """A single mass sheet (external convergence)"""
+
+    model_name = "CONVERGENCE"
+    param_names = ["kappa", "ra_0", "dec_0"]
+    lower_limit_default = {"kappa": -10, "ra_0": -100, "dec_0": -100}
+    upper_limit_default = {"kappa": 10, "ra_0": 100, "dec_0": 100}
+
+    @staticmethod
+    @jit
+    def function(x, y, kappa, ra_0=0, dec_0=0):
+        """Lensing potential.
+
+        :param x: x-coordinate
+        :param y: y-coordinate
+        :param kappa: (external) convergence
+        :return: lensing potential
+        """
+        theta, phi = param_util.cart2polar(x - ra_0, y - dec_0)
+        f_ = 1.0 / 2 * kappa * theta**2
+        return f_
+
+    @staticmethod
+    @jit
+    def derivatives(x, y, kappa, ra_0=0, dec_0=0):
+        """Deflection angle.
+
+        :param x: x-coordinate
+        :param y: y-coordinate
+        :param kappa: (external) convergence
+        :return: deflection angles (first order derivatives)
+        """
+        x_ = x - ra_0
+        y_ = y - dec_0
+        f_x = kappa * x_
+        f_y = kappa * y_
+        return f_x, f_y
+
+    @staticmethod
+    @jit
+    def hessian(x, y, kappa, ra_0=0, dec_0=0):
+        """Hessian matrix.
+
+        :param x: x-coordinate
+        :param y: y-coordinate
+        :param kappa: external convergence
+        :param ra_0: zero point of polynomial expansion (no deflection added)
+        :param dec_0: zero point of polynomial expansion (no deflection added)
+        :return: second order derivatives f_xx, f_xy, f_yx, f_yy
+        """
+        gamma1 = 0
+        gamma2 = 0
+        kappa = kappa
+        f_xx = kappa + gamma1
+        f_yy = kappa - gamma1
+        f_xy = gamma2
+        return f_xx, f_xy, f_xy, f_yy

--- a/jaxtronomy/LensModel/Profiles/shear.py
+++ b/jaxtronomy/LensModel/Profiles/shear.py
@@ -1,0 +1,226 @@
+__author__ = "sibirrer"
+
+import jaxtronomy.Util.param_util as param_util
+from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
+from jaxtronomy.LensModel.Profiles.convergence import Convergence
+import jax.numpy as jnp
+from jax import jit
+
+__all__ = ["Shear", "ShearGammaPsi", "ShearReduced"]
+
+
+class Shear(LensProfileBase):
+    """Class for external shear gamma1, gamma2 expression."""
+
+    param_names = ["gamma1", "gamma2", "ra_0", "dec_0"]
+    lower_limit_default = {"gamma1": -0.5, "gamma2": -0.5, "ra_0": -100, "dec_0": -100}
+    upper_limit_default = {"gamma1": 0.5, "gamma2": 0.5, "ra_0": 100, "dec_0": 100}
+
+    @staticmethod
+    @jit
+    def function(x, y, gamma1, gamma2, ra_0=0, dec_0=0):
+        """
+
+        :param x: x-coordinate (angle)
+        :param y: y0-coordinate (angle)
+        :param gamma1: shear component
+        :param gamma2: shear component
+        :param ra_0: x/ra position where shear deflection is 0
+        :param dec_0: y/dec position where shear deflection is 0
+        :return: lensing potential
+        """
+        x_ = x - ra_0
+        y_ = y - dec_0
+        f_ = 1 / 2.0 * (gamma1 * x_ * x_ + 2 * gamma2 * x_ * y_ - gamma1 * y_ * y_)
+        return f_
+
+    @staticmethod
+    @jit
+    def derivatives(x, y, gamma1, gamma2, ra_0=0, dec_0=0):
+        """
+
+        :param x: x-coordinate (angle)
+        :param y: y0-coordinate (angle)
+        :param gamma1: shear component
+        :param gamma2: shear component
+        :param ra_0: x/ra position where shear deflection is 0
+        :param dec_0: y/dec position where shear deflection is 0
+        :return: deflection angles
+        """
+        x_ = x - ra_0
+        y_ = y - dec_0
+        f_x = gamma1 * x_ + gamma2 * y_
+        f_y = +gamma2 * x_ - gamma1 * y_
+        return f_x, f_y
+
+    @staticmethod
+    @jit
+    def hessian(x, y, gamma1, gamma2, ra_0=0, dec_0=0):
+        """
+
+        :param x: x-coordinate (angle)
+        :param y: y0-coordinate (angle)
+        :param gamma1: shear component
+        :param gamma2: shear component
+        :param ra_0: x/ra position where shear deflection is 0
+        :param dec_0: y/dec position where shear deflection is 0
+        :return: f_xx, f_xy, f_yx, f_yy
+        """
+        gamma1 = gamma1
+        gamma2 = gamma2
+        kappa = 0
+        f_xx = kappa + gamma1
+        f_yy = kappa - gamma1
+        f_xy = gamma2
+        return f_xx, f_xy, f_xy, f_yy
+
+
+class ShearGammaPsi(LensProfileBase):
+    """
+    class to model a shear field with shear strength and direction. The translation ot the cartesian shear distortions
+    is as follow:
+
+    .. math::
+        \\gamma_1 = \\gamma_{ext} \\cos(2 \\phi_{ext})
+        \\gamma_2 = \\gamma_{ext} \\sin(2 \\phi_{ext})
+
+    """
+
+    param_names = ["gamma_ext", "psi_ext", "ra_0", "dec_0"]
+    lower_limit_default = {
+        "gamma_ext": 0,
+        "psi_ext": -jnp.pi,
+        "ra_0": -100,
+        "dec_0": -100,
+    }
+    upper_limit_default = {"gamma_ext": 1, "psi_ext": jnp.pi, "ra_0": 100, "dec_0": 100}
+
+    def __init__(self):
+        super(ShearGammaPsi, self).__init__()
+
+    @staticmethod
+    def function(x, y, gamma_ext, psi_ext, ra_0=0, dec_0=0):
+        """
+
+        :param x: x-coordinate (angle)
+        :param y: y0-coordinate (angle)
+        :param gamma_ext: shear strength
+        :param psi_ext: shear angle (radian)
+        :param ra_0: x/ra position where shear deflection is 0
+        :param dec_0: y/dec position where shear deflection is 0
+        :return:
+        """
+        # change to polar coordinate
+        r, phi = param_util.cart2polar(x - ra_0, y - dec_0)
+        f_ = 1.0 / 2 * gamma_ext * r**2 * jnp.cos(2 * (phi - psi_ext))
+        return f_
+
+    @staticmethod
+    @jit
+    def derivatives(x, y, gamma_ext, psi_ext, ra_0=0, dec_0=0):
+        # rotation angle
+        gamma1, gamma2 = param_util.shear_polar2cartesian(psi_ext, gamma_ext)
+        return Shear.derivatives(x, y, gamma1, gamma2, ra_0, dec_0)
+
+    @staticmethod
+    @jit
+    def hessian(x, y, gamma_ext, psi_ext, ra_0=0, dec_0=0):
+        gamma1, gamma2 = param_util.shear_polar2cartesian(psi_ext, gamma_ext)
+        return Shear.hessian(x, y, gamma1, gamma2, ra_0, dec_0)
+
+
+class ShearReduced(LensProfileBase):
+    """Reduced shear distortions :math:`\\gamma' = \\gamma / (1-\\kappa)`. This
+    distortion keeps the magnification as unity and, thus, does not change the size of
+    apparent objects. To keep the magnification at unity, it requires.
+
+    .. math::
+        (1-\\kappa)^2) - \\gamma_1^2 - \\gamma_2^ = 1
+
+    Thus, for given pair of reduced shear :math:`(\\gamma'_1, \\gamma'_2)`, an additional convergence term is calculated
+    and added to the lensing distortions.
+    """
+
+    param_names = ["gamma1", "gamma2", "ra_0", "dec_0"]
+    lower_limit_default = {"gamma1": -0.5, "gamma2": -0.5, "ra_0": -100, "dec_0": -100}
+    upper_limit_default = {"gamma1": 0.5, "gamma2": 0.5, "ra_0": 100, "dec_0": 100}
+
+    def __init__(self):
+        super(ShearReduced, self).__init__()
+
+    @staticmethod
+    @jit
+    def _kappa_reduced(gamma1, gamma2):
+        """Compute convergence such that magnification is unity.
+
+        :param gamma1: reduced shear
+        :param gamma2: reduced shear
+        :return: kappa
+        """
+        kappa = 1 - 1.0 / jnp.sqrt(1 - gamma1**2 - gamma2**2)
+        gamma1_ = (1 - kappa) * gamma1
+        gamma2_ = (1 - kappa) * gamma2
+        return kappa, gamma1_, gamma2_
+
+    @staticmethod
+    @jit
+    def function(x, y, gamma1, gamma2, ra_0=0, dec_0=0):
+        """
+
+        :param x: x-coordinate (angle)
+        :param y: y0-coordinate (angle)
+        :param gamma1: shear component
+        :param gamma2: shear component
+        :param ra_0: x/ra position where shear deflection is 0
+        :param dec_0: y/dec position where shear deflection is 0
+        :return: lensing potential
+        """
+        kappa, gamma1_, gamma2_ = ShearReduced._kappa_reduced(gamma1, gamma2)
+        f_shear = Shear.function(x, y, gamma1_, gamma2_, ra_0, dec_0)
+        f_kappa = Convergence.function(x, y, kappa, ra_0, dec_0)
+        return f_shear + f_kappa
+
+    @staticmethod
+    @jit
+    def derivatives(x, y, gamma1, gamma2, ra_0=0, dec_0=0):
+        """
+
+        :param x: x-coordinate (angle)
+        :param y: y0-coordinate (angle)
+        :param gamma1: shear component
+        :param gamma2: shear component
+        :param ra_0: x/ra position where shear deflection is 0
+        :param dec_0: y/dec position where shear deflection is 0
+        :return: deflection angles
+        """
+        kappa, gamma1_, gamma2_ = ShearReduced._kappa_reduced(gamma1, gamma2)
+        f_x_shear, f_y_shear = Shear.derivatives(
+            x, y, gamma1_, gamma2_, ra_0, dec_0
+        )
+        f_x_kappa, f_y_kappa = Convergence.derivatives(x, y, kappa, ra_0, dec_0)
+        return f_x_shear + f_x_kappa, f_y_shear + f_y_kappa
+
+    @staticmethod
+    @jit
+    def hessian(x, y, gamma1, gamma2, ra_0=0, dec_0=0):
+        """
+
+        :param x: x-coordinate (angle)
+        :param y: y0-coordinate (angle)
+        :param gamma1: shear component
+        :param gamma2: shear component
+        :param ra_0: x/ra position where shear deflection is 0
+        :param dec_0: y/dec position where shear deflection is 0
+        :return: f_xx, f_xy, f_yx, f_yy
+        """
+        kappa, gamma1_, gamma2_ = ShearReduced._kappa_reduced(gamma1, gamma2)
+        f_xx_g, f_xy_g, f_yx_g, f_yy_g = Shear.hessian(
+            x, y, gamma1_, gamma2_, ra_0, dec_0
+        )
+        f_xx_k, f_xy_k, f_yx_k, f_yy_k = Convergence.hessian(
+            x, y, kappa, ra_0, dec_0
+        )
+        f_xx = f_xx_g + f_xx_k
+        f_yy = f_yy_g + f_yy_k
+        f_xy = f_xy_g + f_xy_k
+        return f_xx, f_xy, f_xy, f_yy

--- a/jaxtronomy/LensModel/Profiles/shear.py
+++ b/jaxtronomy/LensModel/Profiles/shear.py
@@ -150,7 +150,7 @@ class ShearReduced(LensProfileBase):
 
     @staticmethod
     @jit
-    def _kappa_reduced(gamma1, gamma2):
+    def kappa_reduced(gamma1, gamma2):
         """Compute convergence such that magnification is unity.
 
         :param gamma1: reduced shear
@@ -175,7 +175,7 @@ class ShearReduced(LensProfileBase):
         :param dec_0: y/dec position where shear deflection is 0
         :return: lensing potential
         """
-        kappa, gamma1_, gamma2_ = ShearReduced._kappa_reduced(gamma1, gamma2)
+        kappa, gamma1_, gamma2_ = ShearReduced.kappa_reduced(gamma1, gamma2)
         f_shear = Shear.function(x, y, gamma1_, gamma2_, ra_0, dec_0)
         f_kappa = Convergence.function(x, y, kappa, ra_0, dec_0)
         return f_shear + f_kappa
@@ -193,7 +193,7 @@ class ShearReduced(LensProfileBase):
         :param dec_0: y/dec position where shear deflection is 0
         :return: deflection angles
         """
-        kappa, gamma1_, gamma2_ = ShearReduced._kappa_reduced(gamma1, gamma2)
+        kappa, gamma1_, gamma2_ = ShearReduced.kappa_reduced(gamma1, gamma2)
         f_x_shear, f_y_shear = Shear.derivatives(x, y, gamma1_, gamma2_, ra_0, dec_0)
         f_x_kappa, f_y_kappa = Convergence.derivatives(x, y, kappa, ra_0, dec_0)
         return f_x_shear + f_x_kappa, f_y_shear + f_y_kappa
@@ -211,7 +211,7 @@ class ShearReduced(LensProfileBase):
         :param dec_0: y/dec position where shear deflection is 0
         :return: f_xx, f_xy, f_yx, f_yy
         """
-        kappa, gamma1_, gamma2_ = ShearReduced._kappa_reduced(gamma1, gamma2)
+        kappa, gamma1_, gamma2_ = ShearReduced.kappa_reduced(gamma1, gamma2)
         f_xx_g, f_xy_g, f_yx_g, f_yy_g = Shear.hessian(
             x, y, gamma1_, gamma2_, ra_0, dec_0
         )

--- a/jaxtronomy/LensModel/Profiles/shear.py
+++ b/jaxtronomy/LensModel/Profiles/shear.py
@@ -194,9 +194,7 @@ class ShearReduced(LensProfileBase):
         :return: deflection angles
         """
         kappa, gamma1_, gamma2_ = ShearReduced._kappa_reduced(gamma1, gamma2)
-        f_x_shear, f_y_shear = Shear.derivatives(
-            x, y, gamma1_, gamma2_, ra_0, dec_0
-        )
+        f_x_shear, f_y_shear = Shear.derivatives(x, y, gamma1_, gamma2_, ra_0, dec_0)
         f_x_kappa, f_y_kappa = Convergence.derivatives(x, y, kappa, ra_0, dec_0)
         return f_x_shear + f_x_kappa, f_y_shear + f_y_kappa
 
@@ -217,9 +215,7 @@ class ShearReduced(LensProfileBase):
         f_xx_g, f_xy_g, f_yx_g, f_yy_g = Shear.hessian(
             x, y, gamma1_, gamma2_, ra_0, dec_0
         )
-        f_xx_k, f_xy_k, f_yx_k, f_yy_k = Convergence.hessian(
-            x, y, kappa, ra_0, dec_0
-        )
+        f_xx_k, f_xy_k, f_yx_k, f_yy_k = Convergence.hessian(x, y, kappa, ra_0, dec_0)
         f_xx = f_xx_g + f_xx_k
         f_yy = f_yy_g + f_yy_k
         f_xy = f_xy_g + f_xy_k

--- a/jaxtronomy/Util/hyp2f1_util.py
+++ b/jaxtronomy/Util/hyp2f1_util.py
@@ -76,9 +76,7 @@ def hyp2f1_continuation(a, b, c, z, nmax=75):
 
     # The branch cut for this computation of hyp2f1 is on Re(z) >= 1, Im(z) = 0
     # If z is on the branch cut, take the value above the branch cut
-    z = jnp.where(
-        jnp.imag(z) == 0.0, jnp.where(jnp.real(z) >= 1, z + 0.0000001j, z), z
-    )
+    z = jnp.where(jnp.imag(z) == 0.0, jnp.where(jnp.real(z) >= 1, z + 0.0000001j, z), z)
 
     def body_fun(j, val):
         prev_prev_da, prev_prev_db, prev_da, prev_db, sum_1, sum_2 = val
@@ -138,8 +136,9 @@ def hyp2f1_continuation(a, b, c, z, nmax=75):
 @jit
 def hyp2f1_near_one(a, b, c, z, nmax=75):
     """This implementation is based off of equation 15.3.6 in Abramowitz and Stegun.
-    This transformation formula allows for a calculation of hyp2f1 for points near 
-    z = 1 (where other iterative computation schemes converge slowly) by 
+    This transformation formula allows for a calculation of hyp2f1 for points near.
+
+    z = 1 (where other iterative computation schemes converge slowly) by
     transforming z to 1 - z.
 
     However, due to the presence of gamma(c - a - b) and gamma(a + b - c),
@@ -171,6 +170,7 @@ def hyp2f1_near_one(a, b, c, z, nmax=75):
     )
     return term1 + term2
 
+
 @jit
 def hyp2f1(a, b, c, z, nmax=75):
     """This function looks at where z is located on the complex plane and chooses the
@@ -179,8 +179,8 @@ def hyp2f1(a, b, c, z, nmax=75):
 
     If the user already knows which hyp2f1 function to use, this step can be skipped and
     the user can directly call the appropriate hyp2f1 function. If the input z is an
-    array with values in different regions on the complex plane, this function MUST
-    be used so that the appropriate hyp2f1 function is used for each value.
+    array with values in different regions on the complex plane, this function MUST be
+    used so that the appropriate hyp2f1 function is used for each value.
     """
     z = jnp.asarray(z)
     z_shape = jnp.shape(z)
@@ -204,7 +204,7 @@ def hyp2f1(a, b, c, z, nmax=75):
 
     result = lax.fori_loop(0, jnp.size(z), body_fun, jnp.zeros_like(z))
 
-    # Need to reshape result back to the original shape so that if 
+    # Need to reshape result back to the original shape so that if
     # a scalar z is input, a scalar is returned instead of 1d array
     result = jnp.reshape(result, z_shape)
     return result

--- a/jaxtronomy/Util/param_util.py
+++ b/jaxtronomy/Util/param_util.py
@@ -1,6 +1,7 @@
 import jax.numpy as jnp
 from jax import jit
 
+
 @jit
 def cart2polar(x, y, center_x=0, center_y=0):
     """Transforms cartesian coords [x,y] into polar coords [r,phi] in the frame of the
@@ -22,6 +23,7 @@ def cart2polar(x, y, center_x=0, center_y=0):
     phi = jnp.arctan2(coord_shift_y, coord_shift_x)
     return r, phi
 
+
 @jit
 def polar2cart(r, phi, center):
     """Transforms polar coords [r,phi] into cartesian coords [x,y] in the frame of the
@@ -40,6 +42,7 @@ def polar2cart(r, phi, center):
     y = r * jnp.sin(phi)
     return x - center[0], y - center[1]
 
+
 @jit
 def shear_polar2cartesian(phi, gamma):
     """
@@ -52,6 +55,7 @@ def shear_polar2cartesian(phi, gamma):
     gamma2 = gamma * jnp.sin(2 * phi)
     return gamma1, gamma2
 
+
 @jit
 def shear_cartesian2polar(gamma1, gamma2):
     """
@@ -62,6 +66,7 @@ def shear_cartesian2polar(gamma1, gamma2):
     phi = jnp.arctan2(gamma2, gamma1) / 2
     gamma = jnp.sqrt(gamma1**2 + gamma2**2)
     return phi, gamma
+
 
 @jit
 def phi_q2_ellipticity(phi, q):
@@ -76,6 +81,7 @@ def phi_q2_ellipticity(phi, q):
     e2 = (1.0 - q) / (1.0 + q) * jnp.sin(2 * phi)
     return e1, e2
 
+
 @jit
 def ellipticity2phi_q(e1, e2):
     """Transforms complex ellipticity moduli in orientation angle and axis ratio.
@@ -89,6 +95,7 @@ def ellipticity2phi_q(e1, e2):
     c = jnp.minimum(c, 0.9999)
     q = (1 - c) / (1 + c)
     return phi, q
+
 
 @jit
 def transform_e1e2_product_average(x, y, e1, e2, center_x, center_y):
@@ -114,6 +121,7 @@ def transform_e1e2_product_average(x, y, e1, e2, center_x, center_y):
     xt2 = -sin_phi * x_shift + cos_phi * y_shift
     return xt1 * jnp.sqrt(q), xt2 / jnp.sqrt(q)
 
+
 @jit
 def transform_e1e2_square_average(x, y, e1, e2, center_x, center_y):
     """Maps the coordinates x, y with eccentricities e1 e2 into a new elliptical
@@ -136,6 +144,7 @@ def transform_e1e2_square_average(x, y, e1, e2, center_x, center_y):
     x_ = (cos_phi * x_shift + sin_phi * y_shift) * jnp.sqrt(1 - e)
     y_ = (-sin_phi * x_shift + cos_phi * y_shift) * jnp.sqrt(1 + e)
     return x_, y_
+
 
 @jit
 def q2e(q):

--- a/jaxtronomy/Util/param_util.py
+++ b/jaxtronomy/Util/param_util.py
@@ -1,6 +1,7 @@
 import jax.numpy as jnp
+from jax import jit
 
-
+@jit
 def cart2polar(x, y, center_x=0, center_y=0):
     """Transforms cartesian coords [x,y] into polar coords [r,phi] in the frame of the
     lens center.
@@ -21,7 +22,7 @@ def cart2polar(x, y, center_x=0, center_y=0):
     phi = jnp.arctan2(coord_shift_y, coord_shift_x)
     return r, phi
 
-
+@jit
 def polar2cart(r, phi, center):
     """Transforms polar coords [r,phi] into cartesian coords [x,y] in the frame of the
     lense center.
@@ -39,7 +40,7 @@ def polar2cart(r, phi, center):
     y = r * jnp.sin(phi)
     return x - center[0], y - center[1]
 
-
+@jit
 def shear_polar2cartesian(phi, gamma):
     """
 
@@ -51,7 +52,7 @@ def shear_polar2cartesian(phi, gamma):
     gamma2 = gamma * jnp.sin(2 * phi)
     return gamma1, gamma2
 
-
+@jit
 def shear_cartesian2polar(gamma1, gamma2):
     """
     :param gamma1: cartesian shear component
@@ -62,7 +63,7 @@ def shear_cartesian2polar(gamma1, gamma2):
     gamma = jnp.sqrt(gamma1**2 + gamma2**2)
     return phi, gamma
 
-
+@jit
 def phi_q2_ellipticity(phi, q):
     """Transforms orientation angle and axis ratio into complex ellipticity moduli e1,
     e2.
@@ -75,7 +76,7 @@ def phi_q2_ellipticity(phi, q):
     e2 = (1.0 - q) / (1.0 + q) * jnp.sin(2 * phi)
     return e1, e2
 
-
+@jit
 def ellipticity2phi_q(e1, e2):
     """Transforms complex ellipticity moduli in orientation angle and axis ratio.
 
@@ -89,7 +90,7 @@ def ellipticity2phi_q(e1, e2):
     q = (1 - c) / (1 + c)
     return phi, q
 
-
+@jit
 def transform_e1e2_product_average(x, y, e1, e2, center_x, center_y):
     """Maps the coordinates x, y with eccentricities e1 e2 into a new elliptical
     coordinate system such that R = sqrt(R_major * R_minor)
@@ -113,7 +114,7 @@ def transform_e1e2_product_average(x, y, e1, e2, center_x, center_y):
     xt2 = -sin_phi * x_shift + cos_phi * y_shift
     return xt1 * jnp.sqrt(q), xt2 / jnp.sqrt(q)
 
-
+@jit
 def transform_e1e2_square_average(x, y, e1, e2, center_x, center_y):
     """Maps the coordinates x, y with eccentricities e1 e2 into a new elliptical
     coordinate system such that R = sqrt(R_major**2 + R_minor**2)
@@ -136,7 +137,7 @@ def transform_e1e2_square_average(x, y, e1, e2, center_x, center_y):
     y_ = (-sin_phi * x_shift + cos_phi * y_shift) * jnp.sqrt(1 + e)
     return x_, y_
 
-
+@jit
 def q2e(q):
     """computes.
 

--- a/test/test_LensModel/test_Profiles/test_convergence.py
+++ b/test/test_LensModel/test_Profiles/test_convergence.py
@@ -1,0 +1,73 @@
+__author__ = "sibirrer"
+
+
+from lenstronomy.LensModel.Profiles.convergence import Convergence as Convergence_ref
+from jaxtronomy.LensModel.Profiles.convergence import Convergence
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+
+class TestConvergence(object):
+    """Tests the Gaussian methods."""
+
+    def setup_method(self):
+        self.convergence_ref = Convergence_ref()
+        self.kwargs_lens = {"kappa": 0.1}
+
+    def test_function(self):
+        x = np.array([1])
+        y = np.array([0])
+        values = Convergence.function(x, y, **self.kwargs_lens)
+        values_ref = self.convergence_ref.function(x, y, **self.kwargs_lens)
+        npt.assert_array_almost_equal(values, values_ref, decimal=7)
+        x = np.array([0])
+        y = np.array([0])
+        values = Convergence.function(x, y, **self.kwargs_lens)
+        values_ref = self.convergence_ref.function(x, y, **self.kwargs_lens)
+        npt.assert_array_almost_equal(values, values_ref, decimal=7)
+
+        x = np.array([2, 3, 4])
+        y = np.array([1, 1, 1])
+        values = Convergence.function(x, y, **self.kwargs_lens)
+        values_ref = self.convergence_ref.function(x, y, **self.kwargs_lens)
+        npt.assert_array_almost_equal(values, values_ref, decimal=7)
+
+    def test_derivatives(self):
+        x = np.array([1])
+        y = np.array([2])
+        f_x, f_y = Convergence.derivatives(x, y, **self.kwargs_lens)
+        f_x_ref, f_y_ref = self.convergence_ref.derivatives(x, y, **self.kwargs_lens)
+        npt.assert_almost_equal(f_x, f_x_ref, decimal=7)
+        npt.assert_almost_equal(f_y, f_y_ref, decimal=7)
+
+        x = np.array([1, 3, 4])
+        y = np.array([2, 1, 1])
+        f_x, f_y = Convergence.derivatives(x, y, **self.kwargs_lens)
+        f_x_ref, f_y_ref = self.convergence_ref.derivatives(x, y, **self.kwargs_lens)
+        npt.assert_almost_equal(f_x, f_x_ref, decimal=7)
+        npt.assert_almost_equal(f_y, f_y_ref, decimal=7)
+
+    def test_hessian(self):
+        x = np.array([1])
+        y = np.array([2])
+        f_xx, f_xy, f_yx, f_yy = Convergence.hessian(x, y, **self.kwargs_lens)
+        f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.convergence_ref.hessian(x, y, **self.kwargs_lens)
+        npt.assert_almost_equal(f_xx, f_xx_ref, decimal=7)
+        npt.assert_almost_equal(f_yy, f_yy_ref, decimal=7)
+        npt.assert_almost_equal(f_xy, f_xy_ref, decimal=7)
+        npt.assert_almost_equal(f_yx, f_yx_ref, decimal=7)
+
+        x = np.array([1, 3, 4])
+        y = np.array([2, 1, 1])
+        f_xx, f_xy, f_yx, f_yy = Convergence.hessian(x, y, **self.kwargs_lens)
+        f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.convergence_ref.hessian(x, y, **self.kwargs_lens)
+        npt.assert_almost_equal(f_xx, f_xx_ref, decimal=7)
+        npt.assert_almost_equal(f_yy, f_yy_ref, decimal=7)
+        npt.assert_almost_equal(f_xy, f_xy_ref, decimal=7)
+        npt.assert_almost_equal(f_yx, f_yx_ref, decimal=7)
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/test/test_LensModel/test_Profiles/test_convergence.py
+++ b/test/test_LensModel/test_Profiles/test_convergence.py
@@ -53,7 +53,9 @@ class TestConvergence(object):
         x = np.array([1])
         y = np.array([2])
         f_xx, f_xy, f_yx, f_yy = Convergence.hessian(x, y, **self.kwargs_lens)
-        f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.convergence_ref.hessian(x, y, **self.kwargs_lens)
+        f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.convergence_ref.hessian(
+            x, y, **self.kwargs_lens
+        )
         npt.assert_almost_equal(f_xx, f_xx_ref, decimal=7)
         npt.assert_almost_equal(f_yy, f_yy_ref, decimal=7)
         npt.assert_almost_equal(f_xy, f_xy_ref, decimal=7)
@@ -62,7 +64,9 @@ class TestConvergence(object):
         x = np.array([1, 3, 4])
         y = np.array([2, 1, 1])
         f_xx, f_xy, f_yx, f_yy = Convergence.hessian(x, y, **self.kwargs_lens)
-        f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.convergence_ref.hessian(x, y, **self.kwargs_lens)
+        f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.convergence_ref.hessian(
+            x, y, **self.kwargs_lens
+        )
         npt.assert_almost_equal(f_xx, f_xx_ref, decimal=7)
         npt.assert_almost_equal(f_yy, f_yy_ref, decimal=7)
         npt.assert_almost_equal(f_xy, f_xy_ref, decimal=7)

--- a/test/test_LensModel/test_Profiles/test_shear.py
+++ b/test/test_LensModel/test_Profiles/test_shear.py
@@ -92,6 +92,7 @@ class TestShearGammaPsi(object):
 
     def setup_method(self):
         self.sheargammapsi_ref = ShearGammaPsi_ref()
+        test_init = ShearGammaPsi()
 
     def test_function(self):
         x = np.array([1, 3, 4])
@@ -122,6 +123,7 @@ class TestShearReduced(object):
 
     def setup_method(self):
         self.shearreduced_ref = ShearReduced_ref()
+        test_init = ShearReduced()
 
     def test_kappa_reduced(self):
         x = np.array([1, 3, 4])

--- a/test/test_LensModel/test_Profiles/test_shear.py
+++ b/test/test_LensModel/test_Profiles/test_shear.py
@@ -129,7 +129,7 @@ class TestShearReduced(object):
         x = np.array([1, 3, 4])
         y = np.array([2, 1, 1])
         gamma1, gamma2 = -0.4, 0.4
-        kappa, gamma1_, gamma2_ = ShearReduced._kappa_reduced(gamma1, gamma2)
+        kappa, gamma1_, gamma2_ = ShearReduced.kappa_reduced(gamma1, gamma2)
         kappa_ref, gamma1_ref_, gamma2_ref_ = self.shearreduced_ref._kappa_reduced(
             gamma1, gamma2
         )

--- a/test/test_LensModel/test_Profiles/test_shear.py
+++ b/test/test_LensModel/test_Profiles/test_shear.py
@@ -59,7 +59,9 @@ class TestShear(object):
         y = np.array([2])
 
         f_xx, f_xy, f_yx, f_yy = Shear.hessian(x, y, **self.kwargs_lens)
-        f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.shear_ref.hessian(x, y, **self.kwargs_lens)
+        f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.shear_ref.hessian(
+            x, y, **self.kwargs_lens
+        )
         npt.assert_array_almost_equal(f_xx, f_xx_ref, decimal=7)
         npt.assert_array_almost_equal(f_xy, f_xy_ref, decimal=7)
         npt.assert_array_almost_equal(f_yx, f_yx_ref, decimal=7)
@@ -68,7 +70,9 @@ class TestShear(object):
         x = np.array([1, 3, 4])
         y = np.array([2, 1, 1])
         f_xx, f_xy, f_yx, f_yy = Shear.hessian(x, y, **self.kwargs_lens)
-        f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.shear_ref.hessian(x, y, **self.kwargs_lens)
+        f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.shear_ref.hessian(
+            x, y, **self.kwargs_lens
+        )
         npt.assert_array_almost_equal(f_xx, f_xx_ref, decimal=7)
         npt.assert_array_almost_equal(f_xy, f_xy_ref, decimal=7)
         npt.assert_array_almost_equal(f_yx, f_yx_ref, decimal=7)
@@ -124,7 +128,9 @@ class TestShearReduced(object):
         y = np.array([2, 1, 1])
         gamma1, gamma2 = -0.4, 0.4
         kappa, gamma1_, gamma2_ = ShearReduced._kappa_reduced(gamma1, gamma2)
-        kappa_ref, gamma1_ref_, gamma2_ref_ = self.shearreduced_ref._kappa_reduced(gamma1, gamma2)
+        kappa_ref, gamma1_ref_, gamma2_ref_ = self.shearreduced_ref._kappa_reduced(
+            gamma1, gamma2
+        )
         npt.assert_array_almost_equal(kappa, kappa_ref, decimal=7)
         npt.assert_array_almost_equal(gamma1_, gamma1_ref_, decimal=7)
         npt.assert_array_almost_equal(gamma2_, gamma2_ref_, decimal=7)

--- a/test/test_LensModel/test_Profiles/test_shear.py
+++ b/test/test_LensModel/test_Profiles/test_shear.py
@@ -1,0 +1,158 @@
+__author__ = "sibirrer"
+
+from lenstronomy.LensModel.Profiles.shear import Shear as Shear_ref
+from lenstronomy.LensModel.Profiles.shear import ShearGammaPsi as ShearGammaPsi_ref
+from lenstronomy.LensModel.Profiles.shear import ShearReduced as ShearReduced_ref
+from lenstronomy.LensModel.lens_model import LensModel as LensModel_ref
+
+from jaxtronomy.LensModel.Profiles.shear import Shear, ShearGammaPsi, ShearReduced
+from jaxtronomy.LensModel.lens_model import LensModel
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+
+class TestShear(object):
+    """Tests the Gaussian methods."""
+
+    def setup_method(self):
+        self.shear_ref = Shear_ref()
+        gamma1, gamma2 = 0.1, 0.1
+        self.kwargs_lens = {"gamma1": gamma1, "gamma2": gamma2}
+
+    def test_function(self):
+        x = np.array([1])
+        y = np.array([2])
+        values = Shear.function(x, y, **self.kwargs_lens)
+        values_ref = self.shear_ref.function(x, y, **self.kwargs_lens)
+        npt.assert_array_almost_equal(values, values_ref, decimal=7)
+        x = np.array([0])
+        y = np.array([0])
+        values = Shear.function(x, y, **self.kwargs_lens)
+        values_ref = self.shear_ref.function(x, y, **self.kwargs_lens)
+        npt.assert_array_almost_equal(values, values_ref, decimal=7)
+
+        x = np.array([2, 3, 4])
+        y = np.array([1, 1, 1])
+        values = Shear.function(x, y, **self.kwargs_lens)
+        values_ref = self.shear_ref.function(x, y, **self.kwargs_lens)
+        npt.assert_array_almost_equal(values, values_ref, decimal=7)
+
+    def test_derivatives(self):
+        x = np.array([1])
+        y = np.array([2])
+        f_x, f_y = Shear.derivatives(x, y, **self.kwargs_lens)
+        f_x_ref, f_y_ref = self.shear_ref.derivatives(x, y, **self.kwargs_lens)
+        npt.assert_array_almost_equal(f_x, f_x_ref, decimal=7)
+        npt.assert_array_almost_equal(f_y, f_y_ref, decimal=7)
+
+        x = np.array([1, 3, 4])
+        y = np.array([2, 1, 1])
+        f_x, f_y = Shear.derivatives(x, y, **self.kwargs_lens)
+        f_x_ref, f_y_ref = self.shear_ref.derivatives(x, y, **self.kwargs_lens)
+        npt.assert_array_almost_equal(f_x, f_x_ref, decimal=7)
+        npt.assert_array_almost_equal(f_y, f_y_ref, decimal=7)
+
+    def test_hessian(self):
+        x = np.array([1])
+        y = np.array([2])
+
+        f_xx, f_xy, f_yx, f_yy = Shear.hessian(x, y, **self.kwargs_lens)
+        f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.shear_ref.hessian(x, y, **self.kwargs_lens)
+        npt.assert_array_almost_equal(f_xx, f_xx_ref, decimal=7)
+        npt.assert_array_almost_equal(f_xy, f_xy_ref, decimal=7)
+        npt.assert_array_almost_equal(f_yx, f_yx_ref, decimal=7)
+        npt.assert_array_almost_equal(f_yy, f_yy_ref, decimal=7)
+
+        x = np.array([1, 3, 4])
+        y = np.array([2, 1, 1])
+        f_xx, f_xy, f_yx, f_yy = Shear.hessian(x, y, **self.kwargs_lens)
+        f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.shear_ref.hessian(x, y, **self.kwargs_lens)
+        npt.assert_array_almost_equal(f_xx, f_xx_ref, decimal=7)
+        npt.assert_array_almost_equal(f_xy, f_xy_ref, decimal=7)
+        npt.assert_array_almost_equal(f_yx, f_yx_ref, decimal=7)
+        npt.assert_array_almost_equal(f_yy, f_yy_ref, decimal=7)
+
+        gamma1, gamma2 = 0.1, -0.1
+        kwargs = {"gamma1": gamma1, "gamma2": gamma2}
+        lensModel = LensModel(["SHEAR"])
+        lensModel_ref = LensModel_ref(["SHEAR"])
+        gamma1, gamma2 = lensModel.gamma(x, y, [kwargs])
+        gamma1_ref, gamma2_ref = lensModel_ref.gamma(x, y, [kwargs])
+        npt.assert_array_almost_equal(gamma1, gamma1_ref, decimal=9)
+        npt.assert_array_almost_equal(gamma2, gamma2_ref, decimal=9)
+
+
+class TestShearGammaPsi(object):
+
+    def setup_method(self):
+        self.sheargammapsi_ref = ShearGammaPsi_ref()
+
+    def test_function(self):
+        x = np.array([1, 3, 4])
+        y = np.array([2, 1, 1])
+        gamma, psi = 0.1, 0.5
+        values = ShearGammaPsi.function(x, y, gamma, psi)
+        values_ref = self.sheargammapsi_ref.function(x, y, gamma, psi)
+        npt.assert_array_almost_equal(values, values_ref, decimal=7)
+
+    def test_derivatives(self):
+        x = np.array([1, 3, 4])
+        y = np.array([2, 1, 1])
+        gamma, psi = 0.1, 0.5
+        values = ShearGammaPsi.derivatives(x, y, gamma, psi)
+        values_ref = self.sheargammapsi_ref.derivatives(x, y, gamma, psi)
+        npt.assert_array_almost_equal(values, values_ref, decimal=7)
+
+    def test_hessian(self):
+        x = np.array([1, 3, 4])
+        y = np.array([2, 1, 1])
+        gamma, psi = 0.1, 0.5
+        values = ShearGammaPsi.hessian(x, y, gamma, psi)
+        values_ref = self.sheargammapsi_ref.hessian(x, y, gamma, psi)
+        npt.assert_array_almost_equal(values, values_ref, decimal=7)
+
+
+class TestShearReduced(object):
+
+    def setup_method(self):
+        self.shearreduced_ref = ShearReduced_ref()
+
+    def test_kappa_reduced(self):
+        x = np.array([1, 3, 4])
+        y = np.array([2, 1, 1])
+        gamma1, gamma2 = -0.4, 0.4
+        kappa, gamma1_, gamma2_ = ShearReduced._kappa_reduced(gamma1, gamma2)
+        kappa_ref, gamma1_ref_, gamma2_ref_ = self.shearreduced_ref._kappa_reduced(gamma1, gamma2)
+        npt.assert_array_almost_equal(kappa, kappa_ref, decimal=7)
+        npt.assert_array_almost_equal(gamma1_, gamma1_ref_, decimal=7)
+        npt.assert_array_almost_equal(gamma2_, gamma2_ref_, decimal=7)
+
+    def test_function(self):
+        x = np.array([1, 3, 4])
+        y = np.array([2, 1, 1])
+        gamma1, gamma2 = 0.1, 0.5
+        values = ShearReduced.function(x, y, gamma1, gamma2)
+        values_ref = self.shearreduced_ref.function(x, y, gamma1, gamma2)
+        npt.assert_array_almost_equal(values, values_ref, decimal=7)
+
+    def test_derivatives(self):
+        x = np.array([1, 3, 4])
+        y = np.array([2, 1, 1])
+        gamma1, gamma2 = 0.2, 0.4
+        values = ShearReduced.derivatives(x, y, gamma1, gamma2)
+        values_ref = self.shearreduced_ref.derivatives(x, y, gamma1, gamma2)
+        npt.assert_array_almost_equal(values, values_ref, decimal=7)
+
+    def test_hessian(self):
+        x = np.array([1, 3, 4])
+        y = np.array([2, 1, 1])
+        gamma1, gamma2 = 0.1, 0.3
+        values = ShearReduced.hessian(x, y, gamma1, gamma2)
+        values_ref = self.shearreduced_ref.hessian(x, y, gamma1, gamma2)
+        npt.assert_array_almost_equal(values, values_ref, decimal=7)
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/test/test_Util/test_hyp2f1_util.py
+++ b/test/test_Util/test_hyp2f1_util.py
@@ -6,8 +6,7 @@ import jax
 jax.config.update("jax_enable_x64", True)  # 64-bit floats, consistent with numpy
 import jax.numpy as jnp
 from jaxtronomy.Util.hyp2f1_util import (
-    hyp2f1_scalar,
-    hyp2f1_array,
+    hyp2f1,
     hyp2f1_series,
     hyp2f1_near_one,
     hyp2f1_continuation,
@@ -116,26 +115,30 @@ def test_hyp2f1():
     x = jnp.array([-0.8, 1.3, 0.6, -1.6])
     y = jnp.array([0.3, 0.1, 0.6, -2.2])
     z = x + y * 1j
-    result = hyp2f1_array(a, b, c, z)
+    result = hyp2f1(a, b, c, z)
     result_ref = hyp2f1_ref(a, b, c, z)
     assert jnp.allclose(result, result_ref), "hyp2f1 result does not match scipy result"
+    assert jnp.shape(result) == jnp.shape(z), "shape of output does not match shape of input"
 
     # Points that are problematic for specific cases should not be
     # problematic here in the general case
     z = jnp.array([1.01 + 0.0001j, 0.05 + 0.001j, 0.99 + 0.001j])
-    result = hyp2f1_array(a, b, c, z)
+    result = hyp2f1(a, b, c, z)
     result_ref = hyp2f1_ref(a, b, c, z)
     assert jnp.allclose(result, result_ref), "hyp2f1 result does not match scipy result"
+    assert jnp.shape(result) == jnp.shape(z), "shape of output does not match shape of input"
 
     # Supports list inputs
     z = [0.605 + 0.65j, 0.609 + 0.65j, 0.6072 + 0.0651j]
-    result = hyp2f1_array(a, b, c, z)
+    result = hyp2f1(a, b, c, z)
     result_ref = hyp2f1_ref(a, b, c, z)
     assert jnp.allclose(result, result_ref), "hyp2f1 result does not match scipy result"
+    assert jnp.shape(result) == jnp.shape(z), "shape of output does not match shape of input"
 
     # Tests to see if the value above the branch cut is taken
     # Also supports scalar inputs
     z = 3.0 + 0.0j
-    result = hyp2f1_scalar(a, b, c, z)
+    result = hyp2f1(a, b, c, z)
     result_ref = hyp2f1_ref(a, b, c, z)
     assert jnp.allclose(result, result_ref), "hyp2f1 result does not match scipy result"
+    assert jnp.shape(result) == jnp.shape(z), "shape of output does not match shape of input"

--- a/test/test_Util/test_hyp2f1_util.py
+++ b/test/test_Util/test_hyp2f1_util.py
@@ -118,7 +118,9 @@ def test_hyp2f1():
     result = hyp2f1(a, b, c, z)
     result_ref = hyp2f1_ref(a, b, c, z)
     assert jnp.allclose(result, result_ref), "hyp2f1 result does not match scipy result"
-    assert jnp.shape(result) == jnp.shape(z), "shape of output does not match shape of input"
+    assert jnp.shape(result) == jnp.shape(
+        z
+    ), "shape of output does not match shape of input"
 
     # Points that are problematic for specific cases should not be
     # problematic here in the general case
@@ -126,14 +128,18 @@ def test_hyp2f1():
     result = hyp2f1(a, b, c, z)
     result_ref = hyp2f1_ref(a, b, c, z)
     assert jnp.allclose(result, result_ref), "hyp2f1 result does not match scipy result"
-    assert jnp.shape(result) == jnp.shape(z), "shape of output does not match shape of input"
+    assert jnp.shape(result) == jnp.shape(
+        z
+    ), "shape of output does not match shape of input"
 
     # Supports list inputs
     z = [0.605 + 0.65j, 0.609 + 0.65j, 0.6072 + 0.0651j]
     result = hyp2f1(a, b, c, z)
     result_ref = hyp2f1_ref(a, b, c, z)
     assert jnp.allclose(result, result_ref), "hyp2f1 result does not match scipy result"
-    assert jnp.shape(result) == jnp.shape(z), "shape of output does not match shape of input"
+    assert jnp.shape(result) == jnp.shape(
+        z
+    ), "shape of output does not match shape of input"
 
     # Tests to see if the value above the branch cut is taken
     # Also supports scalar inputs
@@ -141,4 +147,6 @@ def test_hyp2f1():
     result = hyp2f1(a, b, c, z)
     result_ref = hyp2f1_ref(a, b, c, z)
     assert jnp.allclose(result, result_ref), "hyp2f1 result does not match scipy result"
-    assert jnp.shape(result) == jnp.shape(z), "shape of output does not match shape of input"
+    assert jnp.shape(result) == jnp.shape(
+        z
+    ), "shape of output does not match shape of input"


### PR DESCRIPTION
This PR adds the convergence and shear profiles to JAXtronomy. Summary of changes:

1. All shear and convergence classes have had their functions changed to staticmethods. This way, an instance of the class does not need to be initialized in order to access their functions. This is because re-creating new instances of classes can sometimes cause the class methods to be recompiled by JAX, and we want to avoid that.
2. I reverted a change I made 2 PR's ago for the hyp2f1 function. We don't need separate functions for scalar and array inputs.
3. JIT decorated all functions in param_util, which was previously missing