### PR TITLE
Added SPP, modified EPL

### DIFF
--- a/jaxtronomy/LensModel/Profiles/epl.py
+++ b/jaxtronomy/LensModel/Profiles/epl.py
@@ -510,9 +510,5 @@ class EPLQPhi(LensProfileBase):
         return self._EPL.density_lens(r, theta_E, gamma)
 
 
-tree_util.register_pytree_node(
-    EPL, EPL._tree_flatten, EPL._tree_unflatten
-)
-tree_util.register_pytree_node(
-    EPLQPhi, EPLQPhi._tree_flatten, EPLQPhi._tree_unflatten
-)
+tree_util.register_pytree_node(EPL, EPL._tree_flatten, EPL._tree_unflatten)
+tree_util.register_pytree_node(EPLQPhi, EPLQPhi._tree_flatten, EPLQPhi._tree_unflatten)

--- a/jaxtronomy/LensModel/Profiles/epl.py
+++ b/jaxtronomy/LensModel/Profiles/epl.py
@@ -73,7 +73,7 @@ class EPL(LensProfileBase):
     }
 
     # These static self variables are not used until self.set_static is called
-    # However these need to be here for the JAX compiler to correctly keep track
+    # However these need to be here for the JAX to correctly keep track of them
     def __init__(self, b=0, t=0, q=0, phi=0, static=False):
         self._static = static
         self._b_static = b

--- a/jaxtronomy/LensModel/Profiles/epl.py
+++ b/jaxtronomy/LensModel/Profiles/epl.py
@@ -11,8 +11,8 @@ import jax.numpy as jnp
 from jaxtronomy.Util.hyp2f1_util import hyp2f1_series as hyp2f1
 import jaxtronomy.Util.util as util
 import jaxtronomy.Util.param_util as param_util
+from jaxtronomy.LensModel.Profiles.spp import SPP
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
-from lenstronomy.LensModel.Profiles.spp import SPP
 
 jax.config.update("jax_enable_x64", True)  # 64-bit floats, consistent with numpy
 
@@ -72,11 +72,32 @@ class EPL(LensProfileBase):
         "center_y": 100,
     }
 
-    def __init__(self):
-        self.epl_major_axis = EPLMajorAxis()
-        self.spp = SPP()
-        super(EPL, self).__init__()
+    # These static self variables are not used until self.set_static is called
+    # However these need to be here for the JAX compiler to correctly keep track
+    def __init__(self, b=0, t=0, q=0, phi=0, static=False):
+        self._static = static
+        self._b_static = b
+        self._t_static = t
+        self._q_static = q
+        self._phi_G_static = phi
 
+    # --------------------------------------------------------------------------------
+    # The following two methods are required to allow the JAX compiler to recognize
+    # this class. Methods involving the self variable can be jit-decorated.
+    # Class methods will need to be recompiled each time a variable in the aux_data
+    # changes to a new value (but there's no need to recompile if it changes to a previous value)
+    def _tree_flatten(self):
+        children = (self._b_static, self._t_static, self._q_static, self._phi_G_static)
+        aux_data = {"static": self._static}
+        return (children, aux_data)
+
+    @classmethod
+    def _tree_unflatten(cls, aux_data, children):
+        return cls(*children, **aux_data)
+
+    # --------------------------------------------------------------------------------
+
+    @jit
     def param_conv(self, theta_E, gamma, e1, e2):
         """Converts parameters as defined in this class to the parameters used in the
         EPLMajorAxis() class.
@@ -89,9 +110,11 @@ class EPL(LensProfileBase):
         """
         if self._static is True:
             return self._b_static, self._t_static, self._q_static, self._phi_G_static
-        return self._param_conv(theta_E, gamma, e1, e2)
+        else:
+            return self._param_conv(theta_E, gamma, e1, e2)
 
     @staticmethod
+    @jit
     def _param_conv(theta_E, gamma, e1, e2):
         """Convert parameters from :math:`R = \\sqrt{q x^2 + y^2/q}` to :math:`R =
         \\sqrt{q^2 x^2 + y^2}`
@@ -128,19 +151,11 @@ class EPL(LensProfileBase):
 
     def set_dynamic(self):
         """
-
         :return:
         """
         self._static = False
-        if hasattr(self, "_b_static"):
-            del self._b_static
-        if hasattr(self, "_t_static"):
-            del self._t_static
-        if hasattr(self, "_phi_G_static"):
-            del self._phi_G_static
-        if hasattr(self, "_q_static"):
-            del self._q_static
 
+    @jit
     def function(self, x, y, theta_E, gamma, e1, e2, center_x=0, center_y=0):
         """
 
@@ -161,10 +176,11 @@ class EPL(LensProfileBase):
         # rotate
         x__, y__ = util.rotate(x_, y_, phi_G)
         # evaluate
-        f_ = self.epl_major_axis.function(x__, y__, b, t, q)
+        f_ = EPLMajorAxis.function(x__, y__, b, t, q)
         # rotate back
         return f_
 
+    @jit
     def derivatives(self, x, y, theta_E, gamma, e1, e2, center_x=0, center_y=0):
         """
 
@@ -185,11 +201,12 @@ class EPL(LensProfileBase):
         # rotate
         x__, y__ = util.rotate(x_, y_, phi_G)
         # evaluate
-        f__x, f__y = self.epl_major_axis.derivatives(x__, y__, b, t, q)
+        f__x, f__y = EPLMajorAxis.derivatives(x__, y__, b, t, q)
         # rotate back
         f_x, f_y = util.rotate(f__x, f__y, -phi_G)
         return f_x, f_y
 
+    @jit
     def hessian(self, x, y, theta_E, gamma, e1, e2, center_x=0, center_y=0):
         """
 
@@ -211,18 +228,19 @@ class EPL(LensProfileBase):
         # rotate
         x__, y__ = util.rotate(x_, y_, phi_G)
         # evaluate
-        f__xx, f__xy, f__yx, f__yy = self.epl_major_axis.hessian(x__, y__, b, t, q)
+        f__xx, f__xy, f__yx, f__yy = EPLMajorAxis.hessian(x__, y__, b, t, q)
         # rotate back
         kappa = 1.0 / 2 * (f__xx + f__yy)
         gamma1__ = 1.0 / 2 * (f__xx - f__yy)
         gamma2__ = f__xy
         gamma1 = jnp.cos(2 * phi_G) * gamma1__ - jnp.sin(2 * phi_G) * gamma2__
-        gamma2 = +jnp.sin(2 * phi_G) * gamma1__ + jnp.cos(2 * phi_G) * gamma2__
+        gamma2 = jnp.sin(2 * phi_G) * gamma1__ + jnp.cos(2 * phi_G) * gamma2__
         f_xx = kappa + gamma1
         f_yy = kappa - gamma1
         f_xy = gamma2
         return f_xx, f_xy, f_xy, f_yy
 
+    @jit
     def mass_3d_lens(self, r, theta_E, gamma, e1=None, e2=None):
         """Computes the spherical power-law mass enclosed (with SPP routine)
 
@@ -233,8 +251,9 @@ class EPL(LensProfileBase):
         :param e2: eccentricity component (not used)
         :return: mass enclosed a 3D radius r.
         """
-        return self.spp.mass_3d_lens(r, theta_E, gamma)
+        return SPP.mass_3d_lens(r, theta_E, gamma)
 
+    @jit
     def density_lens(self, r, theta_E, gamma, e1=None, e2=None):
         """Computes the density at 3d radius r given lens model parameterization. The
         integral in the LOS projection of this quantity results in the convergence
@@ -247,7 +266,7 @@ class EPL(LensProfileBase):
         :param e2: eccentricity component (not used)
         :return: mass enclosed a 3D radius r
         """
-        return self.spp.density_lens(r, theta_E, gamma)
+        return SPP.density_lens(r, theta_E, gamma)
 
 
 class EPLMajorAxis(LensProfileBase):
@@ -267,24 +286,9 @@ class EPLMajorAxis(LensProfileBase):
     def __init__(self):
         super(EPLMajorAxis, self).__init__()
 
-    # --------------------------------------------------------------------------------
-    # The following two methods are required to allow the JAX compiler to recognize
-    # this class. Methods involving the self variable can be jit-decorated.
-    # Class methods will need to be recompiled each time a variable in the aux_data
-    # changes to a new value (in this case, no recompiling is ever done)
-    def _tree_flatten(self):
-        children = ()
-        aux_data = {}
-        return (children, aux_data)
-
-    @classmethod
-    def _tree_unflatten(cls, aux_data, children):
-        return cls(*children, **aux_data)
-
-    # --------------------------------------------------------------------------------
-
+    @staticmethod
     @jit
-    def function(self, x, y, b, t, q):
+    def function(x, y, b, t, q):
         """Returns the lensing potential.
 
         :param x: x-coordinate in image plane relative to center (major axis)
@@ -295,7 +299,7 @@ class EPLMajorAxis(LensProfileBase):
         :return: lensing potential
         """
         # deflection from method
-        alpha_x, alpha_y = self.derivatives(x, y, b, t, q)
+        alpha_x, alpha_y = EPLMajorAxis.derivatives(x, y, b, t, q)
 
         # deflection potential, eq. (15)
         psi = (x * alpha_x + y * alpha_y) / (2 - t)
@@ -347,8 +351,9 @@ class EPLMajorAxis(LensProfileBase):
 
         return alpha_real, alpha_imag
 
+    @staticmethod
     @jit
-    def hessian(self, x, y, b, t, q):
+    def hessian(x, y, b, t, q):
         """Hessian matrix of the lensing potential.
 
         :param x: x-coordinate in image plane relative to center (major axis)
@@ -370,7 +375,7 @@ class EPLMajorAxis(LensProfileBase):
         kappa = jnp.nan_to_num(kappa, posinf=10**10, neginf=-(10**10))
 
         # deflection via method
-        alpha_x, alpha_y = self.derivatives(x, y, b, t, q)
+        alpha_x, alpha_y = EPLMajorAxis.derivatives(x, y, b, t, q)
 
         # shear, eq. (17), corrected version from arXiv/corrigendum
         gamma_1 = (1 - t) * (alpha_x * cos - alpha_y * sin) / r - kappa * cos2
@@ -411,6 +416,21 @@ class EPLQPhi(LensProfileBase):
         self._EPL = EPL()
         super(EPLQPhi, self).__init__()
 
+    # --------------------------------------------------------------------------------
+    # Makes it so that the functions in this class will not recompile when new
+    # instances of EPLQPhi are created
+    def _tree_flatten(self):
+        children = ()
+        aux_data = {}
+        return (children, aux_data)
+
+    @classmethod
+    def _tree_unflatten(cls, aux_data, children):
+        return cls(*children, **aux_data)
+
+    # --------------------------------------------------------------------------------
+
+    @jit
     def function(self, x, y, theta_E, gamma, q, phi, center_x=0, center_y=0):
         """
 
@@ -427,6 +447,7 @@ class EPLQPhi(LensProfileBase):
         e1, e2 = param_util.phi_q2_ellipticity(phi, q)
         return self._EPL.function(x, y, theta_E, gamma, e1, e2, center_x, center_y)
 
+    @jit
     def derivatives(self, x, y, theta_E, gamma, q, phi, center_x=0, center_y=0):
         """
 
@@ -443,6 +464,7 @@ class EPLQPhi(LensProfileBase):
         e1, e2 = param_util.phi_q2_ellipticity(phi, q)
         return self._EPL.derivatives(x, y, theta_E, gamma, e1, e2, center_x, center_y)
 
+    @jit
     def hessian(self, x, y, theta_E, gamma, q, phi, center_x=0, center_y=0):
         """
 
@@ -459,6 +481,7 @@ class EPLQPhi(LensProfileBase):
         e1, e2 = param_util.phi_q2_ellipticity(phi, q)
         return self._EPL.hessian(x, y, theta_E, gamma, e1, e2, center_x, center_y)
 
+    @jit
     def mass_3d_lens(self, r, theta_E, gamma, q=None, phi=None):
         """Computes the spherical power-law mass enclosed (with SPP routine).
 
@@ -471,6 +494,7 @@ class EPLQPhi(LensProfileBase):
         """
         return self._EPL.mass_3d_lens(r, theta_E, gamma)
 
+    @jit
     def density_lens(self, r, theta_E, gamma, q=None, phi=None):
         """Computes the density at 3d radius r given lens model parameterization. The
         integral in the LOS projection of this quantity results in the convergence
@@ -487,5 +511,8 @@ class EPLQPhi(LensProfileBase):
 
 
 tree_util.register_pytree_node(
-    EPLMajorAxis, EPLMajorAxis._tree_flatten, EPLMajorAxis._tree_unflatten
+    EPL, EPL._tree_flatten, EPL._tree_unflatten
+)
+tree_util.register_pytree_node(
+    EPLQPhi, EPLQPhi._tree_flatten, EPLQPhi._tree_unflatten
 )

--- a/jaxtronomy/LensModel/Profiles/epl.py
+++ b/jaxtronomy/LensModel/Profiles/epl.py
@@ -130,6 +130,7 @@ class EPL(LensProfileBase):
         b = theta_E * jnp.sqrt(q)
         return b, t, q, phi_G
 
+    # NOTE: Do not jit-decorate this function; it won't work correctly
     def set_static(self, theta_E, gamma, e1, e2, center_x=0, center_y=0):
         """
 
@@ -147,8 +148,9 @@ class EPL(LensProfileBase):
             self._t_static,
             self._q_static,
             self._phi_G_static,
-        ) = self._param_conv(theta_E, gamma, e1, e2)
+        ) = EPL._param_conv(theta_E, gamma, e1, e2)
 
+    # NOTE: Do not jit-decorate this function; it won't work correctly
     def set_dynamic(self):
         """
         :return:

--- a/jaxtronomy/LensModel/Profiles/hernquist.py
+++ b/jaxtronomy/LensModel/Profiles/hernquist.py
@@ -34,7 +34,7 @@ class Hernquist(LensProfileBase):
 
     The lens model calculation uses angular units as arguments! So to execute a deflection angle calculation one uses
 
-    >>> from lenstronomy.LensModel.Profiles.hernquist import Hernquist
+    >>> from jaxtronomy.LensModel.Profiles.hernquist import Hernquist
     >>> hernquist = Hernquist()
     >>> alpha_x, alpha_y = hernquist.derivatives(x=1, y=1, Rs=rs_angle, sigma0=sigma0, center_x=0, center_y=0)
     """

--- a/jaxtronomy/LensModel/Profiles/spp.py
+++ b/jaxtronomy/LensModel/Profiles/spp.py
@@ -1,0 +1,288 @@
+__author__ = "sibirrer"
+
+from jax import jit
+import jax.numpy as jnp
+from jax.scipy import special
+
+from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
+
+__all__ = ["SPP"]
+
+
+class SPP(LensProfileBase):
+    """Class for circular power-law mass distribution."""
+
+    param_names = ["theta_E", "gamma", "center_x", "center_y"]
+    lower_limit_default = {
+        "theta_E": 0,
+        "gamma": 1.5,
+        "center_x": -100,
+        "center_y": -100,
+    }
+    upper_limit_default = {
+        "theta_E": 100,
+        "gamma": 2.5,
+        "center_x": 100,
+        "center_y": 100,
+    }
+
+    @staticmethod
+    @jit
+    def function(x, y, theta_E, gamma, center_x=0, center_y=0):
+        """
+        :param x: set of x-coordinates
+        :type x: array of size (n)
+        :param y: set of y-coordinates
+        :type y: array of size (n)
+        :param theta_E: Einstein radius of lens
+        :type theta_E: float.
+        :param gamma: power law slope of mass profile
+        :type gamma: <2 float
+        :returns:  function
+        :raises: AttributeError, KeyError
+        """
+        gamma = SPP._gamma_limit(gamma)
+
+        x_ = x - center_x
+        y_ = y - center_y
+        E = theta_E / ((3.0 - gamma) / 2.0) ** (1.0 / (1.0 - gamma))
+        # E = phi_E_spp
+        eta = -gamma + 3
+
+        p2 = x_**2 + y_**2
+        s2 = 0.0  # softening
+        return 2 * E**2 / eta**2 * ((p2 + s2) / E**2) ** (eta / 2)
+
+    @staticmethod
+    @jit
+    def derivatives(x, y, theta_E, gamma, center_x=0.0, center_y=0.0):
+        gamma = SPP._gamma_limit(gamma)
+
+        xt1 = x - center_x
+        xt2 = y - center_y
+
+        r2 = xt1 * xt1 + xt2 * xt2
+        a = jnp.maximum(r2, 0.000001)
+        r = jnp.sqrt(a)
+        alpha = theta_E * (r2 / theta_E**2) ** (1 - gamma / 2.0)
+        fac = alpha / r
+        f_x = fac * xt1
+        f_y = fac * xt2
+        return f_x, f_y
+
+    @staticmethod
+    @jit
+    def hessian(x, y, theta_E, gamma, center_x=0.0, center_y=0.0):
+        gamma = SPP._gamma_limit(gamma)
+        xt1 = x - center_x
+        xt2 = y - center_y
+        E = theta_E / ((3.0 - gamma) / 2.0) ** (1.0 / (1.0 - gamma))
+        # E = phi_E_spp
+        eta = -gamma + 3.0
+
+        P2 = xt1**2 + xt2**2
+        a = jnp.where(P2 < 0.000001, 0.000001, P2)
+
+        kappa = (
+            1.0
+            / eta
+            * (a / E**2) ** (eta / 2 - 1)
+            * ((eta - 2) * (xt1**2 + xt2**2) / a + (1 + 1))
+        )
+        gamma1 = (
+            1.0
+            / eta
+            * (a / E**2) ** (eta / 2 - 1)
+            * ((eta / 2 - 1) * (2 * xt1**2 - 2 * xt2**2) / a)
+        )
+        gamma2 = (
+            4 * xt1 * xt2 * (1.0 / 2 - 1 / eta) * (a / E**2) ** (eta / 2 - 2) / E**2
+        )
+
+        f_xx = kappa + gamma1
+        f_yy = kappa - gamma1
+        f_xy = gamma2
+        return f_xx, f_xy, f_xy, f_yy
+
+    @staticmethod
+    @jit
+    def rho2theta(rho0, gamma):
+        """Converts 3d density into 2d projected density parameter.
+
+        :param rho0:
+        :param gamma:
+        :return:
+        """
+        fac = (
+            jnp.sqrt(jnp.pi)
+            * special.gamma(1.0 / 2 * (-1 + gamma))
+            / special.gamma(gamma / 2.0)
+            * 2
+            / (3 - gamma)
+            * rho0
+        )
+
+        # fac = theta_E**(gamma - 1)
+        theta_E = fac ** (1.0 / (gamma - 1))
+        return theta_E
+
+    @staticmethod
+    @jit
+    def theta2rho(theta_E, gamma):
+        """Converts projected density parameter (in units of deflection) into 3d density
+        parameter.
+
+        :param theta_E:
+        :param gamma:
+        :return:
+        """
+        fac1 = (
+            jnp.sqrt(jnp.pi)
+            * special.gamma(1.0 / 2 * (-1 + gamma))
+            / special.gamma(gamma / 2.0)
+            * 2
+            / (3 - gamma)
+        )
+        fac2 = theta_E ** (gamma - 1)
+        rho0 = fac2 / fac1
+        return rho0
+
+    @staticmethod
+    @jit
+    def mass_3d(r, rho0, gamma):
+        """Mass enclosed a 3d sphere or radius r.
+
+        :param r:
+        :param rho0:
+        :param gamma:
+        :return:
+        """
+        mass_3d = 4 * jnp.pi * rho0 / (-gamma + 3) * r ** (-gamma + 3)
+        return mass_3d
+
+    @staticmethod
+    @jit
+    def mass_3d_lens(r, theta_E, gamma):
+        """
+
+        :param r:
+        :param theta_E:
+        :param gamma:
+        :return:
+        """
+        rho0 = SPP.theta2rho(theta_E, gamma)
+        return SPP.mass_3d(r, rho0, gamma)
+
+    @staticmethod
+    @jit
+    def mass_2d(r, rho0, gamma):
+        """Mass enclosed projected 2d sphere of radius r.
+
+        :param r:
+        :param rho0:
+        :param gamma:
+        :return:
+        """
+        alpha = (
+            jnp.sqrt(jnp.pi)
+            * special.gamma(1.0 / 2 * (-1 + gamma))
+            / special.gamma(gamma / 2.0)
+            * r ** (2 - gamma)
+            / (3 - gamma)
+            * 2
+            * rho0
+        )
+        mass_2d = alpha * r * jnp.pi
+        return mass_2d
+
+    @staticmethod
+    @jit
+    def mass_2d_lens(r, theta_E, gamma):
+        """
+
+        :param r: projected radius
+        :param theta_E: Einstein radius
+        :param gamma: power-law slope
+        :return: 2d projected radius enclosed
+        """
+        rho0 = SPP.theta2rho(theta_E, gamma)
+        return SPP.mass_2d(r, rho0, gamma)
+
+    @staticmethod
+    @jit
+    def grav_pot(x, y, rho0, gamma, center_x=0, center_y=0):
+        """Gravitational potential (modulo 4 pi G and rho0 in appropriate units)
+
+        :param x:
+        :param y:
+        :param rho0:
+        :param gamma:
+        :param center_x:
+        :param center_y:
+        :return:
+        """
+        x_ = x - center_x
+        y_ = y - center_y
+        r = jnp.sqrt(x_**2 + y_**2)
+        mass_3d = SPP.mass_3d(r, rho0, gamma)
+        pot = mass_3d / r
+        return pot
+
+    @staticmethod
+    @jit
+    def density(r, rho0, gamma):
+        """Computes the density.
+
+        :param r:
+        :param rho0:
+        :param gamma:
+        :return:
+        """
+        rho = rho0 / r**gamma
+        return rho
+
+    @staticmethod
+    @jit
+    def density_lens(r, theta_E, gamma):
+        """Computes the density at 3d radius r given lens model parameterization.
+
+        The integral in projected in units of angles (i.e. arc seconds) results in the
+        convergence quantity.
+        """
+        rho0 = SPP.theta2rho(theta_E, gamma)
+        return SPP.density(r, rho0, gamma)
+
+    @staticmethod
+    @jit
+    def density_2d(x, y, rho0, gamma, center_x=0, center_y=0):
+        """Projected density.
+
+        :param x:
+        :param y:
+        :param rho0:
+        :param gamma:
+        :param center_x:
+        :param center_y:
+        :return:
+        """
+        x_ = x - center_x
+        y_ = y - center_y
+        r = jnp.sqrt(x_**2 + y_**2)
+        sigma = (
+            jnp.sqrt(jnp.pi)
+            * special.gamma(1.0 / 2 * (-1 + gamma))
+            / special.gamma(gamma / 2.0)
+            * r ** (1 - gamma)
+            * rho0
+        )
+        return sigma
+
+    @staticmethod
+    @jit
+    def _gamma_limit(gamma):
+        """Limits the power-law slope to certain bounds.
+
+        :param gamma: power-law slope
+        :return: bounded power-law slopte
+        """
+        return gamma

--- a/jaxtronomy/LensModel/profile_list_base.py
+++ b/jaxtronomy/LensModel/profile_list_base.py
@@ -1,4 +1,5 @@
 from lenstronomy.Util.util import convert_bool_list
+from warnings import warn
 
 __all__ = ["ProfileListBase"]
 
@@ -17,6 +18,7 @@ _JAXXED_MODELS = [
     "PJAFFE_ELLIPSE_POTENTIAL",
     "SIS",
     "SHEAR",
+    "SPP",
 ]
 
 _SUPPORTED_MODELS = [
@@ -259,8 +261,10 @@ def lens_class(
     """
 
     if lens_type not in _JAXXED_MODELS:
-        print(
-            "Warning: the {} profile is not currently jaxified; using lenstronomy implementation.".format(
+        warn(
+            "The {} profile is not in JAXtronomy; using lenstronomy implementation.\n"
+            "Note that this may cause crashes in some situations where jax arrays are passed into"
+            " functions utilizing the numba compiler in lenstronomy (e.g. util.rotate)".format(
                 lens_type
             )
         )
@@ -630,7 +634,7 @@ def lens_class(
 
         return SPLCORE()
     elif lens_type == "SPP":
-        from lenstronomy.LensModel.Profiles.spp import SPP
+        from jaxtronomy.LensModel.Profiles.spp import SPP
 
         return SPP()
     elif lens_type == "SYNTHESIS":

--- a/test/test_LensModel/test_Profiles/test_epl.py
+++ b/test/test_LensModel/test_Profiles/test_epl.py
@@ -22,30 +22,22 @@ class TestEPL(object):
 
     def test_param_conv(self):
         theta_E = 12.3
-        gamma, e1, e2 = 1.7, 0.3, -0.2
+        gamma, e1, e2 = 1.7, 0.3, -0.4
         self.profile.set_static(theta_E, gamma, e1, e2)
         self.profile_ref.set_static(theta_E, gamma, e1, e2)
-        self.profile._b_static, self._t_static, self._q_static, self._phi_G_static = (
-            self.profile.param_conv(theta_E, gamma, e1, e2)
-        )
+
+        b_static, t_static, q_static, phi_static = self.profile.param_conv(theta_E, gamma, e1, e2)
+
         (
-            self.profile_ref._b_static,
-            self._t_static,
-            self._q_static,
-            self._phi_G_static,
+            b_static_ref,
+            t_static_ref,
+            q_static_ref,
+            phi_static_ref,
         ) = self.profile_ref.param_conv(theta_E, gamma, e1, e2)
-        npt.assert_almost_equal(
-            self.profile._b_static, self.profile_ref._b_static, decimal=8
-        )
-        npt.assert_almost_equal(
-            self.profile._t_static, self.profile_ref._t_static, decimal=8
-        )
-        npt.assert_almost_equal(
-            self.profile._q_static, self.profile_ref._q_static, decimal=8
-        )
-        npt.assert_almost_equal(
-            self.profile._phi_G_static, self.profile_ref._phi_G_static, decimal=8
-        )
+        npt.assert_almost_equal(b_static, b_static_ref, decimal=8)
+        npt.assert_almost_equal(t_static, t_static_ref, decimal=8)
+        npt.assert_almost_equal(q_static, q_static_ref, decimal=8)
+        npt.assert_almost_equal(phi_static, phi_static_ref, decimal=8)
 
         theta_E = 11.3
         gamma, e1, e2 = 1.6, 0.2, -0.3
@@ -59,6 +51,26 @@ class TestEPL(object):
         npt.assert_almost_equal(t, t_ref, decimal=8)
         npt.assert_almost_equal(q, q_ref, decimal=8)
         npt.assert_almost_equal(phi_G, phi_G_ref, decimal=8)
+
+        # Do the same test as before to make sure that the
+        # static variables are correctly updated with new values
+        theta_E = 4.3
+        gamma, e1, e2 = 2.3, 0.4, -0.2
+        self.profile.set_static(theta_E, gamma, e1, e2)
+        self.profile_ref.set_static(theta_E, gamma, e1, e2)
+
+        b_static, t_static, q_static, phi_static = self.profile.param_conv(theta_E, gamma, e1, e2)
+
+        (
+            b_static_ref,
+            t_static_ref,
+            q_static_ref,
+            phi_static_ref,
+        ) = self.profile_ref.param_conv(theta_E, gamma, e1, e2)
+        npt.assert_almost_equal(b_static, b_static_ref, decimal=8)
+        npt.assert_almost_equal(t_static, t_static_ref, decimal=8)
+        npt.assert_almost_equal(q_static, q_static_ref, decimal=8)
+        npt.assert_almost_equal(phi_static, phi_static_ref, decimal=8)
 
     def test_function(self):
         x = np.array([1])

--- a/test/test_LensModel/test_Profiles/test_spp.py
+++ b/test/test_LensModel/test_Profiles/test_spp.py
@@ -1,0 +1,177 @@
+__author__ = "sibirrer"
+
+from jaxtronomy.LensModel.Profiles.spp import SPP
+from lenstronomy.LensModel.Profiles.spp import SPP as SPP_ref
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+
+class TestSPP(object):
+    """Tests the Gaussian methods."""
+
+    def setup_method(self):
+        self.SPP_ref = SPP_ref()
+
+    def test_function(self):
+        x = np.array([1])
+        y = np.array([2])
+        theta_E = 1.3
+        gamma = 1.9
+
+        values_ref = self.SPP_ref.function(x, y, theta_E, gamma)
+        values = SPP.function(x, y, theta_E, gamma)
+        npt.assert_array_almost_equal(values, values_ref, decimal=8)
+
+        x = np.array([0])
+        y = np.array([0])
+        values_ref = self.SPP_ref.function(x, y, theta_E, gamma)
+        values = SPP.function(x, y, theta_E, gamma)
+        npt.assert_array_almost_equal(values, values_ref, decimal=8)
+
+        x = np.array([2, 3, 4])
+        y = np.array([1, 1, 1])
+        values_ref = self.SPP_ref.function(x, y, theta_E, gamma)
+        values = SPP.function(x, y, theta_E, gamma)
+        npt.assert_array_almost_equal(values, values_ref, decimal=8)
+
+    def test_derivatives(self):
+        x = np.array([1])
+        y = np.array([2])
+        theta_E = 1.3
+        gamma = 1.9
+
+        f_x_ref, f_y_ref = self.SPP_ref.derivatives(x, y, theta_E, gamma)
+        f_x, f_y = SPP.derivatives(x, y, theta_E, gamma)
+        npt.assert_array_almost_equal(f_x, f_x_ref, decimal=8)
+        npt.assert_array_almost_equal(f_y, f_y_ref, decimal=8)
+
+        x = np.array([0])
+        y = np.array([0])
+        f_x_ref, f_y_ref = self.SPP_ref.derivatives(x, y, theta_E, gamma)
+        f_x, f_y = SPP.derivatives(x, y, theta_E, gamma)
+        npt.assert_array_almost_equal(f_x, f_x_ref, decimal=8)
+        npt.assert_array_almost_equal(f_y, f_y_ref, decimal=8)
+
+        x = np.array([2, 3, 4])
+        y = np.array([1, 1, 1])
+        f_x_ref, f_y_ref = self.SPP_ref.derivatives(x, y, theta_E, gamma)
+        f_x, f_y = SPP.derivatives(x, y, theta_E, gamma)
+        npt.assert_array_almost_equal(f_x, f_x_ref, decimal=8)
+        npt.assert_array_almost_equal(f_y, f_y_ref, decimal=8)
+
+    def test_hessian(self):
+        x = np.array([1])
+        y = np.array([2])
+        theta_E = 1.3
+        gamma = 1.9
+
+        f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.SPP_ref.hessian(x, y, theta_E, gamma)
+        f_xx, f_xy, f_yx, f_yy = SPP.hessian(x, y, theta_E, gamma)
+        npt.assert_array_almost_equal(f_xx, f_xx_ref, decimal=8)
+        npt.assert_array_almost_equal(f_xy, f_xy_ref, decimal=8)
+        npt.assert_array_almost_equal(f_yx, f_yx_ref, decimal=8)
+        npt.assert_array_almost_equal(f_yy, f_yy_ref, decimal=8)
+
+        x = np.array([0])
+        y = np.array([0])
+        f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.SPP_ref.hessian(x, y, theta_E, gamma)
+        f_xx, f_xy, f_yx, f_yy = SPP.hessian(x, y, theta_E, gamma)
+        npt.assert_array_almost_equal(f_xx, f_xx_ref, decimal=8)
+        npt.assert_array_almost_equal(f_xy, f_xy_ref, decimal=8)
+        npt.assert_array_almost_equal(f_yx, f_yx_ref, decimal=8)
+        npt.assert_array_almost_equal(f_yy, f_yy_ref, decimal=8)
+
+        x = np.array([2, 3, 4])
+        y = np.array([1, 1, 1])
+        f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.SPP_ref.hessian(x, y, theta_E, gamma)
+        f_xx, f_xy, f_yx, f_yy = SPP.hessian(x, y, theta_E, gamma)
+        npt.assert_array_almost_equal(f_xx, f_xx_ref, decimal=8)
+        npt.assert_array_almost_equal(f_xy, f_xy_ref, decimal=8)
+        npt.assert_array_almost_equal(f_yx, f_yx_ref, decimal=8)
+        npt.assert_array_almost_equal(f_yy, f_yy_ref, decimal=8)
+
+    def test_rho2theta(self):
+        rho0 = 3.8
+        gamma = 1.7
+        theta_ref = self.SPP_ref.rho2theta(rho0, gamma)
+        theta = SPP.rho2theta(rho0, gamma)
+        npt.assert_almost_equal(theta, theta_ref, decimal=8)
+
+    def test_theta2rho(self):
+        theta_E = 7.8
+        gamma = 2.4
+        rho_ref = self.SPP_ref.rho2theta(theta_E, gamma)
+        rho = SPP.rho2theta(theta_E, gamma)
+        npt.assert_almost_equal(rho, rho_ref, decimal=8)
+
+    def test_mass_3d(self):
+        r = 1.1
+        rho0 = 9.2347
+        gamma = 2.12989
+        m_3d_ref = self.SPP_ref.mass_3d(r, rho0, gamma)
+        m_3d = SPP.mass_3d(r, rho0, gamma)
+        npt.assert_almost_equal(m_3d, m_3d_ref, decimal=8)
+
+    def test_mass_3d_lens(self):
+        r = 1.1
+        theta_E = 1.00003234
+        gamma = 2.12989
+        m_3d_ref = self.SPP_ref.mass_3d_lens(r, theta_E, gamma)
+        m_3d = SPP.mass_3d_lens(r, theta_E, gamma)
+        npt.assert_almost_equal(m_3d, m_3d_ref, decimal=8)
+
+    def test_mass_2d(self):
+        r = 1.1
+        rho0 = 9.2347
+        gamma = 2.12989
+        m_2d_ref = self.SPP_ref.mass_2d(r, rho0, gamma)
+        m_2d = SPP.mass_2d(r, rho0, gamma)
+        npt.assert_almost_equal(m_2d, m_2d_ref, decimal=8)
+
+    def test_mass_2d_lens(self):
+        r = 1.1
+        theta_E = 1.00003234
+        gamma = 2.12989
+        m_2d_ref = self.SPP_ref.mass_2d_lens(r, theta_E, gamma)
+        m_2d = SPP.mass_2d_lens(r, theta_E, gamma)
+        npt.assert_almost_equal(m_2d, m_2d_ref, decimal=8)
+
+    def test_grav_pot(self):
+        x, y = 1, 0.27
+        rho0 = 1.32
+        gamma = 2.49832
+        grav_pot_ref = self.SPP_ref.grav_pot(x, y, rho0, gamma, center_x=0, center_y=0)
+        grav_pot = SPP.grav_pot(x, y, rho0, gamma, center_x=0, center_y=0)
+        npt.assert_almost_equal(grav_pot, grav_pot_ref, decimal=8)
+
+    def test_density(self):
+        r = 1.1
+        rho0 = 9.2347
+        gamma = 2.12989
+        density_ref = self.SPP_ref.density(r, rho0, gamma)
+        density = SPP.density(r, rho0, gamma)
+        npt.assert_almost_equal(density, density_ref, decimal=8)
+
+    def test_density_lens(self):
+        r = 1.1
+        theta_E = 1.00003234
+        gamma = 2.12989
+        density_ref = self.SPP_ref.density_lens(r, theta_E, gamma)
+        density = SPP.density_lens(r, theta_E, gamma)
+        npt.assert_almost_equal(density, density_ref, decimal=8)
+
+    def test_density_2d(self):
+        x = 1.1
+        y = 2.38123
+        rho0 = 1.00003234
+        gamma = 2.12989
+        density_ref = self.SPP_ref.density_2d(x, y, rho0, gamma)
+        density = SPP.density_2d(x, y, rho0, gamma)
+        npt.assert_almost_equal(density, density_ref, decimal=8)
+
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/test/test_LensModel/test_Profiles/test_spp.py
+++ b/test/test_LensModel/test_Profiles/test_spp.py
@@ -67,7 +67,9 @@ class TestSPP(object):
         theta_E = 1.3
         gamma = 1.9
 
-        f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.SPP_ref.hessian(x, y, theta_E, gamma)
+        f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.SPP_ref.hessian(
+            x, y, theta_E, gamma
+        )
         f_xx, f_xy, f_yx, f_yy = SPP.hessian(x, y, theta_E, gamma)
         npt.assert_array_almost_equal(f_xx, f_xx_ref, decimal=8)
         npt.assert_array_almost_equal(f_xy, f_xy_ref, decimal=8)
@@ -76,7 +78,9 @@ class TestSPP(object):
 
         x = np.array([0])
         y = np.array([0])
-        f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.SPP_ref.hessian(x, y, theta_E, gamma)
+        f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.SPP_ref.hessian(
+            x, y, theta_E, gamma
+        )
         f_xx, f_xy, f_yx, f_yy = SPP.hessian(x, y, theta_E, gamma)
         npt.assert_array_almost_equal(f_xx, f_xx_ref, decimal=8)
         npt.assert_array_almost_equal(f_xy, f_xy_ref, decimal=8)
@@ -85,7 +89,9 @@ class TestSPP(object):
 
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])
-        f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.SPP_ref.hessian(x, y, theta_E, gamma)
+        f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.SPP_ref.hessian(
+            x, y, theta_E, gamma
+        )
         f_xx, f_xy, f_yx, f_yy = SPP.hessian(x, y, theta_E, gamma)
         npt.assert_array_almost_equal(f_xx, f_xx_ref, decimal=8)
         npt.assert_array_almost_equal(f_xy, f_xy_ref, decimal=8)
@@ -170,7 +176,6 @@ class TestSPP(object):
         density_ref = self.SPP_ref.density_2d(x, y, rho0, gamma)
         density = SPP.density_2d(x, y, rho0, gamma)
         npt.assert_almost_equal(density, density_ref, decimal=8)
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously, only the EPLMajorAxis class was jaxified. This PR jaxifies the EPL, EPLQPhi, and SPP classes to finish the job.

The way the static variables are handled in the EPL class has been slightly modified. JAX does not like it when variables are deleted, so that no longer happens in the `set_dynamic` function.

After this PR, the only profiles left to jaxify for use in slsim are the SIE and NIE profiles which are used in EPL_SERSIC deflectors when gamma=2