### PR TITLE
 jit-decorated several functions in SinglePlane and LightModelBase, changed ProfileListBase imports, added Gaussian profiles

### DIFF
--- a/jaxtronomy/LensModel/LineOfSight/single_plane_los.py
+++ b/jaxtronomy/LensModel/LineOfSight/single_plane_los.py
@@ -316,24 +316,25 @@ class SinglePlaneLOS(SinglePlane):
 
         return f_xx, f_xy, f_yx, f_yy
 
-    def mass_3d(self, r, kwargs, bool_list=None):
+    def mass_3d(self, r, kwargs, k=None):
         """Computes the mass within a 3d sphere of radius r *for the main lens only*
 
         :param r: radius (in angular units)
         :param kwargs: list of keyword arguments of lens model parameters matching the
             lens model classes
-        :param bool_list: list of bools that are part of the output
+        :param k: only evaluate the k-th lens model
+        :type k: None, int, or tuple of ints
         :return: mass (in angular units, modulo epsilon_crit)
         """
 
         print("Note: The computation of the 3d mass ignores the LOS corrections.")
 
         kwargs_main, kwargs_los = self.split_lens_los(kwargs)
-        mass_3d = self._main_lens.mass_3d(r=r, kwargs=kwargs_main, bool_list=bool_list)
+        mass_3d = self._main_lens.mass_3d(r=r, kwargs=kwargs_main, k=k)
 
         return mass_3d
 
-    def mass_2d(self, r, kwargs, bool_list=None):
+    def mass_2d(self, r, kwargs, k=None):
         """Computes the mass enclosed a projected (2d) radius r *for the main lens only*
 
         The mass definition is such that:
@@ -345,32 +346,34 @@ class SinglePlaneLOS(SinglePlane):
 
         :param r: radius (in angular units)
         :param kwargs: list of keyword arguments of lens model parameters matching the lens model classes
-        :param bool_list: list of bools that are part of the output
+        :param k: only evaluate the k-th lens model
+        :type k: None, int, or tuple of ints
         :return: projected mass (in angular units, modulo epsilon_crit)
         """
 
         print("Note: The computation of the 2d mass ignores the LOS corrections.")
 
         kwargs_main, kwargs_los = self.split_lens_los(kwargs)
-        mass_2d = self._main_lens.mass_2d(r=r, kwargs=kwargs_main, bool_list=bool_list)
+        mass_2d = self._main_lens.mass_2d(r=r, kwargs=kwargs_main, k=k)
 
         return mass_2d
 
-    def density(self, r, kwargs, bool_list=None):
+    def density(self, r, kwargs, k=None):
         """3d mass density at radius r *for the main lens only* The integral in the LOS
         projection of this quantity results in the convergence quantity.
 
         :param r: radius (in angular units)
         :param kwargs: list of keyword arguments of lens model parameters matching the
             lens model classes
-        :param bool_list: list of bools that are part of the output
+        :param k: only evaluate the k-th lens model
+        :type k: None, int, or tuple of ints
         :return: mass density at radius r (in angular units, modulo epsilon_crit)
         """
 
         print("Note: The computation of the density ignores the LOS corrections.")
 
         kwargs_main, kwargs_los = self.split_lens_los(kwargs)
-        density = self._main_lens.density(r=r, kwargs=kwargs_main, bool_list=bool_list)
+        density = self._main_lens.density(r=r, kwargs=kwargs_main, k=k)
 
         return density
 

--- a/jaxtronomy/LensModel/Profiles/gaussian.py
+++ b/jaxtronomy/LensModel/Profiles/gaussian.py
@@ -1,0 +1,253 @@
+__author__ = "sibirrer"
+# this file contains a class to make a gaussian
+
+import jax
+from jax import jit, lax, numpy as jnp, tree_util
+import jax.scipy.special
+from jaxtronomy.LensModel.Profiles.gaussian_potential import GaussianPotential
+from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
+
+jax.config.update("jax_enable_x64", True)
+
+__all__ = ["Gaussian"]
+
+GAUSSIAN_INSTANCE = GaussianPotential()
+
+class Gaussian(LensProfileBase):
+    """This class contains functions to evaluate a Gaussian convergence and calculates
+    its derivative and hessian matrix."""
+
+    param_names = ["amp", "sigma", "center_x", "center_y"]
+    lower_limit_default = {"amp": 0, "sigma": 0, "center_x": -100, "center_y": -100}
+    upper_limit_default = {"amp": 100, "sigma": 100, "center_x": 100, "center_y": 100}
+
+    def __init__(self):
+        self.ds = 0.00001
+        super(LensProfileBase, self).__init__()
+
+    def _tree_flatten(self):
+        children = ()
+        aux_data = {}
+        return (children, aux_data)
+
+    @classmethod
+    def _tree_unflatten(cls, aux_data, children):
+        return cls(*children, **aux_data)
+
+    # --------------------------------------------------------------------------------
+
+    @jit
+    def function(self, x, y, amp, sigma, center_x=0, center_y=0):
+        """Returns potential for a Gaussian convergence."""
+        x_ = x - center_x
+        y_ = y - center_y
+        r = jnp.sqrt(x_**2 + y_**2)
+        sigma_x, sigma_y = sigma, sigma
+        c = 1.0 / (2 * sigma_x * sigma_y)
+        num_int = Gaussian._num_integral(r, c)
+        amp_density = self._amp2d_to_3d(amp, sigma_x, sigma_y)
+        amp2d = amp_density / (jnp.sqrt(jnp.pi) * jnp.sqrt(sigma_x * sigma_y * 2))
+        amp2d *= 2 * 1.0 / (2 * c)
+        return num_int * amp2d
+
+    @staticmethod
+    @jit
+    def _num_integral(r, c):
+        """Numerical integral of (1-e^{-c*x^2})/x dx from 0 to r
+        calculated using a trapezoidal sum with 1000 steps.
+        If r is a 1D array of size n, then there are n integrals
+        which are computed in parallel.
+
+        :param r: radius
+        :param c: 1/2sigma^2
+        :return: Array with the same shape as r containing the result
+         for each integral
+        """
+        def trapezoidal_sum(i, val):
+            sum = val
+            dx = r/num_iterations
+            x_left = dx * i
+            x_right = dx * (i + 1)
+            y_left = jnp.where(x_left == 0, 0, (1 - jnp.exp(-c * x_left**2))/x_left)
+            y_right = (1 - jnp.exp(-c * x_right**2))/x_right
+            sum += (y_left + y_right)/2 * dx
+            return sum
+
+        num_iterations = 200
+        sum = jnp.zeros_like(r, dtype=float)
+        return lax.fori_loop(0, num_iterations, trapezoidal_sum, sum)
+
+    @jit
+    def derivatives(self, x, y, amp, sigma, center_x=0, center_y=0):
+        """Returns df/dx and df/dy of the function."""
+        x_ = x - center_x
+        y_ = y - center_y
+        R = jnp.sqrt(x_**2 + y_**2)
+        R = jnp.where(R <= self.ds, self.ds, R)
+        alpha = self.alpha_abs(R, amp, sigma)
+        return alpha / R * x_, alpha / R * y_
+
+    @jit
+    def hessian(self, x, y, amp, sigma, center_x=0, center_y=0):
+        """Returns Hessian matrix of function d^2f/dx^2, d^2/dxdy, d^2/dydx,
+        d^f/dy^2."""
+        x_ = x - center_x
+        y_ = y - center_y
+        r = jnp.sqrt(x_**2 + y_**2)
+        sigma_x, sigma_y = sigma, sigma
+        r = jnp.where(r < self.ds, self.ds, r)
+        d_alpha_dr = -self.d_alpha_dr(r, amp, sigma_x, sigma_y)
+        alpha = self.alpha_abs(r, amp, sigma)
+
+        f_xx = -(d_alpha_dr / r + alpha / r**2) * x_**2 / r + alpha / r
+        f_yy = -(d_alpha_dr / r + alpha / r**2) * y_**2 / r + alpha / r
+        f_xy = -(d_alpha_dr / r + alpha / r**2) * x_ * y_ / r
+        return f_xx, f_xy, f_xy, f_yy
+
+    @jit
+    def density(self, r, amp, sigma):
+        """
+
+        :param r:
+        :param amp:
+        :param sigma:
+        :return:
+        """
+        sigma_x, sigma_y = sigma, sigma
+        return GAUSSIAN_INSTANCE.function(r, 0, amp, sigma_x, sigma_y)
+
+    @jit
+    def density_2d(self, x, y, amp, sigma, center_x=0, center_y=0):
+        """
+
+        :param x:
+        :param y:
+        :param amp:
+        :param sigma:
+        :param center_x:
+        :param center_y:
+        :return:
+        """
+        sigma_x, sigma_y = sigma, sigma
+        amp2d = self._amp3d_to_2d(amp, sigma_x, sigma_y)
+        return GAUSSIAN_INSTANCE.function(x, y, amp2d, sigma_x, sigma_y, center_x, center_y)
+
+    @jit
+    def mass_2d(self, R, amp, sigma):
+        """
+
+        :param R:
+        :param amp:
+        :param sigma:
+        :return:
+        """
+        sigma_x, sigma_y = sigma, sigma
+        amp2d = amp / (jnp.sqrt(jnp.pi) * jnp.sqrt(sigma_x * sigma_y * 2))
+        c = 1.0 / (2 * sigma_x * sigma_y)
+        return amp2d * 2 * jnp.pi * 1.0 / (2 * c) * (1.0 - jnp.exp(-c * R**2))
+
+    @jit
+    def mass_2d_lens(self, R, amp, sigma):
+        """
+
+        :param R:
+        :param amp:
+        :param sigma: 
+        :return:
+        """
+        sigma_x, sigma_y = sigma, sigma
+        amp_density = self._amp2d_to_3d(amp, sigma_x, sigma_y)
+        return self.mass_2d(R, amp_density, sigma)
+
+    @jit
+    def alpha_abs(self, R, amp, sigma):
+        """Absolute value of the deflection.
+
+        :param R:
+        :param amp:
+        :param sigma:
+        :return:
+        """
+        sigma_x, sigma_y = sigma, sigma
+        amp_density = self._amp2d_to_3d(amp, sigma_x, sigma_y)
+        alpha = self.mass_2d(R, amp_density, sigma) / jnp.pi / R
+        return alpha
+
+    @jit
+    def d_alpha_dr(self, R, amp, sigma_x, sigma_y):
+        """
+
+        :param R:
+        :param amp:
+        :param sigma_x:
+        :param sigma_y:
+        :return:
+        """
+        c = 1.0 / (2 * sigma_x * sigma_y)
+        A = self._amp2d_to_3d(amp, sigma_x, sigma_y) * jnp.sqrt(
+            2 / jnp.pi * sigma_x * sigma_y
+        )
+        return 1.0 / R**2 * (-1 + (1 + 2 * c * R**2) * jnp.exp(-c * R**2)) * A
+
+    @jit
+    def mass_3d(self, R, amp, sigma):
+        """
+
+        :param R:
+        :param amp:
+        :param sigma:
+        :return:
+        """
+        sigma_x, sigma_y = sigma, sigma
+        A = amp / (2 * jnp.pi * sigma_x * sigma_y)
+        c = 1.0 / (2 * sigma_x * sigma_y)
+        result = (
+            1.0
+            / (2 * c)
+            * (
+                -R * jnp.exp(-c * R**2)
+                + jax.scipy.special.erf(jnp.sqrt(c) * R) * jnp.sqrt(jnp.pi / (4 * c))
+            )
+        )
+        return result * A * 4 * jnp.pi
+
+    @jit
+    def mass_3d_lens(self, R, amp, sigma):
+        """
+
+        :param R:
+        :param amp:
+        :param sigma:
+        :return:
+        """
+        sigma_x, sigma_y = sigma, sigma
+        amp_density = self._amp2d_to_3d(amp, sigma_x, sigma_y)
+        return self.mass_3d(R, amp_density, sigma)
+
+    @staticmethod
+    @jit
+    def _amp3d_to_2d(amp, sigma_x, sigma_y):
+        """Converts 3d density into 2d density parameter.
+
+        :param amp:
+        :param sigma_x:
+        :param sigma_y:
+        :return:
+        """
+        return amp * jnp.sqrt(jnp.pi) * jnp.sqrt(sigma_x * sigma_y * 2)
+
+    @staticmethod
+    @jit
+    def _amp2d_to_3d(amp, sigma_x, sigma_y):
+        """Converts 3d density into 2d density parameter.
+
+        :param amp:
+        :param sigma_x:
+        :param sigma_y:
+        :return:
+        """
+        return amp / (jnp.sqrt(jnp.pi) * jnp.sqrt(sigma_x * sigma_y * 2))
+    
+
+tree_util.register_pytree_node(Gaussian, Gaussian._tree_flatten, Gaussian._tree_unflatten)
+

--- a/jaxtronomy/LensModel/Profiles/gaussian_potential.py
+++ b/jaxtronomy/LensModel/Profiles/gaussian_potential.py
@@ -1,0 +1,44 @@
+__author__ = "sibirrer"
+# this file contains a class to make a gaussian
+
+from jax import jit, numpy as jnp
+from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
+
+__all__ = ["GaussianPotential"]
+
+
+class GaussianPotential(LensProfileBase):
+    """This class contains functions to evaluate a Gaussian potential and calculates its
+    derivative and hessian matrix."""
+
+    param_names = ["amp", "sigma_x", "sigma_y", "center_x", "center_y"]
+    lower_limit_default = {"amp": 0, "sigma_x": 0, "sigma_y": 0, "center_x": -100, "center_y": -100}
+    upper_limit_default = {"amp": 100, "sigma_x": 100, "sigma_y": 100, "center_x": 100, "center_y": 100}
+
+    @staticmethod
+    @jit
+    def function(x, y, amp, sigma_x, sigma_y, center_x=0, center_y=0):
+        """Returns Gaussian."""
+        c = amp / (2 * jnp.pi * sigma_x * sigma_y)
+        delta_x = x - center_x
+        delta_y = y - center_y
+        exponent = -((delta_x / sigma_x) ** 2 + (delta_y / sigma_y) ** 2) / 2.0
+        return c * jnp.exp(exponent)
+
+    @staticmethod
+    @jit
+    def derivatives(x, y, amp, sigma_x, sigma_y, center_x=0, center_y=0):
+        """Returns df/dx and df/dy of the function."""
+        f_ = GaussianPotential.function(x, y, amp, sigma_x, sigma_y, center_x, center_y)
+        return f_ * (center_x - x) / sigma_x**2, f_ * (center_y - y) / sigma_y**2
+
+    @staticmethod
+    @jit
+    def hessian(x, y, amp, sigma_x, sigma_y, center_x=0, center_y=0):
+        """Returns Hessian matrix of function d^2f/dx^2, d^2/dxdy, d^2/dydx,
+        d^f/dy^2."""
+        f_ = GaussianPotential.function(x, y, amp, sigma_x, sigma_y, center_x, center_y)
+        f_xx = f_ * ((-1.0 / sigma_x**2) + (center_x - x) ** 2 / sigma_x**4)
+        f_yy = f_ * ((-1.0 / sigma_y**2) + (center_y - y) ** 2 / sigma_y**4)
+        f_xy = f_ * (center_x - x) / sigma_x**2 * (center_y - y) / sigma_y**2
+        return f_xx, f_xy, f_xy, f_yy

--- a/jaxtronomy/LensModel/Profiles/gaussian_potential.py
+++ b/jaxtronomy/LensModel/Profiles/gaussian_potential.py
@@ -18,7 +18,16 @@ class GaussianPotential(LensProfileBase):
     @staticmethod
     @jit
     def function(x, y, amp, sigma_x, sigma_y, center_x=0, center_y=0):
-        """Returns Gaussian."""
+        """Returns Gaussian.
+        
+        :param x: x position
+        :param y: y position
+        :param amp: amplitude of Gaussian
+        :param sigma_x: standard deviation of Gaussian in the x direction
+        :param sigma_y: standard deviation of Gaussian in the y direction
+        :param center_x: x position of the center of the lens
+        :param center_y: y position of the center of the lens
+        """
         c = amp / (2 * jnp.pi * sigma_x * sigma_y)
         delta_x = x - center_x
         delta_y = y - center_y
@@ -28,7 +37,16 @@ class GaussianPotential(LensProfileBase):
     @staticmethod
     @jit
     def derivatives(x, y, amp, sigma_x, sigma_y, center_x=0, center_y=0):
-        """Returns df/dx and df/dy of the function."""
+        """Returns df/dx and df/dy of the function.
+        
+        :param x: x position
+        :param y: y position
+        :param amp: amplitude of Gaussian
+        :param sigma_x: standard deviation of Gaussian in the x direction
+        :param sigma_y: standard deviation of Gaussian in the y direction
+        :param center_x: x position of the center of the lens
+        :param center_y: y position of the center of the lens
+        """
         f_ = GaussianPotential.function(x, y, amp, sigma_x, sigma_y, center_x, center_y)
         return f_ * (center_x - x) / sigma_x**2, f_ * (center_y - y) / sigma_y**2
 
@@ -36,7 +54,16 @@ class GaussianPotential(LensProfileBase):
     @jit
     def hessian(x, y, amp, sigma_x, sigma_y, center_x=0, center_y=0):
         """Returns Hessian matrix of function d^2f/dx^2, d^2/dxdy, d^2/dydx,
-        d^f/dy^2."""
+        d^f/dy^2.
+        
+        :param x: x position
+        :param y: y position
+        :param amp: amplitude of Gaussian
+        :param sigma_x: standard deviation of Gaussian in the x direction
+        :param sigma_y: standard deviation of Gaussian in the y direction
+        :param center_x: x position of the center of the lens
+        :param center_y: y position of the center of the lens
+        """
         f_ = GaussianPotential.function(x, y, amp, sigma_x, sigma_y, center_x, center_y)
         f_xx = f_ * ((-1.0 / sigma_x**2) + (center_x - x) ** 2 / sigma_x**4)
         f_yy = f_ * ((-1.0 / sigma_y**2) + (center_y - y) ** 2 / sigma_y**4)

--- a/jaxtronomy/LensModel/Profiles/nfw.py
+++ b/jaxtronomy/LensModel/Profiles/nfw.py
@@ -187,7 +187,7 @@ class NFW(LensProfileBase):
     @staticmethod
     @jit
     def mass_3d(r, Rs, rho0):
-        """Mass enclosed a 3d sphere or radius r.
+        """Mass enclosed a 3d sphere of radius r.
 
         :param r: 3d radius
         :param Rs: scale radius
@@ -201,7 +201,7 @@ class NFW(LensProfileBase):
     @staticmethod
     @jit
     def mass_3d_lens(r, Rs, alpha_Rs):
-        """Mass enclosed a 3d sphere or radius r. This function takes as ijnput the
+        """Mass enclosed a 3d sphere of radius r. This function takes as input the
         lensing parameterization.
 
         :param r: 3d radius
@@ -216,7 +216,7 @@ class NFW(LensProfileBase):
     @staticmethod
     @jit
     def mass_2d(R, Rs, rho0):
-        """Mass enclosed a 2d cylinder or projected radius R.
+        """Mass enclosed a 2d cylinder of projected radius R.
 
         :param R: projected radius
         :param Rs: scale radius

--- a/jaxtronomy/LensModel/profile_list_base.py
+++ b/jaxtronomy/LensModel/profile_list_base.py
@@ -8,6 +8,8 @@ _JAXXED_MODELS = [
     "CSE",
     "EPL",
     "EPL_Q_PHI",
+    "GAUSSIAN",
+    "GAUSSIAN_POTENTIAL",
     "HERNQUIST",
     "HERNQUIST_ELLIPSE_CSE",
     "LOS",
@@ -262,209 +264,204 @@ def lens_class(
     :return: class instance of the lens model type
     """
 
-    if lens_type not in _JAXXED_MODELS:
-        warn(
-            "The {} profile is not in JAXtronomy; using lenstronomy implementation.\n"
-            "Note that this may cause crashes in some situations where jax arrays are passed into"
-            " functions utilizing the numba compiler in lenstronomy (e.g. util.rotate)".format(
-                lens_type
-            )
-        )
-    else:
-        pass
-
-    if lens_type == "ARC_PERT":
-        from lenstronomy.LensModel.Profiles.arc_perturbations import (
-            ArcPerturbations,
+    if lens_type not in _JAXXED_MODELS and lens_type in _SUPPORTED_MODELS:
+        raise ValueError(
+            "The {} profile is not in JAXtronomy; use lenstronomy instead."
+            .format(lens_type)
         )
 
-        return ArcPerturbations()
-    if lens_type == "BLANK_PLANE":
-        from lenstronomy.LensModel.Profiles.blank_plane import BlankPlane
+    # if lens_type == "ARC_PERT":
+    #     from lenstronomy.LensModel.Profiles.arc_perturbations import (
+    #         ArcPerturbations,
+    #     )
 
-        return BlankPlane()
-    elif lens_type == "CHAMELEON":
-        from lenstronomy.LensModel.Profiles.chameleon import Chameleon
+    #     return ArcPerturbations()
+    # if lens_type == "BLANK_PLANE":
+    #     from lenstronomy.LensModel.Profiles.blank_plane import BlankPlane
 
-        return Chameleon()
-    elif lens_type == "CNFW":
-        from lenstronomy.LensModel.Profiles.cnfw import CNFW
+    #     return BlankPlane()
+    # elif lens_type == "CHAMELEON":
+    #     from lenstronomy.LensModel.Profiles.chameleon import Chameleon
 
-        return CNFW()
-    elif lens_type == "CNFW_ELLIPSE_POTENTIAL":
-        from lenstronomy.LensModel.Profiles.cnfw_ellipse_potential import (
-            CNFWEllipsePotential,
-        )
+    #     return Chameleon()
+    # elif lens_type == "CNFW":
+    #     from lenstronomy.LensModel.Profiles.cnfw import CNFW
 
-        return CNFWEllipsePotential()
-    elif lens_type == "CONST_MAG":
-        from lenstronomy.LensModel.Profiles.const_mag import ConstMag
+    #     return CNFW()
+    # elif lens_type == "CNFW_ELLIPSE_POTENTIAL":
+    #     from lenstronomy.LensModel.Profiles.cnfw_ellipse_potential import (
+    #         CNFWEllipsePotential,
+    #     )
 
-        return ConstMag()
+    #     return CNFWEllipsePotential()
+    # elif lens_type == "CONST_MAG":
+    #     from lenstronomy.LensModel.Profiles.const_mag import ConstMag
+
+    #     return ConstMag()
     elif lens_type == "CONVERGENCE":
         from jaxtronomy.LensModel.Profiles.convergence import Convergence
 
         return Convergence()
-    elif lens_type == "coreBURKERT":
-        from lenstronomy.LensModel.Profiles.coreBurkert import CoreBurkert
+    # elif lens_type == "coreBURKERT":
+    #     from lenstronomy.LensModel.Profiles.coreBurkert import CoreBurkert
 
-        return CoreBurkert()
-    elif lens_type == "CORED_DENSITY":
-        from lenstronomy.LensModel.Profiles.cored_density import CoredDensity
+    #     return CoreBurkert()
+    # elif lens_type == "CORED_DENSITY":
+    #     from lenstronomy.LensModel.Profiles.cored_density import CoredDensity
 
-        return CoredDensity()
-    elif lens_type == "CORED_DENSITY_2":
-        from lenstronomy.LensModel.Profiles.cored_density_2 import CoredDensity2
+    #     return CoredDensity()
+    # elif lens_type == "CORED_DENSITY_2":
+    #     from lenstronomy.LensModel.Profiles.cored_density_2 import CoredDensity2
 
-        return CoredDensity2()
-    elif lens_type == "CORED_DENSITY_2_MST":
-        from lenstronomy.LensModel.Profiles.cored_density_mst import CoredDensityMST
+    #     return CoredDensity2()
+    # elif lens_type == "CORED_DENSITY_2_MST":
+    #     from lenstronomy.LensModel.Profiles.cored_density_mst import CoredDensityMST
 
-        return CoredDensityMST(profile_type="CORED_DENSITY_2")
-    elif lens_type == "CORED_DENSITY_EXP":
-        from lenstronomy.LensModel.Profiles.cored_density_exp import CoredDensityExp
+    #     return CoredDensityMST(profile_type="CORED_DENSITY_2")
+    # elif lens_type == "CORED_DENSITY_EXP":
+    #     from lenstronomy.LensModel.Profiles.cored_density_exp import CoredDensityExp
 
-        return CoredDensityExp()
-    elif lens_type == "CORED_DENSITY_EXP_MST":
-        from lenstronomy.LensModel.Profiles.cored_density_mst import CoredDensityMST
+    #     return CoredDensityExp()
+    # elif lens_type == "CORED_DENSITY_EXP_MST":
+    #     from lenstronomy.LensModel.Profiles.cored_density_mst import CoredDensityMST
 
-        return CoredDensityMST(profile_type="CORED_DENSITY_EXP")
-    elif lens_type == "CORED_DENSITY_MST":
-        from lenstronomy.LensModel.Profiles.cored_density_mst import CoredDensityMST
+    #     return CoredDensityMST(profile_type="CORED_DENSITY_EXP")
+    # elif lens_type == "CORED_DENSITY_MST":
+    #     from lenstronomy.LensModel.Profiles.cored_density_mst import CoredDensityMST
 
-        return CoredDensityMST(profile_type="CORED_DENSITY")
-    elif lens_type == "CORED_DENSITY_ULDM_MST":
-        from lenstronomy.LensModel.Profiles.cored_density_mst import CoredDensityMST
+    #     return CoredDensityMST(profile_type="CORED_DENSITY")
+    # elif lens_type == "CORED_DENSITY_ULDM_MST":
+    #     from lenstronomy.LensModel.Profiles.cored_density_mst import CoredDensityMST
 
-        return CoredDensityMST(profile_type="CORED_DENSITY_ULDM")
+    #     return CoredDensityMST(profile_type="CORED_DENSITY_ULDM")
     elif lens_type == "CSE":
         from jaxtronomy.LensModel.Profiles.cored_steep_ellipsoid import CSE
 
         return CSE()
-    elif lens_type == "CTNFW_GAUSS_DEC":
-        from lenstronomy.LensModel.Profiles.gauss_decomposition import CTNFWGaussDec
+    # elif lens_type == "CTNFW_GAUSS_DEC":
+    #     from lenstronomy.LensModel.Profiles.gauss_decomposition import CTNFWGaussDec
 
-        return CTNFWGaussDec()
-    elif lens_type == "CURVED_ARC_CONST":
-        from lenstronomy.LensModel.Profiles.curved_arc_const import CurvedArcConst
+    #     return CTNFWGaussDec()
+    # elif lens_type == "CURVED_ARC_CONST":
+    #     from lenstronomy.LensModel.Profiles.curved_arc_const import CurvedArcConst
 
-        return CurvedArcConst()
-    elif lens_type == "CURVED_ARC_CONST_MST":
-        from lenstronomy.LensModel.Profiles.curved_arc_const import CurvedArcConstMST
+    #     return CurvedArcConst()
+    # elif lens_type == "CURVED_ARC_CONST_MST":
+    #     from lenstronomy.LensModel.Profiles.curved_arc_const import CurvedArcConstMST
 
-        return CurvedArcConstMST()
-    elif lens_type == "CURVED_ARC_SIS_MST":
-        from lenstronomy.LensModel.Profiles.curved_arc_sis_mst import CurvedArcSISMST
+    #     return CurvedArcConstMST()
+    # elif lens_type == "CURVED_ARC_SIS_MST":
+    #     from lenstronomy.LensModel.Profiles.curved_arc_sis_mst import CurvedArcSISMST
 
-        return CurvedArcSISMST()
-    elif lens_type == "CURVED_ARC_SPP":
-        from lenstronomy.LensModel.Profiles.curved_arc_spp import CurvedArcSPP
+    #     return CurvedArcSISMST()
+    # elif lens_type == "CURVED_ARC_SPP":
+    #     from lenstronomy.LensModel.Profiles.curved_arc_spp import CurvedArcSPP
 
-        return CurvedArcSPP()
-    elif lens_type == "CURVED_ARC_SPT":
-        from lenstronomy.LensModel.Profiles.curved_arc_spt import CurvedArcSPT
+    #     return CurvedArcSPP()
+    # elif lens_type == "CURVED_ARC_SPT":
+    #     from lenstronomy.LensModel.Profiles.curved_arc_spt import CurvedArcSPT
 
-        return CurvedArcSPT()
-    elif lens_type == "CURVED_ARC_TAN_DIFF":
-        from lenstronomy.LensModel.Profiles.curved_arc_tan_diff import (
-            CurvedArcTanDiff,
-        )
+    #     return CurvedArcSPT()
+    # elif lens_type == "CURVED_ARC_TAN_DIFF":
+    #     from lenstronomy.LensModel.Profiles.curved_arc_tan_diff import (
+    #         CurvedArcTanDiff,
+    #     )
 
-        return CurvedArcTanDiff()
-    elif lens_type == "DIPOLE":
-        from lenstronomy.LensModel.Profiles.dipole import Dipole
+    #     return CurvedArcTanDiff()
+    # elif lens_type == "DIPOLE":
+    #     from lenstronomy.LensModel.Profiles.dipole import Dipole
 
-        return Dipole()
-    elif lens_type == "DOUBLE_CHAMELEON":
-        from lenstronomy.LensModel.Profiles.chameleon import DoubleChameleon
+    #     return Dipole()
+    # elif lens_type == "DOUBLE_CHAMELEON":
+    #     from lenstronomy.LensModel.Profiles.chameleon import DoubleChameleon
 
-        return DoubleChameleon()
+    #     return DoubleChameleon()
     elif lens_type == "EPL":
         from jaxtronomy.LensModel.Profiles.epl import EPL
 
         return EPL()
-    elif lens_type == "EPL_BOXYDISKY":
-        from lenstronomy.LensModel.Profiles.epl_boxydisky import EPL_BOXYDISKY
+    # elif lens_type == "EPL_BOXYDISKY":
+    #     from lenstronomy.LensModel.Profiles.epl_boxydisky import EPL_BOXYDISKY
 
-        return EPL_BOXYDISKY()
-    elif lens_type == "EPL_MULTIPOLE_M3M4":
-        from lenstronomy.LensModel.Profiles.epl_multipole_m3m4 import EPL_MULTIPOLE_M3M4
+    #     return EPL_BOXYDISKY()
+    # elif lens_type == "EPL_MULTIPOLE_M3M4":
+    #     from lenstronomy.LensModel.Profiles.epl_multipole_m3m4 import EPL_MULTIPOLE_M3M4
 
-        return EPL_MULTIPOLE_M3M4()
-    elif lens_type == "EPL_NUMBA":
-        from lenstronomy.LensModel.Profiles.epl_numba import EPL_numba
+    #     return EPL_MULTIPOLE_M3M4()
+    # elif lens_type == "EPL_NUMBA":
+    #     from lenstronomy.LensModel.Profiles.epl_numba import EPL_numba
 
-        return EPL_numba()
+    #     return EPL_numba()
     elif lens_type == "EPL_Q_PHI":
         from jaxtronomy.LensModel.Profiles.epl import EPLQPhi
 
         return EPLQPhi()
-    elif lens_type == "ElliSLICE":
-        from lenstronomy.LensModel.Profiles.elliptical_density_slice import (
-            ElliSLICE,
-        )
+    # elif lens_type == "ElliSLICE":
+    #     from lenstronomy.LensModel.Profiles.elliptical_density_slice import (
+    #         ElliSLICE,
+    #     )
 
-        return ElliSLICE()
-    elif lens_type == "FLEXION":
-        from lenstronomy.LensModel.Profiles.flexion import Flexion
+    #     return ElliSLICE()
+    # elif lens_type == "FLEXION":
+    #     from lenstronomy.LensModel.Profiles.flexion import Flexion
 
-        return Flexion()
-    elif lens_type == "FLEXIONFG":
-        from lenstronomy.LensModel.Profiles.flexionfg import Flexionfg
+    #     return Flexion()
+    # elif lens_type == "FLEXIONFG":
+    #     from lenstronomy.LensModel.Profiles.flexionfg import Flexionfg
 
-        return Flexionfg()
+    #     return Flexionfg()
     elif lens_type == "GAUSSIAN":
-        from lenstronomy.LensModel.Profiles.gaussian import Gaussian
+        from jaxtronomy.LensModel.Profiles.gaussian import Gaussian
 
         return Gaussian()
-    elif lens_type == "GAUSSIAN_ELLIPSE_KAPPA":
-        from lenstronomy.LensModel.Profiles.gaussian_ellipse_kappa import (
-            GaussianEllipseKappa,
-        )
+    # elif lens_type == "GAUSSIAN_ELLIPSE_KAPPA":
+    #     from lenstronomy.LensModel.Profiles.gaussian_ellipse_kappa import (
+    #         GaussianEllipseKappa,
+    #     )
 
-        return GaussianEllipseKappa()
-    elif lens_type == "GAUSSIAN_ELLIPSE_POTENTIAL":
-        from lenstronomy.LensModel.Profiles.gaussian_ellipse_potential import (
-            GaussianEllipsePotential,
-        )
+    #     return GaussianEllipseKappa()
+    # elif lens_type == "GAUSSIAN_ELLIPSE_POTENTIAL":
+    #     from lenstronomy.LensModel.Profiles.gaussian_ellipse_potential import (
+    #         GaussianEllipsePotential,
+    #     )
 
-        return GaussianEllipsePotential()
+    #     return GaussianEllipsePotential()
     elif lens_type == "GAUSSIAN_POTENTIAL":
-        from lenstronomy.LensModel.Profiles.gaussian_potential import GaussianPotential
+        from jaxtronomy.LensModel.Profiles.gaussian_potential import GaussianPotential
 
         return GaussianPotential()
-    elif lens_type == "GNFW":
-        from lenstronomy.LensModel.Profiles.gnfw import GNFW
+    # elif lens_type == "GNFW":
+    #     from lenstronomy.LensModel.Profiles.gnfw import GNFW
 
-        return GNFW()
+    #     return GNFW()
     elif lens_type == "HERNQUIST":
         from jaxtronomy.LensModel.Profiles.hernquist import Hernquist
 
         return Hernquist()
-    elif lens_type == "HERNQUIST_ELLIPSE_POTENTIAL":
-        from lenstronomy.LensModel.Profiles.hernquist_ellipse_potential import (
-            HernquistEllipsePotential,
-        )
+    # elif lens_type == "HERNQUIST_ELLIPSE_POTENTIAL":
+    #     from lenstronomy.LensModel.Profiles.hernquist_ellipse_potential import (
+    #         HernquistEllipsePotential,
+    #     )
 
-        return HernquistEllipsePotential()
+    #     return HernquistEllipsePotential()
     elif lens_type == "HERNQUIST_ELLIPSE_CSE":
         from jaxtronomy.LensModel.Profiles.hernquist_ellipse_cse import (
             HernquistEllipseCSE,
         )
 
         return HernquistEllipseCSE()
-    elif lens_type == "HESSIAN":
-        from lenstronomy.LensModel.Profiles.hessian import Hessian
+    # elif lens_type == "HESSIAN":
+    #     from lenstronomy.LensModel.Profiles.hessian import Hessian
 
-        return Hessian()
-    elif lens_type == "INTERPOL":
-        from lenstronomy.LensModel.Profiles.interpol import Interpol
+    #     return Hessian()
+    # elif lens_type == "INTERPOL":
+    #     from lenstronomy.LensModel.Profiles.interpol import Interpol
 
-        return Interpol(**kwargs_interp)
-    elif lens_type == "INTERPOL_SCALED":
-        from lenstronomy.LensModel.Profiles.interpol import InterpolScaled
+    #     return Interpol(**kwargs_interp)
+    # elif lens_type == "INTERPOL_SCALED":
+    #     from lenstronomy.LensModel.Profiles.interpol import InterpolScaled
 
-        return InterpolScaled(**kwargs_interp)
+    #     return InterpolScaled(**kwargs_interp)
     elif lens_type == "LOS":
         from jaxtronomy.LensModel.LineOfSight.LOSModels.los import LOS
 
@@ -475,68 +472,68 @@ def lens_class(
         )
 
         return LOSMinimal()
-    elif lens_type == "MULTIPOLE":
-        from lenstronomy.LensModel.Profiles.multipole import Multipole
+    # elif lens_type == "MULTIPOLE":
+    #     from lenstronomy.LensModel.Profiles.multipole import Multipole
 
-        return Multipole()
-    elif lens_type == "MULTI_GAUSSIAN":
-        from lenstronomy.LensModel.Profiles.multi_gaussian import (
-            MultiGaussian,
-        )
+    #     return Multipole()
+    # elif lens_type == "MULTI_GAUSSIAN":
+    #     from lenstronomy.LensModel.Profiles.multi_gaussian import (
+    #         MultiGaussian,
+    #     )
 
-        return MultiGaussian()
-    elif lens_type == "MULTI_GAUSSIAN_ELLIPSE_POTENTIAL":
-        from lenstronomy.LensModel.Profiles.multi_gaussian import (
-            MultiGaussianEllipsePotential,
-        )
+    #     return MultiGaussian()
+    # elif lens_type == "MULTI_GAUSSIAN_ELLIPSE_POTENTIAL":
+    #     from lenstronomy.LensModel.Profiles.multi_gaussian import (
+    #         MultiGaussianEllipsePotential,
+    #     )
 
-        return MultiGaussianEllipsePotential()
+    #     return MultiGaussianEllipsePotential()
     elif lens_type == "NFW":
         from jaxtronomy.LensModel.Profiles.nfw import NFW
 
         return NFW()
-    elif lens_type == "NFW_ELLIPSE_POTENTIAL":
-        from lenstronomy.LensModel.Profiles.nfw_ellipse_potential import (
-            NFWEllipsePotential,
-        )
+    # elif lens_type == "NFW_ELLIPSE_POTENTIAL":
+    #     from lenstronomy.LensModel.Profiles.nfw_ellipse_potential import (
+    #         NFWEllipsePotential,
+    #     )
 
-        return NFWEllipsePotential()
+    #     return NFWEllipsePotential()
     elif lens_type == "NFW_ELLIPSE_CSE":
         from jaxtronomy.LensModel.Profiles.nfw_ellipse_cse import NFW_ELLIPSE_CSE
 
         return NFW_ELLIPSE_CSE()
-    elif lens_type == "NFW_ELLIPSE_GAUSS_DEC":
-        from lenstronomy.LensModel.Profiles.gauss_decomposition import (
-            NFWEllipseGaussDec,
-        )
+    # elif lens_type == "NFW_ELLIPSE_GAUSS_DEC":
+    #     from lenstronomy.LensModel.Profiles.gauss_decomposition import (
+    #         NFWEllipseGaussDec,
+    #     )
 
-        return NFWEllipseGaussDec()
-    elif lens_type == "NFW_MC":
-        from lenstronomy.LensModel.Profiles.nfw_mass_concentration import NFWMC
+    #     return NFWEllipseGaussDec()
+    # elif lens_type == "NFW_MC":
+    #     from lenstronomy.LensModel.Profiles.nfw_mass_concentration import NFWMC
 
-        return NFWMC(z_lens=z_lens, z_source=z_source)
-    elif lens_type == "NFW_MC_ELLIPSE_POTENTIAL":
-        from lenstronomy.LensModel.Profiles.nfw_mass_concentration_ellipse import (
-            NFWMCEllipsePotential,
-        )
+    #     return NFWMC(z_lens=z_lens, z_source=z_source)
+    # elif lens_type == "NFW_MC_ELLIPSE_POTENTIAL":
+    #     from lenstronomy.LensModel.Profiles.nfw_mass_concentration_ellipse import (
+    #         NFWMCEllipsePotential,
+    #     )
 
-        return NFWMCEllipsePotential(z_lens=z_lens, z_source=z_source)
+    #     return NFWMCEllipsePotential(z_lens=z_lens, z_source=z_source)
     elif lens_type == "NIE":
         from jaxtronomy.LensModel.Profiles.nie import NIE
 
         return NIE()
-    elif lens_type == "NIE_POTENTIAL":
-        from lenstronomy.LensModel.Profiles.nie_potential import NIE_POTENTIAL
+    # elif lens_type == "NIE_POTENTIAL":
+    #     from lenstronomy.LensModel.Profiles.nie_potential import NIE_POTENTIAL
 
-        return NIE_POTENTIAL()
-    elif lens_type == "NIE_SIMPLE":
-        from lenstronomy.LensModel.Profiles.nie import NIEMajorAxis
+    #     return NIE_POTENTIAL()
+    # elif lens_type == "NIE_SIMPLE":
+    #     from lenstronomy.LensModel.Profiles.nie import NIEMajorAxis
 
-        return NIEMajorAxis()
-    elif lens_type == "PEMD":
-        from lenstronomy.LensModel.Profiles.pemd import PEMD
+    #     return NIEMajorAxis()
+    # elif lens_type == "PEMD":
+    #     from lenstronomy.LensModel.Profiles.pemd import PEMD
 
-        return PEMD()
+    #     return PEMD()
     elif lens_type == "PJAFFE":
         from jaxtronomy.LensModel.Profiles.pseudo_jaffe import PseudoJaffe
 
@@ -547,70 +544,70 @@ def lens_class(
         )
 
         return PseudoJaffeEllipsePotential()
-    elif lens_type == "POINT_MASS":
-        from lenstronomy.LensModel.Profiles.point_mass import PointMass
+    # elif lens_type == "POINT_MASS":
+    #     from lenstronomy.LensModel.Profiles.point_mass import PointMass
 
-        return PointMass()
-    elif lens_type == "PSEUDO_DPL":
-        from lenstronomy.LensModel.Profiles.pseudo_double_powerlaw import (
-            PseudoDoublePowerlaw,
-        )
+    #     return PointMass()
+    # elif lens_type == "PSEUDO_DPL":
+    #     from lenstronomy.LensModel.Profiles.pseudo_double_powerlaw import (
+    #         PseudoDoublePowerlaw,
+    #     )
 
-        return PseudoDoublePowerlaw()
-    elif lens_type == "RADIAL_INTERPOL":
-        from lenstronomy.LensModel.Profiles.radial_interpolated import (
-            RadialInterpolate,
-        )
+    #     return PseudoDoublePowerlaw()
+    # elif lens_type == "RADIAL_INTERPOL":
+    #     from lenstronomy.LensModel.Profiles.radial_interpolated import (
+    #         RadialInterpolate,
+    #     )
 
-        return RadialInterpolate()
-    elif lens_type == "SERSIC":
-        from lenstronomy.LensModel.Profiles.sersic import Sersic
+    #     return RadialInterpolate()
+    # elif lens_type == "SERSIC":
+    #     from lenstronomy.LensModel.Profiles.sersic import Sersic
 
-        return Sersic()
-    elif lens_type == "SERSIC_ELLIPSE_GAUSS_DEC":
-        from lenstronomy.LensModel.Profiles.gauss_decomposition import (
-            SersicEllipseGaussDec,
-        )
+    #     return Sersic()
+    # elif lens_type == "SERSIC_ELLIPSE_GAUSS_DEC":
+    #     from lenstronomy.LensModel.Profiles.gauss_decomposition import (
+    #         SersicEllipseGaussDec,
+    #     )
 
-        return SersicEllipseGaussDec()
-    elif lens_type == "SERSIC_ELLIPSE_KAPPA":
-        from lenstronomy.LensModel.Profiles.sersic_ellipse_kappa import (
-            SersicEllipseKappa,
-        )
+    #     return SersicEllipseGaussDec()
+    # elif lens_type == "SERSIC_ELLIPSE_KAPPA":
+    #     from lenstronomy.LensModel.Profiles.sersic_ellipse_kappa import (
+    #         SersicEllipseKappa,
+    #     )
 
-        return SersicEllipseKappa()
-    elif lens_type == "SERSIC_ELLIPSE_POTENTIAL":
-        from lenstronomy.LensModel.Profiles.sersic_ellipse_potential import (
-            SersicEllipsePotential,
-        )
+    #     return SersicEllipseKappa()
+    # elif lens_type == "SERSIC_ELLIPSE_POTENTIAL":
+    #     from lenstronomy.LensModel.Profiles.sersic_ellipse_potential import (
+    #         SersicEllipsePotential,
+    #     )
 
-        return SersicEllipsePotential()
-    elif lens_type == "SHAPELETS_CART":
-        from lenstronomy.LensModel.Profiles.shapelet_pot_cartesian import (
-            CartShapelets,
-        )
+    #     return SersicEllipsePotential()
+    # elif lens_type == "SHAPELETS_CART":
+    #     from lenstronomy.LensModel.Profiles.shapelet_pot_cartesian import (
+    #         CartShapelets,
+    #     )
 
-        return CartShapelets()
-    elif lens_type == "SHAPELETS_POLAR":
-        from lenstronomy.LensModel.Profiles.shapelet_pot_polar import PolarShapelets
+    #     return CartShapelets()
+    # elif lens_type == "SHAPELETS_POLAR":
+    #     from lenstronomy.LensModel.Profiles.shapelet_pot_polar import PolarShapelets
 
-        return PolarShapelets()
-    elif lens_type == "SHIFT":
-        from lenstronomy.LensModel.Profiles.constant_shift import Shift
+    #     return PolarShapelets()
+    # elif lens_type == "SHIFT":
+    #     from lenstronomy.LensModel.Profiles.constant_shift import Shift
 
-        return Shift()
+    #     return Shift()
     elif lens_type == "SHEAR":
         from jaxtronomy.LensModel.Profiles.shear import Shear
 
         return Shear()
-    elif lens_type == "SHEAR_GAMMA_PSI":
-        from lenstronomy.LensModel.Profiles.shear import ShearGammaPsi
+    # elif lens_type == "SHEAR_GAMMA_PSI":
+    #     from lenstronomy.LensModel.Profiles.shear import ShearGammaPsi
 
-        return ShearGammaPsi()
-    elif lens_type == "SHEAR_REDUCED":
-        from lenstronomy.LensModel.Profiles.shear import ShearReduced
+    #     return ShearGammaPsi()
+    # elif lens_type == "SHEAR_REDUCED":
+    #     from lenstronomy.LensModel.Profiles.shear import ShearReduced
 
-        return ShearReduced()
+    #     return ShearReduced()
     elif lens_type == "SIE":
         from jaxtronomy.LensModel.Profiles.sie import SIE
 
@@ -619,61 +616,60 @@ def lens_class(
         from jaxtronomy.LensModel.Profiles.sis import SIS
 
         return SIS()
-    elif lens_type == "SIS_TRUNCATED":
-        from lenstronomy.LensModel.Profiles.sis_truncate import SIS_truncate
+    # elif lens_type == "SIS_TRUNCATED":
+    #     from lenstronomy.LensModel.Profiles.sis_truncate import SIS_truncate
 
-        return SIS_truncate()
-    elif lens_type == "SPEMD":
-        from lenstronomy.LensModel.Profiles.spemd import SPEMD
+    #     return SIS_truncate()
+    # elif lens_type == "SPEMD":
+    #     from lenstronomy.LensModel.Profiles.spemd import SPEMD
 
-        return SPEMD()
-    elif lens_type == "SPEP":
-        from lenstronomy.LensModel.Profiles.spep import SPEP
+    #     return SPEMD()
+    # elif lens_type == "SPEP":
+    #     from lenstronomy.LensModel.Profiles.spep import SPEP
 
-        return SPEP()
-    elif lens_type == "SPL_CORE":
-        from lenstronomy.LensModel.Profiles.splcore import SPLCORE
+    #     return SPEP()
+    # elif lens_type == "SPL_CORE":
+    #     from lenstronomy.LensModel.Profiles.splcore import SPLCORE
 
-        return SPLCORE()
+    #     return SPLCORE()
     elif lens_type == "SPP":
         from jaxtronomy.LensModel.Profiles.spp import SPP
 
         return SPP()
-    elif lens_type == "SYNTHESIS":
-        from lenstronomy.LensModel.Profiles.synthesis import SynthesisProfile
+    # elif lens_type == "SYNTHESIS":
+    #     from lenstronomy.LensModel.Profiles.synthesis import SynthesisProfile
 
-        return SynthesisProfile(**kwargs_synthesis)
-    elif lens_type == "TABULATED_DEFLECTIONS":
-        from lenstronomy.LensModel.Profiles.numerical_deflections import (
-            TabulatedDeflections,
-        )
+    #     return SynthesisProfile(**kwargs_synthesis)
+    # elif lens_type == "TABULATED_DEFLECTIONS":
+    #     from lenstronomy.LensModel.Profiles.numerical_deflections import (
+    #         TabulatedDeflections,
+    #     )
 
-        return TabulatedDeflections(custom_class)
-    elif lens_type == "TNFW":
-        from lenstronomy.LensModel.Profiles.tnfw import TNFW
+    #     return TabulatedDeflections(custom_class)
+    # elif lens_type == "TNFW":
+    #     from lenstronomy.LensModel.Profiles.tnfw import TNFW
 
-        return TNFW()
-    elif lens_type == "TNFWC":
-        from lenstronomy.LensModel.Profiles.nfw_core_truncated import TNFWC
+    #     return TNFW()
+    # elif lens_type == "TNFWC":
+    #     from lenstronomy.LensModel.Profiles.nfw_core_truncated import TNFWC
 
-        return TNFWC()
-    elif lens_type == "TNFW_ELLIPSE_POTENTIAL":
-        from lenstronomy.LensModel.Profiles.tnfw_ellipse_potential import (
-            TNFWELLIPSEPotential,
-        )
+    #     return TNFWC()
+    # elif lens_type == "TNFW_ELLIPSE_POTENTIAL":
+    #     from lenstronomy.LensModel.Profiles.tnfw_ellipse_potential import (
+    #         TNFWELLIPSEPotential,
+    #     )
 
-        return TNFWELLIPSEPotential()
-    elif lens_type == "TRIPLE_CHAMELEON":
-        from lenstronomy.LensModel.Profiles.chameleon import TripleChameleon
+    #     return TNFWELLIPSEPotential()
+    # elif lens_type == "TRIPLE_CHAMELEON":
+    #     from lenstronomy.LensModel.Profiles.chameleon import TripleChameleon
 
-        return TripleChameleon()
-    elif lens_type == "ULDM":
-        from lenstronomy.LensModel.Profiles.uldm import Uldm
+    #     return TripleChameleon()
+    # elif lens_type == "ULDM":
+    #     from lenstronomy.LensModel.Profiles.uldm import Uldm
 
-        return Uldm()
+    #     return Uldm()
     # when adding a new profile, insert the corresponding elif statement in its
     # alphabetical position
-
     else:
         raise ValueError(
             "%s is not a valid lens model. Supported are: %s."

--- a/jaxtronomy/LensModel/single_plane.py
+++ b/jaxtronomy/LensModel/single_plane.py
@@ -1,8 +1,9 @@
 __author__ = "sibirrer"
 
 import jax
-import jax.numpy as jnp
+from jax import jit, numpy as jnp
 from jaxtronomy.LensModel.profile_list_base import ProfileListBase
+from functools import partial
 
 jax.config.update("jax_enable_x64", True)
 
@@ -12,6 +13,7 @@ __all__ = ["SinglePlane"]
 class SinglePlane(ProfileListBase):
     """Class to handle an arbitrary list of lens models in a single lensing plane."""
 
+    @partial(jit, static_argnums=(0,4))
     def ray_shooting(self, x, y, kwargs, k=None):
         """Maps image to source position (inverse deflection).
 
@@ -22,6 +24,7 @@ class SinglePlane(ProfileListBase):
         :param kwargs: list of keyword arguments of lens model parameters matching the
             lens model classes
         :param k: only evaluate the k-th lens model
+        :type k: None, int, or tuple of ints
         :return: source plane positions corresponding to (x, y) in the image plane
         """
 
@@ -39,7 +42,8 @@ class SinglePlane(ProfileListBase):
         :param y_source: source position
         :param kwargs_lens: list of keyword arguments of lens model parameters matching
             the lens model classes
-        :param k:
+        :param k: only evaluate the k-th lens model
+        :type k: None, int, or tuple of ints
         :return: fermat potential in arcsec**2 without geometry term (second part of Eqn
             1 in Suyu et al. 2013) as a list
         """
@@ -50,6 +54,7 @@ class SinglePlane(ProfileListBase):
         geometry = ((x_image - x_source) ** 2 + (y_image - y_source) ** 2) / 2.0
         return geometry - potential
 
+    @partial(jit, static_argnums=(0,4))
     def potential(self, x, y, kwargs, k=None):
         """Lensing potential.
 
@@ -60,6 +65,7 @@ class SinglePlane(ProfileListBase):
         :param kwargs: list of keyword arguments of lens model parameters matching the
             lens model classes
         :param k: only evaluate the k-th lens model
+        :type k: None, int, or tuple of ints
         :return: lensing potential in units of arcsec^2
         """
         x = jnp.array(x, dtype=float)
@@ -73,6 +79,7 @@ class SinglePlane(ProfileListBase):
                 potential += func.function(x, y, **kwargs[i])
         return potential
 
+    @partial(jit, static_argnums=(0,4))
     def alpha(self, x, y, kwargs, k=None):
         """Deflection angles.
 
@@ -83,6 +90,7 @@ class SinglePlane(ProfileListBase):
         :param kwargs: list of keyword arguments of lens model parameters matching the
             lens model classes
         :param k: only evaluate the k-th lens model
+        :type k: None, int, or tuple of ints
         :return: deflectionangles in units of arcsec
         """
         x = jnp.array(x, dtype=float)
@@ -100,6 +108,7 @@ class SinglePlane(ProfileListBase):
 
         return f_x, f_y
 
+    @partial(jit, static_argnums=(0,4))
     def hessian(self, x, y, kwargs, k=None):
         """Hessian matrix.
 
@@ -110,6 +119,7 @@ class SinglePlane(ProfileListBase):
         :param kwargs: list of keyword arguments of lens model parameters matching the
             lens model classes
         :param k: only evaluate the k-th lens model
+        :type k: None, int, or tuple of ints
         :return: f_xx, f_xy, f_yx, f_yy components
         """
         x = jnp.array(x, dtype=float)
@@ -134,6 +144,7 @@ class SinglePlane(ProfileListBase):
                 f_yy += f_yy_i
         return f_xx, f_xy, f_yx, f_yy
 
+    @partial(jit, static_argnums=(0,3))
     def mass_3d(self, r, kwargs, bool_list=None):
         """Computes the mass within a 3d sphere of radius r.
 
@@ -145,7 +156,7 @@ class SinglePlane(ProfileListBase):
         :param r: radius (in angular units)
         :param kwargs: list of keyword arguments of lens model parameters matching the
             lens model classes
-        :param bool_list: list of bools that are part of the output
+        :param bool_list: tuple of bools that are part of the output
         :return: mass (in angular units, modulo epsilon_crit)
         """
         bool_list = self._bool_list(bool_list)
@@ -161,6 +172,7 @@ class SinglePlane(ProfileListBase):
                 mass_3d += mass_3d_i
         return mass_3d
 
+    @partial(jit, static_argnums=(0,3))
     def mass_2d(self, r, kwargs, bool_list=None):
         """Computes the mass enclosed a projected (2d) radius r.
 
@@ -174,7 +186,7 @@ class SinglePlane(ProfileListBase):
         :param r: radius (in angular units)
         :param kwargs: list of keyword arguments of lens model parameters matching the
             lens model classes
-        :param bool_list: list of bools that are part of the output
+        :param bool_list: tuple of bools that are part of the output
         :return: projected mass (in angular units, modulo epsilon_crit)
         """
         bool_list = self._bool_list(bool_list)
@@ -190,6 +202,7 @@ class SinglePlane(ProfileListBase):
                 mass_2d += mass_2d_i
         return mass_2d
 
+    @partial(jit, static_argnums=(0,3))
     def density(self, r, kwargs, bool_list=None):
         """3d mass density at radius r The integral in the LOS projection of this
         quantity results in the convergence quantity.
@@ -197,7 +210,7 @@ class SinglePlane(ProfileListBase):
         :param r: radius (in angular units)
         :param kwargs: list of keyword arguments of lens model parameters matching the
             lens model classes
-        :param bool_list: list of bools that are part of the output
+        :param bool_list: tuple of bools that are part of the output
         :return: mass density at radius r (in angular units, modulo epsilon_crit)
         """
         bool_list = self._bool_list(bool_list)

--- a/jaxtronomy/LensModel/single_plane.py
+++ b/jaxtronomy/LensModel/single_plane.py
@@ -145,7 +145,7 @@ class SinglePlane(ProfileListBase):
         return f_xx, f_xy, f_yx, f_yy
 
     @partial(jit, static_argnums=(0,3))
-    def mass_3d(self, r, kwargs, bool_list=None):
+    def mass_3d(self, r, kwargs, k=None):
         """Computes the mass within a 3d sphere of radius r.
 
         if you want to have physical units of kg, you need to multiply by this factor:
@@ -156,10 +156,11 @@ class SinglePlane(ProfileListBase):
         :param r: radius (in angular units)
         :param kwargs: list of keyword arguments of lens model parameters matching the
             lens model classes
-        :param bool_list: tuple of bools that are part of the output
+        :param k: only evaluate the k-th lens model
+        :type k: None, int, or tuple of ints
         :return: mass (in angular units, modulo epsilon_crit)
         """
-        bool_list = self._bool_list(bool_list)
+        bool_list = self._bool_list(k)
         mass_3d = 0
         for i, func in enumerate(self.func_list):
             if bool_list[i] is True:
@@ -173,7 +174,7 @@ class SinglePlane(ProfileListBase):
         return mass_3d
 
     @partial(jit, static_argnums=(0,3))
-    def mass_2d(self, r, kwargs, bool_list=None):
+    def mass_2d(self, r, kwargs, k=None):
         """Computes the mass enclosed a projected (2d) radius r.
 
         The mass definition is such that:
@@ -186,10 +187,11 @@ class SinglePlane(ProfileListBase):
         :param r: radius (in angular units)
         :param kwargs: list of keyword arguments of lens model parameters matching the
             lens model classes
-        :param bool_list: tuple of bools that are part of the output
+        :param k: only evaluate the k-th lens model
+        :type k: None, int, or tuple of ints
         :return: projected mass (in angular units, modulo epsilon_crit)
         """
-        bool_list = self._bool_list(bool_list)
+        bool_list = self._bool_list(k)
         mass_2d = 0
         for i, func in enumerate(self.func_list):
             if bool_list[i] is True:
@@ -203,17 +205,18 @@ class SinglePlane(ProfileListBase):
         return mass_2d
 
     @partial(jit, static_argnums=(0,3))
-    def density(self, r, kwargs, bool_list=None):
+    def density(self, r, kwargs, k=None):
         """3d mass density at radius r The integral in the LOS projection of this
         quantity results in the convergence quantity.
 
         :param r: radius (in angular units)
         :param kwargs: list of keyword arguments of lens model parameters matching the
             lens model classes
-        :param bool_list: tuple of bools that are part of the output
+        :param k: only evaluate the k-th lens model
+        :type k: None, int, or tuple of ints
         :return: mass density at radius r (in angular units, modulo epsilon_crit)
         """
-        bool_list = self._bool_list(bool_list)
+        bool_list = self._bool_list(k)
         density = 0
         for i, func in enumerate(self.func_list):
             if bool_list[i] is True:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-lenstronomy==1.12.0
+lenstronomy>=1.12.1
 numpy>=1.17.0
 scipy>=0.19.1
 jax>=0.4.12

--- a/test/test_LensModel/test_Profiles/test_gaussian.py
+++ b/test/test_LensModel/test_Profiles/test_gaussian.py
@@ -16,7 +16,7 @@ jax.config.update("jax_enable_x64", True)
 # NOTE: Since there is no scipy.integrate.quad function in JAX,
 #       the _num_integral function is implemented using trapezoidal
 #       integration, resulting in numerical differences from lenstronomy.
-#       It is accurate up to 5 decimal places.
+#       It is accurate up to 4 decimal places.
 
 class TestGaussian(object):
     def setup_method(self):
@@ -85,10 +85,9 @@ class TestGaussian(object):
         npt.assert_array_almost_equal(f_xy_ref, f_xy, decimal=6)
         npt.assert_array_almost_equal(f_yx_ref, f_yx, decimal=6)
         npt.assert_array_almost_equal(f_yy_ref, f_yy, decimal=6)
+        
         x = np.array([0])
         y = np.array([0])
-        amp = 1.3
-        sigma = 0.5
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
             x, y, amp, sigma
         )

--- a/test/test_LensModel/test_Profiles/test_gaussian.py
+++ b/test/test_LensModel/test_Profiles/test_gaussian.py
@@ -30,7 +30,7 @@ class TestGaussian(object):
         sigma = 0.5
         values_ref = self.profile_ref.function(x, y, amp, sigma)
         values = self.profile.function(x, y, amp, sigma)
-        npt.assert_array_almost_equal(values_ref, values, decimal=5)
+        npt.assert_array_almost_equal(values_ref, values, decimal=4)
 
         x = np.array([0])
         y = np.array([0])
@@ -38,13 +38,13 @@ class TestGaussian(object):
         sigma = 0.5
         values_ref = self.profile_ref.function(x, y, amp, sigma)
         values = self.profile.function(x, y, amp, sigma)
-        npt.assert_array_almost_equal(values_ref, values, decimal=5)
+        npt.assert_array_almost_equal(values_ref, values, decimal=4)
 
         x = np.array([2., 3., 4.])
         y = np.array([1., 1., 1.])
         values_ref = self.profile_ref.function(x, y, amp, sigma)
         values = self.profile.function(x, y, amp, sigma)
-        npt.assert_almost_equal(values_ref, values, decimal=5)
+        npt.assert_almost_equal(values_ref, values, decimal=4)
 
     def test_derivatives(self):
         x = np.array([1])

--- a/test/test_LensModel/test_Profiles/test_gaussian.py
+++ b/test/test_LensModel/test_Profiles/test_gaussian.py
@@ -13,6 +13,10 @@ from jaxtronomy.LensModel.Profiles.gaussian_potential import GaussianPotential
 
 jax.config.update("jax_enable_x64", True)
 
+# NOTE: Since there is no scipy.integrate.quad function in JAX,
+#       the _num_integral function is implemented using trapezoidal
+#       integration, resulting in numerical differences from lenstronomy.
+#       It is accurate up to 5 decimal places.
 
 class TestGaussian(object):
     def setup_method(self):
@@ -26,22 +30,21 @@ class TestGaussian(object):
         sigma = 0.5
         values_ref = self.profile_ref.function(x, y, amp, sigma)
         values = self.profile.function(x, y, amp, sigma)
-        npt.assert_array_almost_equal(values_ref, values, decimal=6)
+        npt.assert_array_almost_equal(values_ref, values, decimal=5)
 
-        # NOTE: This test fails with 32 bit floats
         x = np.array([0])
         y = np.array([0])
         amp = 1.3
         sigma = 0.5
         values_ref = self.profile_ref.function(x, y, amp, sigma)
         values = self.profile.function(x, y, amp, sigma)
-        npt.assert_array_almost_equal(values_ref, values, decimal=6)
+        npt.assert_array_almost_equal(values_ref, values, decimal=5)
 
         x = np.array([2., 3., 4.])
         y = np.array([1., 1., 1.])
         values_ref = self.profile_ref.function(x, y, amp, sigma)
         values = self.profile.function(x, y, amp, sigma)
-        npt.assert_almost_equal(values_ref, values, decimal=6)
+        npt.assert_almost_equal(values_ref, values, decimal=5)
 
     def test_derivatives(self):
         x = np.array([1])
@@ -197,7 +200,7 @@ class TestGaussian(object):
         result_ref = np.array(result_ref)
 
         result = self.profile._num_integral(r, c)
-        npt.assert_array_almost_equal(result_ref, result, decimal=6)
+        npt.assert_array_almost_equal(result_ref, result, decimal=4)
 
 
 class TestGaussianPotential(object):

--- a/test/test_LensModel/test_Profiles/test_gaussian.py
+++ b/test/test_LensModel/test_Profiles/test_gaussian.py
@@ -1,0 +1,297 @@
+__author__ = "sibirrer"
+
+import jax
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from lenstronomy.LensModel.Profiles.gaussian import Gaussian as Gaussian_ref
+from jaxtronomy.LensModel.Profiles.gaussian import Gaussian
+
+from lenstronomy.LensModel.Profiles.gaussian_potential import GaussianPotential as GaussianPotential_ref
+from jaxtronomy.LensModel.Profiles.gaussian_potential import GaussianPotential
+
+jax.config.update("jax_enable_x64", True)
+
+
+class TestGaussian(object):
+    def setup_method(self):
+        self.profile_ref = Gaussian_ref()
+        self.profile = Gaussian()
+
+    def test_function(self):
+        x = np.array([1])
+        y = np.array([2])
+        amp = 1.3
+        sigma = 0.5
+        values_ref = self.profile_ref.function(x, y, amp, sigma)
+        values = self.profile.function(x, y, amp, sigma)
+        npt.assert_array_almost_equal(values_ref, values, decimal=6)
+
+        # NOTE: This test fails with 32 bit floats
+        x = np.array([0])
+        y = np.array([0])
+        amp = 1.3
+        sigma = 0.5
+        values_ref = self.profile_ref.function(x, y, amp, sigma)
+        values = self.profile.function(x, y, amp, sigma)
+        npt.assert_array_almost_equal(values_ref, values, decimal=6)
+
+        x = np.array([2., 3., 4.])
+        y = np.array([1., 1., 1.])
+        values_ref = self.profile_ref.function(x, y, amp, sigma)
+        values = self.profile.function(x, y, amp, sigma)
+        npt.assert_almost_equal(values_ref, values, decimal=6)
+
+    def test_derivatives(self):
+        x = np.array([1])
+        y = np.array([2])
+        amp = 1.3
+        sigma = 0.5
+        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, amp, sigma)
+        f_x, f_y = self.profile.derivatives(x, y, amp, sigma)
+        npt.assert_array_almost_equal(f_x_ref, f_x, decimal=6)
+        npt.assert_array_almost_equal(f_y_ref, f_y, decimal=6)
+        # NOTE: This test fails with 32 bit floats
+        x = np.array([0])
+        y = np.array([0])
+        amp = 1.3
+        sigma = 0.5
+        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, amp, sigma)
+        f_x, f_y = self.profile.derivatives(x, y, amp, sigma)
+        npt.assert_array_almost_equal(f_x_ref, f_x, decimal=6)
+        npt.assert_array_almost_equal(f_y_ref, f_y, decimal=6)
+
+        x = np.array([2, 3, 4])
+        y = np.array([1, 1, 1])
+        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, amp, sigma)
+        f_x, f_y = self.profile.derivatives(x, y, amp, sigma)
+        npt.assert_array_almost_equal(f_x_ref, f_x, decimal=6)
+        npt.assert_array_almost_equal(f_y_ref, f_y, decimal=6)
+
+    def test_hessian(self):
+        x = np.array([1])
+        y = np.array([2])
+        amp = 1.3
+        sigma = 0.5
+        f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
+            x, y, amp, sigma
+        )
+        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, amp, sigma)
+        npt.assert_array_almost_equal(f_xx_ref, f_xx, decimal=6)
+        npt.assert_array_almost_equal(f_xy_ref, f_xy, decimal=6)
+        npt.assert_array_almost_equal(f_yx_ref, f_yx, decimal=6)
+        npt.assert_array_almost_equal(f_yy_ref, f_yy, decimal=6)
+        x = np.array([0])
+        y = np.array([0])
+        amp = 1.3
+        sigma = 0.5
+        f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
+            x, y, amp, sigma
+        )
+        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, amp, sigma)
+        npt.assert_array_almost_equal(f_xx_ref, f_xx, decimal=6)
+        npt.assert_array_almost_equal(f_xy_ref, f_xy, decimal=6)
+        npt.assert_array_almost_equal(f_yx_ref, f_yx, decimal=6)
+        npt.assert_array_almost_equal(f_yy_ref, f_yy, decimal=6)
+
+        x = np.array([2, 3, 4])
+        y = np.array([1, 1, 1])
+        f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
+            x, y, amp, sigma
+        )
+        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, amp, sigma)
+        npt.assert_array_almost_equal(f_xx_ref, f_xx, decimal=6)
+        npt.assert_array_almost_equal(f_xy_ref, f_xy, decimal=6)
+        npt.assert_array_almost_equal(f_yx_ref, f_yx, decimal=6)
+        npt.assert_array_almost_equal(f_yy_ref, f_yy, decimal=6)
+
+    def test_density(self):
+        r = np.array([0, 1.0, 2.7, 3.4, 5.9])
+        amp = 1.7
+        sigma = 0.4
+        density = self.profile.density(r, amp, sigma)
+        density_ref = self.profile_ref.density(r, amp, sigma)
+        npt.assert_array_almost_equal(density_ref, density, decimal=6)
+
+    def test_density2d(self):
+        x = np.array([0, 1.0, 2.7, 3.4, 5.9])
+        y = np.array([0, 1.3, 2.1, 3.2, 5.2])
+        amp = 1.7
+        sigma = 0.4
+        density = self.profile.density_2d(x, y, amp, sigma)
+        density_ref = self.profile_ref.density_2d(x, y, amp, sigma)
+        npt.assert_array_almost_equal(density_ref, density, decimal=6)
+
+    def test_mass2d(self):
+        r = np.array([0, 1.0, 2.7, 3.4, 5.9])
+        amp = 1.7
+        sigma = 0.4
+        mass2d = self.profile.mass_2d(r, amp, sigma)
+        mass2d_ref = self.profile_ref.mass_2d(r, amp, sigma)
+        npt.assert_array_almost_equal(mass2d_ref, mass2d, decimal=6)
+
+    def test_mass2d_lens(self):
+        r = np.array([0, 1.0, 2.7, 3.4, 5.9])
+        amp = 1.7
+        sigma = 0.4
+        mass2d = self.profile.mass_2d_lens(r, amp, sigma)
+        mass2d_ref = self.profile_ref.mass_2d_lens(r, amp, sigma)
+        npt.assert_array_almost_equal(mass2d_ref, mass2d, decimal=6)
+
+    def test_alpha_abs(self):
+        r = np.array([0, 1.0, 2.7, 3.4, 5.9])
+        amp = 1.7
+        sigma = 0.4
+        alpha_abs = self.profile.alpha_abs(r, amp, sigma)
+        alpha_abs_ref = self.profile_ref.alpha_abs(r, amp, sigma)
+        npt.assert_array_almost_equal(alpha_abs_ref, alpha_abs, decimal=6)
+
+    def test_d_alpha_dr(self):
+        r = np.array([0, 1.0, 2.7, 3.4, 5.9])
+        amp = 1.7
+        sigma_x = 0.4
+        sigma_y = 0.1
+        d_alpha_dr = self.profile.d_alpha_dr(r, amp, sigma_x, sigma_y)
+        d_alpha_dr_ref = self.profile_ref.d_alpha_dr(r, amp, sigma_x, sigma_y)
+        npt.assert_array_almost_equal(d_alpha_dr_ref, d_alpha_dr, decimal=6)
+
+    def test_mass3d(self):
+        r = np.array([0, 1.0, 2.7, 3.4, 5.9])
+        amp = 1.7
+        sigma = 0.4
+        mass3d = self.profile.mass_3d(r, amp, sigma)
+        mass3d_ref = self.profile_ref.mass_3d(r, amp, sigma)
+        npt.assert_array_almost_equal(mass3d_ref, mass3d, decimal=6)
+
+    def test_mass3d_lens(self):
+        r = np.array([0, 1.0, 2.7, 3.4, 5.9])
+        amp = 1.7
+        sigma = 0.4
+        mass3d = self.profile.mass_3d_lens(r, amp, sigma)
+        mass3d_ref = self.profile_ref.mass_3d_lens(r, amp, sigma)
+        npt.assert_array_almost_equal(mass3d_ref, mass3d, decimal=6)
+
+    def test_amp3d_to_2d(self):
+        amp = 1.7
+        sigma_x = 0.4
+        sigma_y = 0.8
+        amp2d = self.profile._amp3d_to_2d(amp, sigma_x, sigma_y)
+        amp2d_ref = self.profile_ref._amp3d_to_2d(amp, sigma_x, sigma_y)
+        npt.assert_array_almost_equal(amp2d_ref, amp2d, decimal=6)
+
+    def test_amp2d_to_3d(self):
+        amp = 1.7
+        sigma_x = 0.4
+        sigma_y = 0.8
+        amp3d = self.profile._amp2d_to_3d(amp, sigma_x, sigma_y)
+        amp3d_ref = self.profile_ref._amp2d_to_3d(amp, sigma_x, sigma_y)
+        npt.assert_array_almost_equal(amp3d_ref, amp3d, decimal=6)
+
+    def test_num_integral(self):
+        r = np.array([0.1, 1.0, 2.7, 3.4, 5.9])
+        c = 0.4
+        result_ref = []
+        for i in range(len(r)):
+            result_ref.append(self.profile_ref._num_integral(r[i], c))
+        result_ref = np.array(result_ref)
+
+        result = self.profile._num_integral(r, c)
+        npt.assert_array_almost_equal(result_ref, result, decimal=6)
+
+
+class TestGaussianPotential(object):
+    def setup_method(self):
+        self.profile_ref = GaussianPotential_ref()
+        self.profile = GaussianPotential()
+
+    def test_function(self):
+        x = np.array([1])
+        y = np.array([2])
+        amp = 1.3
+        sigma_x, sigma_y = 0.5, 0.7
+        values_ref = self.profile_ref.function(x, y, amp, sigma_x, sigma_y)
+        values = self.profile.function(x, y, amp, sigma_x, sigma_y)
+        npt.assert_array_almost_equal(values_ref, values, decimal=8)
+        
+        # NOTE: This test fails with 32 bit floats
+        x = np.array([0])
+        y = np.array([0])
+        amp = 1.3
+        sigma_x, sigma_y = 0.5, 0.7
+        values_ref = self.profile_ref.function(x, y, amp, sigma_x, sigma_y)
+        values = self.profile.function(x, y, amp, sigma_x, sigma_y)
+        npt.assert_array_almost_equal(values_ref, values, decimal=8)
+
+        x = np.array([2., 3., 4.])
+        y = np.array([1., 1., 1.])
+        values_ref = self.profile_ref.function(x, y, amp, sigma_x, sigma_y)
+        values = self.profile.function(x, y, amp, sigma_x, sigma_y)
+        npt.assert_almost_equal(values_ref, values, decimal=8)
+
+    def test_derivatives(self):
+        x = np.array([1])
+        y = np.array([2])
+        amp = 1.3
+        sigma_x, sigma_y = 0.5, 0.7
+        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, amp, sigma_x, sigma_y)
+        f_x, f_y = self.profile.derivatives(x, y, amp, sigma_x, sigma_y)
+        npt.assert_array_almost_equal(f_x_ref, f_x, decimal=8)
+        npt.assert_array_almost_equal(f_y_ref, f_y, decimal=8)
+        # NOTE: This test fails with 32 bit floats
+        x = np.array([0])
+        y = np.array([0])
+        amp = 1.3
+        sigma_x, sigma_y = 0.5, 0.7
+        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, amp, sigma_x, sigma_y)
+        f_x, f_y = self.profile.derivatives(x, y, amp, sigma_x, sigma_y)
+        npt.assert_array_almost_equal(f_x_ref, f_x, decimal=8)
+        npt.assert_array_almost_equal(f_y_ref, f_y, decimal=8)
+
+        x = np.array([2, 3, 4])
+        y = np.array([1, 1, 1])
+        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, amp, sigma_x, sigma_y)
+        f_x, f_y = self.profile.derivatives(x, y, amp, sigma_x, sigma_y)
+        npt.assert_array_almost_equal(f_x_ref, f_x, decimal=8)
+        npt.assert_array_almost_equal(f_y_ref, f_y, decimal=8)
+
+    def test_hessian(self):
+        x = np.array([1])
+        y = np.array([2])
+        amp = 1.3
+        sigma_x, sigma_y = 0.5, 0.7
+        f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
+            x, y, amp, sigma_x, sigma_y
+        )
+        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, amp, sigma_x, sigma_y)
+        npt.assert_array_almost_equal(f_xx_ref, f_xx, decimal=8)
+        npt.assert_array_almost_equal(f_xy_ref, f_xy, decimal=8)
+        npt.assert_array_almost_equal(f_yx_ref, f_yx, decimal=8)
+        npt.assert_array_almost_equal(f_yy_ref, f_yy, decimal=8)
+        x = np.array([0])
+        y = np.array([0])
+        amp = 1.3
+        sigma_x, sigma_y = 0.5, 0.7
+        f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
+            x, y, amp, sigma_x, sigma_y
+        )
+        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, amp, sigma_x, sigma_y)
+        npt.assert_array_almost_equal(f_xx_ref, f_xx, decimal=8)
+        npt.assert_array_almost_equal(f_xy_ref, f_xy, decimal=8)
+        npt.assert_array_almost_equal(f_yx_ref, f_yx, decimal=8)
+        npt.assert_array_almost_equal(f_yy_ref, f_yy, decimal=8)
+
+        x = np.array([2, 3, 4])
+        y = np.array([1, 1, 1])
+        f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
+            x, y, amp, sigma_x, sigma_y
+        )
+        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, amp, sigma_x, sigma_y)
+        npt.assert_array_almost_equal(f_xx_ref, f_xx, decimal=8)
+        npt.assert_array_almost_equal(f_xy_ref, f_xy, decimal=8)
+        npt.assert_array_almost_equal(f_yx_ref, f_yx, decimal=8)
+        npt.assert_array_almost_equal(f_yy_ref, f_yy, decimal=8)
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/test/test_lenstronomy_import.py
+++ b/test/test_lenstronomy_import.py
@@ -2,4 +2,4 @@ def test_lenstronomy_version():
     """Tests the import of lenstronomy."""
     import lenstronomy
 
-    assert lenstronomy.__version__ == "1.12.0"
+    assert lenstronomy.__version__ == "1.12.1"


### PR DESCRIPTION
This PR accomplishes three things:

- JIT-decorated several functions in SinglePlane and LightModelBase so that it is more explicit which variables are static variables. Additionally, changed some np arrays into jnp arrays for compatibility with JAX auto-differentiation. Finally, since lists cannot be marked as static variables in JAX, but tuples can, the docstrings for the functions involving `k` and `bool_list` have been changed to reflect the fact that these arguments should now be tuples.

- Since JAX jit and numba jit are incompatible, ProfileListBase no longer imports lens profiles from lenstronomy, since it would end up crashing most of the time anyways when certain numba-jitted util functions are called from lenstronomy. Now, only jaxified profiles are imported. (This was discussed a while ago, but I did not get around to changing it until now)

- Since Natalie wrote a lot of the SinglePlane and LensModel test functions using the Gaussian profiles, I had to change these tests since the Gaussian profiles were not yet implemented in JAXtronomy. Midway through changing the tests, I realized that it would be easier and faster to simply implement the Gaussian profiles into JAXtronomy, so that's what I did.
