### PR TITLE
Fix issues with autodifferentiation

### DIFF
--- a/jaxtronomy/LensModel/Profiles/epl.py
+++ b/jaxtronomy/LensModel/Profiles/epl.py
@@ -326,23 +326,8 @@ class EPLMajorAxis(LensProfileBase):
         R = jnp.maximum(R, 0.000000001)
         f = (1.0 - q) / (1.0 + q)
 
-        # nmax is the number of iterations required to calculate hyp2f1
-        # In order to maintain high accuracy, the number of iterations
-        # depends on how close -f exp{2 i phi} is to the unit circle
-        nmax = jnp.where(
-            f > 0.97,
-            1000,
-            jnp.where(
-                f > 0.95,
-                300,
-                jnp.where(
-                    f > 0.9, 175, jnp.where(f > 0.71, 100, jnp.where(f > 0.3, 50, 20))
-                ),
-            ),
-        )
-
         # angular dependency with extra factor of R, eq. (23)
-        R_omega = Z * hyp2f1(1, t / 2, 2 - t / 2, -f * Z / jnp.conj(Z), nmax)
+        R_omega = Z * hyp2f1(1, t / 2, 2 - t / 2, -f * Z / jnp.conj(Z))
 
         # deflection, eq. (22)
         alpha = 2 / (1 + q) * (b / R) ** t * R_omega

--- a/jaxtronomy/Util/hyp2f1_util.py
+++ b/jaxtronomy/Util/hyp2f1_util.py
@@ -9,6 +9,7 @@ from jax.scipy.special import gamma
 #       whenever c - b - a is not an integer. Other implementations are required
 #       for these situations.
 
+
 @jit
 def hyp2f1_series(a, b, c, z):
     """This computation uses the well known relation between successive terms in the
@@ -196,9 +197,7 @@ def hyp2f1(a, b, c, z):
 
     # Check each z value and evaluate corresponding hyp2f1
     def body_fun(i, val):
-        ith_result = lax.switch(
-            case.at[i].get(), hyp2f1_func, a, b, c, z.at[i].get()
-        )
+        ith_result = lax.switch(case.at[i].get(), hyp2f1_func, a, b, c, z.at[i].get())
         val = val.at[i].set(ith_result)
         return val
 

--- a/jaxtronomy/Util/hyp2f1_util.py
+++ b/jaxtronomy/Util/hyp2f1_util.py
@@ -43,7 +43,7 @@ def hyp2f1_series(a, b, c, z):
 
         return [partial_sum, A_i]
 
-    result = lax.fori_loop(1, 200, body_fun, [partial_sum, A_i])
+    result = lax.fori_loop(1, 150, body_fun, [partial_sum, A_i])
     return result[0]
 
 

--- a/jaxtronomy/Util/param_util.py
+++ b/jaxtronomy/Util/param_util.py
@@ -103,7 +103,16 @@ def transform_e1e2_product_average(x, y, e1, e2, center_x, center_y):
     coordinate system such that R = sqrt(R_major * R_minor) :param x: x-coordinate
     :param y: y-coordinate :param e1: eccentricity :param e2: eccentricity :param
     center_x: center of distortion :param center_y: center of distortion :return:
-    distorted coordinates x', y'."""
+    distorted coordinates x', y'
+    
+    :param x: x-coordinate
+    :param y: y-coordinate
+    :param e1: eccentricity
+    :param e2: eccentricity
+    :param center_x: center of distortion
+    :param center_y: center of distortion
+    :return: distorted coordinates x', y'
+    """
     x_shift = x - center_x
     y_shift = y - center_y
 

--- a/jaxtronomy/Util/param_util.py
+++ b/jaxtronomy/Util/param_util.py
@@ -101,7 +101,6 @@ def ellipticity2phi_q(e1, e2):
 def transform_e1e2_product_average(x, y, e1, e2, center_x, center_y):
     """Maps the coordinates x, y with eccentricities e1 e2 into a new elliptical
     coordinate system such that R = sqrt(R_major * R_minor)
-
     :param x: x-coordinate
     :param y: y-coordinate
     :param e1: eccentricity
@@ -110,16 +109,13 @@ def transform_e1e2_product_average(x, y, e1, e2, center_x, center_y):
     :param center_y: center of distortion
     :return: distorted coordinates x', y'
     """
-    phi_g, q = ellipticity2phi_q(e1, e2)
     x_shift = x - center_x
     y_shift = y - center_y
 
-    cos_phi = jnp.cos(phi_g)
-    sin_phi = jnp.sin(phi_g)
-
-    xt1 = cos_phi * x_shift + sin_phi * y_shift
-    xt2 = -sin_phi * x_shift + cos_phi * y_shift
-    return xt1 * jnp.sqrt(q), xt2 / jnp.sqrt(q)
+    norm = jnp.maximum(jnp.sqrt(jnp.abs(1 - e1 ** 2 - e2 ** 2)), 0.000001)
+    x_ = ((1 - e1) * x_shift - e2 * y_shift) / norm
+    y_ = (-e2 * x_shift + (1 + e1) * y_shift) / norm
+    return x_, y_
 
 
 @jit

--- a/jaxtronomy/Util/param_util.py
+++ b/jaxtronomy/Util/param_util.py
@@ -104,7 +104,7 @@ def transform_e1e2_product_average(x, y, e1, e2, center_x, center_y):
     :param y: y-coordinate :param e1: eccentricity :param e2: eccentricity :param
     center_x: center of distortion :param center_y: center of distortion :return:
     distorted coordinates x', y'
-    
+
     :param x: x-coordinate
     :param y: y-coordinate
     :param e1: eccentricity

--- a/jaxtronomy/Util/param_util.py
+++ b/jaxtronomy/Util/param_util.py
@@ -100,19 +100,14 @@ def ellipticity2phi_q(e1, e2):
 @jit
 def transform_e1e2_product_average(x, y, e1, e2, center_x, center_y):
     """Maps the coordinates x, y with eccentricities e1 e2 into a new elliptical
-    coordinate system such that R = sqrt(R_major * R_minor)
-    :param x: x-coordinate
-    :param y: y-coordinate
-    :param e1: eccentricity
-    :param e2: eccentricity
-    :param center_x: center of distortion
-    :param center_y: center of distortion
-    :return: distorted coordinates x', y'
-    """
+    coordinate system such that R = sqrt(R_major * R_minor) :param x: x-coordinate
+    :param y: y-coordinate :param e1: eccentricity :param e2: eccentricity :param
+    center_x: center of distortion :param center_y: center of distortion :return:
+    distorted coordinates x', y'."""
     x_shift = x - center_x
     y_shift = y - center_y
 
-    norm = jnp.maximum(jnp.sqrt(jnp.abs(1 - e1 ** 2 - e2 ** 2)), 0.000001)
+    norm = jnp.maximum(jnp.sqrt(jnp.abs(1 - e1**2 - e2**2)), 0.000001)
     x_ = ((1 - e1) * x_shift - e2 * y_shift) / norm
     y_ = (-e2 * x_shift + (1 + e1) * y_shift) / norm
     return x_, y_

--- a/test/test_Util/test_hyp2f1_util.py
+++ b/test/test_Util/test_hyp2f1_util.py
@@ -25,22 +25,21 @@ def test_hyp2f1_series():
         result, result_ref
     ), "hyp2f1_series result does not match scipy result"
 
-    # Points very close to the boundary of the circle require
-    # more iterations for a more accurate result
+    # Points very close to the boundary of the circle are less accurate
     # Supports list inputs
     z = [0.99 + 0.001j]
-    result = hyp2f1_series(a, b, c, z, nmax=250)
+    result = hyp2f1_series(a, b, c, z)
     result_ref = hyp2f1_ref(a, b, c, z)
     assert jnp.allclose(
-        result, result_ref
+        result, result_ref, atol=1e-4
     ), "hyp2f1_series result does not match scipy result"
 
     # Also supports scalar inputs
     z = -0.99 + 0.001j
-    result = hyp2f1_series(a, b, c, z, nmax=250)
+    result = hyp2f1_series(a, b, c, z)
     result_ref = hyp2f1_ref(a, b, c, z)
     assert jnp.allclose(
-        result, result_ref
+        result, result_ref, atol=1e-4
     ), "hyp2f1_series result does not match scipy result"
     assert result.ndim == 0
 
@@ -57,20 +56,19 @@ def test_hyp2f1_near_one():
         result, result_ref
     ), "hyp2f1_near_one result does not match scipy result"
 
-    # Points very close to the boundary of the circle require
-    # more iterations for a more accurate result
+    # Points very close to the boundary of the circle are less accurate
     # Also supports list inputs
     z = [0.05 + 0.001j]
-    result = hyp2f1_near_one(a, b, c, z, nmax=300)
+    result = hyp2f1_near_one(a, b, c, z)
     result_ref = hyp2f1_ref(a, b, c, z)
     assert jnp.allclose(
-        result, result_ref
+        result, result_ref, atol=1e-2
     ), "hyp2f1_near_one result does not match scipy result"
 
-    # Tests to see if the value above the branch cut is taken
+    # Tests to see if the value of z above the branch cut is taken
     # Also supports scalar inputs
     z = 1.1 + 0.0j
-    result = hyp2f1_near_one(a, b, c, z, nmax=300)
+    result = hyp2f1_near_one(a, b, c, z)
     result_ref = hyp2f1_ref(a, b, c, z)
     assert jnp.allclose(
         result, result_ref
@@ -89,14 +87,13 @@ def test_hyp2f1_continuation():
         result, result_ref
     ), "hyp2f1_continuation result does not match scipy result"
 
-    # Points very close to the boundary of the circle require
-    # more iterations for a more accurate result
+    # Points very close to the boundary of the circle are less accurate
     # Also supports list inputs
-    z = [1.05 + 0.0001 * 1j]
-    result = hyp2f1_continuation(a, b, c, z, nmax=250)
+    z = [1.03 + 0.001j]
+    result = hyp2f1_continuation(a, b, c, z)
     result_ref = hyp2f1_ref(a, b, c, z)
     assert jnp.allclose(
-        result, result_ref
+        result, result_ref, atol=1e-4
     ), "hyp2f1_continuation result does not match scipy result"
 
     # Tests to see if the value above the branch cut is taken

--- a/test/test_Util/test_param_util.py
+++ b/test/test_Util/test_param_util.py
@@ -82,16 +82,27 @@ def test_ellipticity2phi_q():
     npt.assert_array_almost_equal(q, q_ref, decimal=8)
 
 
-def test_transform_e1e2():
+def test_transform_e1e2_product_average():
     e1 = 0.01
-    e2 = 0.0
+    e2 = -0.03
     x = 0.0
     y = 1.0
     x_, y_ = param_util.transform_e1e2_product_average(
-        x, y, e1, e2, center_x=0, center_y=0
+        x, y, e1, e2, center_x=-0.3, center_y=0.4
     )
     x_ref, y_ref = param_util_ref.transform_e1e2_product_average(
-        x, y, e1, e2, center_x=0, center_y=0
+        x, y, e1, e2, center_x=-0.3, center_y=0.4
+    )
+    npt.assert_almost_equal(x_, x_ref, decimal=8)
+    npt.assert_almost_equal(y_, y_ref, decimal=8)
+
+    e1 = 0.0
+    e2 = 0.0
+    x_, y_ = param_util.transform_e1e2_product_average(
+        x, y, e1, e2, center_x=-0.3, center_y=0.4
+    )
+    x_ref, y_ref = param_util_ref.transform_e1e2_product_average(
+        x, y, e1, e2, center_x=-0.3, center_y=0.4
     )
     npt.assert_almost_equal(x_, x_ref, decimal=8)
     npt.assert_almost_equal(y_, y_ref, decimal=8)


### PR DESCRIPTION
This PR accomplishes two things:

1. Changes the transform_e1e2_product_average function in param_util so that it is differentiable at e1=e2=0 (this was done a while ago for lenstronomy but I only made a PR for jaxtronomy now).
2. The jaxopt optimizer uses reverse-mode autodifferentiation to calculate gradients. This is not possible for computations that involve loops where the starting or stopping conditions are dynamic. Thus, we have to sacrifice some flexibility and always do the same number of iterations so that reverse-mode autodifferentiation can be used. The hyp2f1 calculations for the EPL profile have to be modified as a result.