### PR TITLE
Implement Gaussian convolution and Numerics/NumericsSubFrame classes

### DIFF
--- a/jaxtronomy/ImSim/Numerics/convolution.py
+++ b/jaxtronomy/ImSim/Numerics/convolution.py
@@ -201,14 +201,13 @@ class GaussianConvolution(object):
 
         # This num_pix definition is equivalent to that of the scipy ndimage.gaussian_filter
         # num_pix = 2r + 1 where r = round(truncation * sigma) is the radius of the gaussian kernel
-        kernel_radius = round(self._sigma_scaled * self._truncation)
-        if kernel_radius < 1:
-            kernel_radius = 1
+        kernel_radius = max(round(self._sigma_scaled * self._truncation), 1)
         num_pix = 2 * kernel_radius + 1
         kernel = self.pixel_kernel(num_pix)
 
         # Before convolution, images will be padded
-        self._pad_width = kernel_radius
+        # Even though kernel_radius is already an int, we need to apply int because of some JAX nonsense
+        self._pad_width = int(kernel_radius)
 
         self.PixelKernelConv = PixelKernelConvolution(
             kernel, convolution_type="fft_static"

--- a/jaxtronomy/ImSim/Numerics/convolution.py
+++ b/jaxtronomy/ImSim/Numerics/convolution.py
@@ -200,20 +200,15 @@ class GaussianConvolution(object):
             self._sigma_scaled *= supersampling_factor
 
         # This num_pix definition is equivalent to that of the scipy ndimage.gaussian_filter
-        # num_pix = 2 * r + 1 where r = truncation * sigma is the radius of the gaussian kernel
-        num_pix = int(2 * truncation * self._sigma_scaled + 1)
-
-        # Ensure num_pix is odd and >= 3
-        if num_pix < 3:
-            num_pix = 3
-        if num_pix % 2 == 0:
-            num_pix += 1
-
+        # num_pix = 2r + 1 where r = round(truncation * sigma) is the radius of the gaussian kernel
+        kernel_radius = round(self._sigma_scaled * self._truncation)
+        if kernel_radius < 1:
+            kernel_radius = 1
+        num_pix = 2 * kernel_radius + 1
         kernel = self.pixel_kernel(num_pix)
 
-        # Before convolution, images will be padded. The width of the pad is equal to the
-        # radius of the gaussian kernel
-        self._pad_width = int(self._sigma_scaled * self._truncation)
+        # Before convolution, images will be padded
+        self._pad_width = kernel_radius
 
         self.PixelKernelConv = PixelKernelConvolution(
             kernel, convolution_type="fft_static"

--- a/jaxtronomy/ImSim/Numerics/convolution.py
+++ b/jaxtronomy/ImSim/Numerics/convolution.py
@@ -1,4 +1,3 @@
-import jax.lax
 from jax import jit, numpy as jnp, tree_util
 from jax.scipy import signal
 import numpy as np

--- a/jaxtronomy/ImSim/Numerics/numerics.py
+++ b/jaxtronomy/ImSim/Numerics/numerics.py
@@ -2,7 +2,7 @@ from jaxtronomy.ImSim.Numerics.grid import RegularGrid
 from jaxtronomy.ImSim.Numerics.convolution import (
     SubgridKernelConvolution,
     PixelKernelConvolution,
-    MultiGaussianConvolution,
+    GaussianConvolution,
 )
 from jaxtronomy.Util import util
 from lenstronomy.ImSim.Numerics.point_source_rendering import PointSourceRendering
@@ -123,11 +123,8 @@ class Numerics(PointSourceRendering):
             pixel_scale = pixel_grid.pixel_width
             fwhm = psf.fwhm  # FWHM  in units of angle
             sigma = util.fwhm2sigma(fwhm)
-            sigma_list = [sigma]
-            fraction_list = [1]
-            self._conv = MultiGaussianConvolution(
-                sigma_list,
-                fraction_list,
+            self._conv = GaussianConvolution(
+                sigma,
                 pixel_scale,
                 supersampling_factor,
                 supersampling_convolution,

--- a/jaxtronomy/ImSim/Numerics/numerics.py
+++ b/jaxtronomy/ImSim/Numerics/numerics.py
@@ -1,0 +1,223 @@
+from jaxtronomy.ImSim.Numerics.grid import RegularGrid
+from jaxtronomy.ImSim.Numerics.convolution import (
+    SubgridKernelConvolution,
+    PixelKernelConvolution,
+    MultiGaussianConvolution
+)
+from jaxtronomy.Util import util
+from lenstronomy.ImSim.Numerics.point_source_rendering import PointSourceRendering
+from lenstronomy.Util import kernel_util
+from jax import jit
+import numpy as np
+from functools import partial
+
+__all__ = ["Numerics"]
+
+
+class Numerics(PointSourceRendering):
+    """This classes manages the numerical options and computations of an image.
+
+    The class has two main functions, re_size_convolve() and coordinates_evaluate()
+    """
+
+    def __init__(
+        self,
+        pixel_grid,
+        psf,
+        supersampling_factor=1,
+        compute_mode="regular",
+        supersampling_convolution=False,
+        supersampling_kernel_size=5,
+        flux_evaluate_indexes=None,
+        supersampled_indexes=None,
+        compute_indexes=None,
+        point_source_supersampling_factor=1,
+        convolution_kernel_size=None,
+        convolution_type="fft",
+        truncation=4,
+    ):
+        """
+
+        :param pixel_grid: PixelGrid() class instance
+        :param psf: PSF() class instance
+        :param compute_mode: options are: 'regular'. 'adaptive' is not supported in JAXtronomy
+        :param supersampling_factor: int, factor of higher resolution sub-pixel sampling of surface brightness
+        :param supersampling_convolution: bool, if True, performs (part of) the convolution on the super-sampled
+         grid/pixels
+        :param supersampling_kernel_size: int (odd number), size (in regular pixel units) of the super-sampled
+         convolution
+        :param flux_evaluate_indexes: boolean 2d array of size of image before supersampling (or None, then initiated as gird of True's).
+         Pixels indicated with True will be used to perform the surface brightness computation (and possible lensing
+         ray-shooting). Pixels marked as False will be assigned a flux value of zero (or ignored in the adaptive
+         convolution)
+        :param supersampled_indexes: 2d boolean array (only used in mode='adaptive') of pixels to be supersampled (in
+         surface brightness and if supersampling_convolution=True also in convolution). All other pixels not set to =True
+         will not be super-sampled.
+        :param compute_indexes: 2d boolean array (only used in compute_mode='adaptive'), marks pixel that the response after
+         convolution is computed (all others =0). This can be set to likelihood_mask in the Likelihood module for
+         consistency.
+        :param point_source_supersampling_factor: super-sampling resolution of the point source placing
+        :param convolution_kernel_size: int, odd number, size of convolution kernel before supersampling. If None, takes size of point_source_kernel
+            Only relevant for psf type PIXEL
+        :param convolution_type: string, 'fft', 'grid', 'fft_static' mode of 2d convolution
+        """
+        if compute_mode != "regular":
+            if compute_mode == "adaptive":
+                raise ValueError("AdaptiveConvolution not implemented in Jaxtronomy. Please use lenstronomy instead.")
+            else:
+                raise ValueError(
+                'compute_mode specified as %s not valid. Options are "regular" and "adaptive" (adaptive only supported in lenstronomy)'
+            )
+        # if no super sampling, turn the supersampling convolution off
+        self._psf_type = psf.psf_type
+        if not isinstance(supersampling_factor, int):
+            raise TypeError(
+                "supersampling_factor needs to be an integer! Current type is %s"
+                % type(supersampling_factor)
+            )
+        if supersampling_factor == 1:
+            supersampling_convolution = False
+        self._pixel_width = pixel_grid.pixel_width
+        nx, ny = pixel_grid.num_pixel_axes
+        transform_pix2angle = pixel_grid.transform_pix2angle
+        ra_at_xy_0, dec_at_xy_0 = pixel_grid.radec_at_xy_0
+        # This is only used for adaptive convolution which is not implemented in JAXtronomy 
+        #if supersampled_indexes is None:
+        #    supersampled_indexes = np.zeros((nx, ny), dtype=bool)
+        self._grid = RegularGrid(
+            nx,
+            ny,
+            transform_pix2angle,
+            ra_at_xy_0,
+            dec_at_xy_0,
+            supersampling_factor,
+            flux_evaluate_indexes,
+        )
+        if self._psf_type == "PIXEL":
+            if supersampling_convolution is True:
+                kernel_super = psf.kernel_point_source_supersampled(
+                    supersampling_factor
+                )
+                if convolution_kernel_size is not None:
+                    kernel_super = self._supersampling_cut_kernel(
+                        kernel_super, convolution_kernel_size, supersampling_factor
+                    )
+                self._conv = SubgridKernelConvolution(
+                    kernel_super,
+                    supersampling_factor,
+                    supersampling_kernel_size=supersampling_kernel_size,
+                    convolution_type=convolution_type,
+                )
+            else:
+                kernel = psf.kernel_point_source
+                kernel = self._supersampling_cut_kernel(
+                    kernel, convolution_kernel_size, supersampling_factor=1
+                )
+                self._conv = PixelKernelConvolution(
+                    kernel, convolution_type=convolution_type
+                )
+
+        elif self._psf_type == "GAUSSIAN":
+            pixel_scale = pixel_grid.pixel_width
+            fwhm = psf.fwhm  # FWHM  in units of angle
+            sigma = util.fwhm2sigma(fwhm)
+            sigma_list = [sigma]
+            fraction_list = [1]
+            self._conv = MultiGaussianConvolution(
+                sigma_list,
+                fraction_list,
+                pixel_scale,
+                supersampling_factor,
+                supersampling_convolution,
+                truncation=truncation,
+            )
+        elif self._psf_type == "NONE":
+            self._conv = None
+        else:
+            raise ValueError(
+                "psf_type %s not valid! Chose either NONE, GAUSSIAN or PIXEL."
+                % self._psf_type
+            )
+        super(Numerics, self).__init__(
+            pixel_grid=pixel_grid,
+            supersampling_factor=point_source_supersampling_factor,
+            psf=psf,
+        )
+        if supersampling_convolution is True:
+            self._high_res_return = True
+        else:
+            self._high_res_return = False
+
+    @partial(jit, static_argnums=(0, 2))
+    def re_size_convolve(self, flux_array, unconvolved=False):
+        """
+
+        :param flux_array: 1d array, flux values corresponding to coordinates_evaluate
+            (i.e. flux_array shape must match self._grid with supersample factor and flux_evaluate_indexes)
+        :param unconvolved: boolean, if True, does not apply a convolution
+        :return: convolved image on regular pixel grid, 2d array
+        """
+        # add supersampled region to lower resolution on
+        image_low_res, image_high_res_partial = self._grid.flux_array2image_low_high(
+            flux_array, high_res_return=self._high_res_return
+        )
+        if unconvolved is True or self._psf_type == "NONE":
+            image_conv = image_low_res
+        else:
+            # convolve low res grid and high res grid
+            image_conv = self._conv.re_size_convolve(
+                image_low_res, image_high_res_partial
+            )
+        return image_conv * self._pixel_width**2
+
+    @property
+    def grid_supersampling_factor(self):
+        """
+
+        :return: supersampling factor set for higher resolution sub-pixel sampling of surface brightness
+        """
+        return self._grid.supersampling_factor
+
+    @property
+    def coordinates_evaluate(self):
+        """
+
+        :return: 1d array of all coordinates being evaluated to perform the image computation
+        """
+        return self._grid.coordinates_evaluate
+
+    @staticmethod
+    def _supersampling_cut_kernel(
+        kernel_super, convolution_kernel_size, supersampling_factor
+    ):
+        """
+
+        :param kernel_super: super-sampled kernel
+        :param convolution_kernel_size: size of convolution kernel in units of regular pixels (odd)
+        :param supersampling_factor: super-sampling factor of convolution kernel
+        :return: cut out kernel in super-sampling size
+        """
+        if convolution_kernel_size is not None:
+            size = convolution_kernel_size * supersampling_factor
+            if size % 2 == 0:
+                size += 1
+            kernel_cut = kernel_util.cut_psf(kernel_super, size, normalisation=False)
+            return kernel_cut
+        else:
+            return kernel_super
+
+    @property
+    def convolution_class(self):
+        """
+
+        :return: convolution class (can be SubgridKernelConvolution, PixelKernelConvolution)
+        """
+        return self._conv
+
+    @property
+    def grid_class(self):
+        """
+
+        :return: grid class (can be RegularGrid)
+        """
+        return self._grid

--- a/jaxtronomy/ImSim/Numerics/numerics_subframe.py
+++ b/jaxtronomy/ImSim/Numerics/numerics_subframe.py
@@ -1,0 +1,196 @@
+from functools import partial
+import numpy as np
+from jax import jit, numpy as jnp
+
+from jaxtronomy.ImSim.Numerics.numerics import Numerics
+from lenstronomy.ImSim.Numerics.point_source_rendering import PointSourceRendering
+from lenstronomy.Data.pixel_grid import PixelGrid
+
+# NOTE: This file is copy-pasted from lenstronomy, with import statements changed.
+#       No other changes have been made
+
+__all__ = ["NumericsSubFrame"]
+
+
+class NumericsSubFrame(PointSourceRendering):
+    """This class finds the optimal rectangular sub-frame of a data to be modelled that
+    contains all the flux_evaluate_indexes and performs the numerical calculations only
+    in this frame and then patches zeros around it to match the full data size."""
+
+    def __init__(
+        self,
+        pixel_grid,
+        psf,
+        supersampling_factor=1,
+        compute_mode="regular",
+        supersampling_convolution=False,
+        supersampling_kernel_size=5,
+        flux_evaluate_indexes=None,
+        supersampled_indexes=None,
+        compute_indexes=None,
+        point_source_supersampling_factor=1,
+        convolution_kernel_size=None,
+        convolution_type="fft",
+        truncation=4,
+    ):
+        """
+
+        :param pixel_grid: PixelGrid() class instance
+        :param psf: PSF() class instance
+        :param compute_mode: options are: 'regular', 'adaptive'
+        :param supersampling_factor: int, factor of higher resolution sub-pixel sampling of surface brightness
+        :param supersampling_convolution: bool, if True, performs (part of) the convolution on the super-sampled
+        grid/pixels
+        :param supersampling_kernel_size: int (odd number), size (in regular pixel units) of the super-sampled
+        convolution
+        :param flux_evaluate_indexes: boolean 2d array of size of image before supersampling (or None, then initiated as grid of True's).
+        Pixels indicated with True will be used to perform the surface brightness computation (and possible lensing
+        ray-shooting). Pixels marked as False will be assigned a flux value of zero (or ignored in the adaptive
+        convolution)
+        :param supersampled_indexes: 2d boolean array (only used in mode='adaptive') of pixels to be supersampled (in
+        surface brightness and if supersampling_convolution=True also in convolution)
+        :param compute_indexes: 2d boolean array (only used in mode='adaptive'), marks pixel that the resonse after
+        convolution is computed (all others =0). This can be set to likelihood_mask in the Likelihood module for
+        consistency.
+        :param point_source_supersampling_factor: super-sampling resolution of the point source placing
+        :param convolution_kernel_size: int, odd number, size of convolution kernel. If None, takes size of
+        point_source_kernel
+
+        """
+        # if no super sampling, turn the supersampling convolution off
+
+        self._nx, self._ny = pixel_grid.num_pixel_axes
+        self._init_sub_frame(flux_evaluate_indexes)
+        pixel_grid_sub = self._sub_pixel_grid(pixel_grid)
+        self._numerics_subframe = Numerics(
+            pixel_grid=pixel_grid_sub,
+            psf=psf,
+            supersampling_factor=supersampling_factor,
+            compute_mode=compute_mode,
+            supersampling_convolution=supersampling_convolution,
+            supersampling_kernel_size=supersampling_kernel_size,
+            flux_evaluate_indexes=self._cut_frame(flux_evaluate_indexes),
+            supersampled_indexes=self._cut_frame(supersampled_indexes),
+            compute_indexes=self._cut_frame(compute_indexes),
+            point_source_supersampling_factor=point_source_supersampling_factor,
+            convolution_kernel_size=convolution_kernel_size,
+            convolution_type=convolution_type,
+            truncation=truncation,
+        )
+        super(NumericsSubFrame, self).__init__(
+            pixel_grid=pixel_grid,
+            supersampling_factor=point_source_supersampling_factor,
+            psf=psf,
+        )
+
+    @partial(jit, static_argnums=(0,2))
+    def re_size_convolve(self, flux_array, unconvolved=False):
+        """
+
+        :param flux_array: 1d array, flux values corresponding to coordinates_evaluate
+        :return: convolved image on regular pixel grid, 2d array
+        """
+        # add supersampled region to lower resolution on
+        image_sub_frame = self._numerics_subframe.re_size_convolve(
+            flux_array, unconvolved=unconvolved
+        )
+        return self._complete_frame(image_sub_frame)
+
+    @property
+    def grid_supersampling_factor(self):
+        """
+
+        :return: supersampling factor set for higher resolution sub-pixel sampling of surface brightness
+        """
+        return self._numerics_subframe.grid_supersampling_factor
+
+    @property
+    def coordinates_evaluate(self):
+        """
+
+        :return: 1d array of all coordinates being evaluated to perform the image computation
+        """
+        return self._numerics_subframe.coordinates_evaluate
+
+    @property
+    def convolution_class(self):
+        """
+
+        :return: convolution class (can be SubgridKernelConvolution, PixelKernelConvolution, MultiGaussianConvolution, ...)
+        """
+        return self._numerics_subframe.convolution_class
+
+    @property
+    def grid_class(self):
+        """
+
+        :return: grid class (can be RegularGrid, AdaptiveGrid)
+        """
+        return self._numerics_subframe.grid_class
+
+    @partial(jit, static_argnums=0)
+    def _complete_frame(self, image_sub_frame):
+        """
+        :param image_sub_frame: 2d numpy array of size of the sub-frame
+        :return: 2d numpy array of size of image with added zeros on their edges
+        """
+        if self._subframe_calc is True:
+            image = jnp.zeros((self._nx, self._ny))
+            image = image.at[
+                self._x_min_sub : self._x_max_sub + 1,
+                self._y_min_sub : self._y_max_sub + 1,
+            ].set(image_sub_frame)
+        else:
+            image = image_sub_frame
+        return image
+
+    def _init_sub_frame(self, flux_evaluate_indexes):
+        """Smaller frame that encloses all the idex_mask :return:"""
+        if flux_evaluate_indexes is None:
+            self._subframe_calc = False
+            self._x_min_sub, self._y_min_sub = 0, 0
+            self._x_max_sub, self._y_max_sub = self._nx, self._ny
+        else:
+            self._subframe_calc = True
+            self._x_min_sub = np.min(np.where(flux_evaluate_indexes)[0])
+            self._x_max_sub = np.max(np.where(flux_evaluate_indexes)[0])
+            self._y_min_sub = np.min(np.where(flux_evaluate_indexes)[1])
+            self._y_max_sub = np.max(np.where(flux_evaluate_indexes)[1])
+
+    def _cut_frame(self, image):
+        """
+
+        :param image: 2d array of full image size
+        :return: 2d array of the sub-frame
+        """
+        if self._subframe_calc is True and image is not None:
+            return image[
+                self._x_min_sub : self._x_max_sub + 1,
+                self._y_min_sub : self._y_max_sub + 1,
+            ]
+        else:
+            return image
+
+    def _sub_pixel_grid(self, pixel_grid):
+        """Creates a PixelGrid instance covering the sub-frame area only.
+
+        :param pixel_grid: PixelGrid instance of the full image
+        :return: PixelGrid instance
+        """
+        if self._subframe_calc is True:
+            transform_pix2angle = pixel_grid.transform_pix2angle
+            nx_sub = self._x_max_sub - self._x_min_sub + 1
+            ny_sub = self._y_max_sub - self._y_min_sub + 1
+            ra_at_xy_0_sub, dec_at_xy_0_sub = pixel_grid.map_pix2coord(
+                self._x_min_sub, self._y_min_sub
+            )
+            pixel_grid_sub = PixelGrid(
+                nx=nx_sub,
+                ny=ny_sub,
+                transform_pix2angle=transform_pix2angle,
+                ra_at_xy_0=ra_at_xy_0_sub,
+                dec_at_xy_0=dec_at_xy_0_sub,
+            )
+        else:
+            pixel_grid_sub = pixel_grid
+        return pixel_grid_sub

--- a/jaxtronomy/LightModel/Profiles/gaussian.py
+++ b/jaxtronomy/LightModel/Profiles/gaussian.py
@@ -1,0 +1,348 @@
+from jax import jit, numpy as jnp
+import jaxtronomy.Util.param_util as param_util
+
+
+class Gaussian(object):
+    """Class for Gaussian light profile The two-dimensional Gaussian profile amplitude
+    is defined such that the 2D integral leads to the 'amp' value.
+
+    profile name in LightModel module: 'GAUSSIAN'
+    """
+
+    def __init__(self):
+        self.param_names = ["amp", "sigma", "center_x", "center_y"]
+        self.lower_limit_default = {
+            "amp": 0,
+            "sigma": 0,
+            "center_x": -100,
+            "center_y": -100,
+        }
+        self.upper_limit_default = {
+            "amp": 1000,
+            "sigma": 100,
+            "center_x": 100,
+            "center_y": 100,
+        }
+
+    @staticmethod
+    @jit
+    def function(x, y, amp, sigma, center_x=0, center_y=0):
+        """Surface brightness per angular unit.
+
+        :param x: coordinate on the sky
+        :param y: coordinate on the sky
+        :param amp: amplitude, such that 2D integral leads to this value
+        :param sigma: sigma of Gaussian in each direction
+        :param center_x: center of profile
+        :param center_y: center of profile
+        :return: surface brightness at (x, y)
+        """
+        c = amp / (2 * jnp.pi * sigma**2)
+        r2 = (x - center_x) ** 2 / sigma**2 + (y - center_y) ** 2 / sigma**2
+        return c * jnp.exp(-r2 / 2.0)
+
+    @staticmethod
+    def total_flux(amp, sigma, center_x=0, center_y=0):
+        """Integrated flux of the profile.
+
+        :param amp: amplitude, such that 2D integral leads to this value
+        :param sigma: sigma of Gaussian in each direction
+        :param center_x: center of profile
+        :param center_y: center of profile
+        :return: total flux
+        """
+        return amp
+
+    @staticmethod
+    @jit
+    def light_3d(r, amp, sigma):
+        """3D brightness per angular volume element.
+
+        :param r: 3d distance from center of profile
+        :param amp: amplitude, such that 2D integral leads to this value
+        :param sigma: sigma of Gaussian in each direction
+        :return: 3D brightness per angular volume element
+        """
+        amp3d = amp / jnp.sqrt(2 * sigma**2) / jnp.sqrt(jnp.pi)
+        sigma3d = sigma
+        return Gaussian.function(r, 0, amp3d, sigma3d)
+
+
+class GaussianEllipse(object):
+    """Class for Gaussian light profile with ellipticity.
+
+    profile name in LightModel module: 'GAUSSIAN_ELLIPSE'
+    """
+
+    param_names = ["amp", "sigma", "e1", "e2", "center_x", "center_y"]
+    lower_limit_default = {
+        "amp": 0,
+        "sigma": 0,
+        "e1": -0.5,
+        "e2": -0.5,
+        "center_x": -100,
+        "center_y": -100,
+    }
+    upper_limit_default = {
+        "amp": 1000,
+        "sigma": 100,
+        "e1": -0.5,
+        "e2": -0.5,
+        "center_x": 100,
+        "center_y": 100,
+    }
+
+    @staticmethod
+    @jit
+    def function(x, y, amp, sigma, e1, e2, center_x=0, center_y=0):
+        """
+
+        :param x: coordinate on the sky
+        :param y: coordinate on the sky
+        :param amp: amplitude, such that 2D integral leads to this value
+        :param sigma: sigma of Gaussian in each direction
+        :param e1: eccentricity modulus
+        :param e2: eccentricity modulus
+        :param center_x: center of profile
+        :param center_y: center of profile
+        :return: surface brightness at (x, y)
+        """
+        x_, y_ = param_util.transform_e1e2_product_average(
+            x, y, e1, e2, center_x, center_y
+        )
+        return Gaussian.function(x_, y_, amp, sigma, center_x=0, center_y=0)
+
+    @staticmethod
+    def total_flux(
+        amp, sigma=None, e1=None, e2=None, center_x=None, center_y=None
+    ):
+        """Total integrated flux of profile.
+
+        :param amp: amplitude, such that 2D integral leads to this value
+        :param sigma: sigma of Gaussian in each direction
+        :param e1: eccentricity modulus
+        :param e2: eccentricity modulus
+        :param center_x: center of profile
+        :param center_y: center of profile
+        :return: total flux
+        """
+        return amp
+
+    @staticmethod
+    @jit
+    def light_3d(r, amp, sigma, e1=0, e2=0):
+        """3D brightness per angular volume element.
+
+        :param r: 3d distance from center of profile
+        :param amp: amplitude, such that 2D integral leads to this value
+        :param sigma: sigma of Gaussian in each direction
+        :param e1: eccentricity modulus
+        :param e2: eccentricity modulus
+        :return: 3D brightness per angular volume element
+        """
+        return Gaussian.light_3d(r, amp, sigma=sigma)
+
+class MultiGaussian(object):
+    """Class for elliptical pseudo Jaffe lens light (2d projected light/mass
+    distribution.
+
+    profile name in LightModel module: 'MULTI_GAUSSIAN'
+    """
+
+    param_names = ["amp", "sigma", "center_x", "center_y"]
+    lower_limit_default = {
+        "amp": 0,
+        "sigma": 0,
+        "e1": -0.5,
+        "e2": -0.5,
+        "center_x": -100,
+        "center_y": -100,
+    }
+    upper_limit_default = {
+        "amp": 1000,
+        "sigma": 100,
+        "e1": -0.5,
+        "e2": -0.5,
+        "center_x": 100,
+        "center_y": 100,
+    }
+
+    @staticmethod
+    @jit
+    def function(x, y, amp, sigma, center_x=0, center_y=0):
+        """Surface brightness per angular unit.
+
+        :param x: coordinate on the sky
+        :param y: coordinate on the sky
+        :param amp: list of amplitudes of individual Gaussian profiles
+        :param sigma: list of widths of individual Gaussian profiles
+        :param center_x: center of profile
+        :param center_y: center of profile
+        :return: surface brightness at (x, y)
+        """
+        f_ = jnp.zeros_like(x, dtype=float)
+        for i in range(len(amp)):
+            f_ += Gaussian.function(x, y, amp[i], sigma[i], center_x, center_y)
+        return f_
+
+    @staticmethod
+    @jit
+    def total_flux(amp, sigma, center_x=0, center_y=0):
+        """Total integrated flux of profile.
+
+        :param amp: list of amplitudes of individual Gaussian profiles
+        :param sigma: list of widths of individual Gaussian profiles
+        :param center_x: center of profile
+        :param center_y: center of profile
+        :return: total flux
+        """
+        flux = 0
+        for i in range(len(amp)):
+            flux += Gaussian.total_flux(amp[i], sigma[i], center_x, center_y)
+        return flux
+
+    @staticmethod
+    @jit
+    def function_split(x, y, amp, sigma, center_x=0, center_y=0):
+        """Split surface brightness in individual components.
+
+        :param x: coordinate on the sky
+        :param y: coordinate on the sky
+        :param amp: list of amplitudes of individual Gaussian profiles
+        :param sigma: list of widths of individual Gaussian profiles
+        :param center_x: center of profile
+        :param center_y: center of profile
+        :return: list of arrays of surface brightness
+        """
+        f_list = []
+        for i in range(len(amp)):
+            f_list.append(
+                Gaussian.function(x, y, amp[i], sigma[i], center_x, center_y)
+            )
+        return f_list
+
+    @staticmethod
+    @jit
+    def light_3d(r, amp, sigma):
+        """3D brightness per angular volume element.
+
+        :param r: 3d distance from center of profile
+        :param amp: list of amplitudes of individual Gaussian profiles
+        :param sigma: list of widths of individual Gaussian profiles
+        :return: 3D brightness per angular volume element
+        """
+        f_ = jnp.zeros_like(r, dtype=float)
+        for i in range(len(amp)):
+            f_ += Gaussian.light_3d(r, amp[i], sigma[i])
+        return f_
+
+
+class MultiGaussianEllipse(object):
+    """Class for elliptical multi Gaussian profile.
+
+    profile name in LightModel module: 'MULTI_GAUSSIAN_ELLIPSE'
+    """
+
+    param_names = ["amp", "sigma", "e1", "e2", "center_x", "center_y"]
+    lower_limit_default = {
+        "amp": 0,
+        "sigma": 0,
+        "e1": -0.5,
+        "e2": -0.5,
+        "center_x": -100,
+        "center_y": -100,
+    }
+    upper_limit_default = {
+        "amp": 1000,
+        "sigma": 100,
+        "e1": -0.5,
+        "e2": -0.5,
+        "center_x": 100,
+        "center_y": 100,
+    }
+
+    @staticmethod
+    @jit
+    def function(x, y, amp, sigma, e1, e2, center_x=0, center_y=0):
+        """Surface brightness per angular unit.
+
+        :param x: coordinate on the sky
+        :param y: coordinate on the sky
+        :param amp: list of amplitudes of individual Gaussian profiles
+        :param sigma: list of widths of individual Gaussian profiles
+        :param e1: eccentricity modulus
+        :param e2: eccentricity modulus
+        :param center_x: center of profile
+        :param center_y: center of profile
+        :return: surface brightness at (x, y)
+        """
+        x_, y_ = param_util.transform_e1e2_product_average(
+            x, y, e1, e2, center_x, center_y
+        )
+
+        f_ = jnp.zeros_like(x, dtype=float)
+        for i in range(len(amp)):
+            f_ += Gaussian.function(
+                x_, y_, amp[i], sigma[i], center_x=0, center_y=0
+            )
+        return f_
+
+    @staticmethod
+    @jit
+    def total_flux(amp, sigma, e1, e2, center_x=0, center_y=0):
+        """Total integrated flux of profile.
+
+        :param amp: list of amplitudes of individual Gaussian profiles
+        :param sigma: list of widths of individual Gaussian profiles
+        :param e1: eccentricity modulus
+        :param e2: eccentricity modulus
+        :param center_x: center of profile
+        :param center_y: center of profile
+        :return: total flux
+        """
+        flux = 0
+        for i in range(len(amp)):
+            flux += Gaussian.total_flux(amp[i], sigma[i], center_x, center_y)
+        return flux
+
+    @staticmethod
+    @jit
+    def function_split(x, y, amp, sigma, e1, e2, center_x=0, center_y=0):
+        """Split surface brightness in individual components.
+
+        :param x: coordinate on the sky
+        :param y: coordinate on the sky
+        :param amp: list of amplitudes of individual Gaussian profiles
+        :param sigma: list of widths of individual Gaussian profiles
+        :param e1: eccentricity modulus
+        :param e2: eccentricity modulus
+        :param center_x: center of profile
+        :param center_y: center of profile
+        :return: list of arrays of surface brightness
+        """
+        x_, y_ = param_util.transform_e1e2_product_average(
+            x, y, e1, e2, center_x, center_y
+        )
+        f_list = []
+        for i in range(len(amp)):
+            f_list.append(
+                Gaussian.function(x_, y_, amp[i], sigma[i], center_x=0, center_y=0)
+            )
+        return f_list
+
+    @staticmethod
+    @jit
+    def light_3d(r, amp, sigma, e1=0, e2=0):
+        """3D brightness per angular volume element.
+
+        :param r: 3d distance from center of profile
+        :param amp: list of amplitudes of individual Gaussian profiles
+        :param sigma: list of widths of individual Gaussian profiles
+        :param e1: eccentricity modulus
+        :param e2: eccentricity modulus
+        :return: 3D brightness per angular volume element
+        """
+        f_ = jnp.zeros_like(r, dtype=float)
+        for i in range(len(amp)):
+            f_ += Gaussian.light_3d(r, amp[i], sigma[i])
+        return f_

--- a/jaxtronomy/LightModel/Profiles/gaussian.py
+++ b/jaxtronomy/LightModel/Profiles/gaussian.py
@@ -142,7 +142,7 @@ class GaussianEllipse(object):
 
 
 class MultiGaussian(object):
-    """Class for elliptical pseudo Jaffe lens light (2d projected light/mass
+    """Class for Multi Gaussian lens light (2d projected light/mass
     distribution.
 
     profile name in LightModel module: 'MULTI_GAUSSIAN'

--- a/jaxtronomy/LightModel/light_model_base.py
+++ b/jaxtronomy/LightModel/light_model_base.py
@@ -1,6 +1,5 @@
 __author__ = "sibirrer"
 
-# NOTE: Copy pasted from lenstronomy, functions have not been jaxified yet
 # this file contains a class which describes the surface brightness of the light models
 
 from lenstronomy.Util.util import convert_bool_list
@@ -14,6 +13,10 @@ sersic_major_axis_conf = convention_conf.get("sersic_major_axis", False)
 __all__ = ["LightModelBase"]
 
 _JAXXED_MODELS = [
+    "GAUSSIAN",
+    "GAUSSIAN_ELLIPSE",
+    "MULTI_GAUSSIAN",
+    "MULTI_GAUSSIAN_ELLIPSE",
     "SERSIC",
     "SERSIC_ELLIPSE",
     "SERSIC_ELLIPSE_Q_PHI",
@@ -70,29 +73,29 @@ class LightModelBase(object):
         if sersic_major_axis is None:
             sersic_major_axis = sersic_major_axis_conf
         for profile_type in light_model_list:
-            # if profile_type == "GAUSSIAN":
-            #     from lenstronomy.LightModel.Profiles.gaussian import Gaussian
+            if profile_type == "GAUSSIAN":
+                 from jaxtronomy.LightModel.Profiles.gaussian import Gaussian
 
-            #     self.func_list.append(Gaussian())
-            # elif profile_type == "GAUSSIAN_ELLIPSE":
-            #     from lenstronomy.LightModel.Profiles.gaussian import GaussianEllipse
+                 self.func_list.append(Gaussian())
+            elif profile_type == "GAUSSIAN_ELLIPSE":
+                 from jaxtronomy.LightModel.Profiles.gaussian import GaussianEllipse
 
-            #     self.func_list.append(GaussianEllipse())
+                 self.func_list.append(GaussianEllipse())
             # elif profile_type == "ELLIPSOID":
             #     from lenstronomy.LightModel.Profiles.ellipsoid import Ellipsoid
 
             #     self.func_list.append(Ellipsoid())
-            # elif profile_type == "MULTI_GAUSSIAN":
-            #     from lenstronomy.LightModel.Profiles.gaussian import MultiGaussian
+            elif profile_type == "MULTI_GAUSSIAN":
+                 from jaxtronomy.LightModel.Profiles.gaussian import MultiGaussian
 
-            #     self.func_list.append(MultiGaussian())
-            # elif profile_type == "MULTI_GAUSSIAN_ELLIPSE":
-            #     from lenstronomy.LightModel.Profiles.gaussian import (
-            #         MultiGaussianEllipse,
-            #     )
+                 self.func_list.append(MultiGaussian())
+            elif profile_type == "MULTI_GAUSSIAN_ELLIPSE":
+                 from jaxtronomy.LightModel.Profiles.gaussian import (
+                     MultiGaussianEllipse,
+                 )
 
-            #     self.func_list.append(MultiGaussianEllipse())
-            if profile_type == "SERSIC":
+                 self.func_list.append(MultiGaussianEllipse())
+            elif profile_type == "SERSIC":
                 from jaxtronomy.LightModel.Profiles.sersic import Sersic
 
                 self.func_list.append(Sersic(smoothing=smoothing))
@@ -319,17 +322,13 @@ class LightModelBase(object):
                 ]:
                     kwargs_new = kwargs_list_standard[i].copy()
                     if norm is True:
-                        # TODO: Re-implement when these profiles are added to jaxtronomy
-                        # if model in ["MULTI_GAUSSIAN", "MULTI_GAUSSIAN_ELLIPSE"]:
-                        #     new = {
-                        #         "amp": np.array(kwargs_new["amp"])
-                        #         / kwargs_new["amp"][0]
-                        #     }
-                        # else:
-                        #     new = {"amp": 1}
-                        new = {
-                            "amp": 1
-                        }  # Delete this line when the above if statement is re-implemented
+                        if model in ["MULTI_GAUSSIAN", "MULTI_GAUSSIAN_ELLIPSE"]:
+                            new = {
+                                "amp": jnp.array(kwargs_new["amp"])
+                                / kwargs_new["amp"][0]
+                            }
+                        else:
+                            new = {"amp": 1}
                         kwargs_new.update(new)
                     norm_flux = self.func_list[i].total_flux(**kwargs_new)
                     norm_flux_list.append(norm_flux)

--- a/jaxtronomy/Util/util.py
+++ b/jaxtronomy/Util/util.py
@@ -60,7 +60,7 @@ def displaceAbs(x, y, sourcePos_x, sourcePos_y):
 
 @jit
 def fwhm2sigma(fwhm):
-    """
+    """Converts the fwhm of a gaussian to std.
 
     :param fwhm: full-width-half-max value
     :return: gaussian sigma (sqrt(var))
@@ -84,7 +84,8 @@ def image2array(image):
 
 @jit
 def rotate(xcoords, ycoords, angle):
-    """
+    """Rotates x and y coordinates by an angle.
+
     :param xcoords: x points
     :param ycoords: y points
     :param angle: angle in radians
@@ -97,7 +98,7 @@ def rotate(xcoords, ycoords, angle):
 
 @jit
 def sigma2fwhm(sigma):
-    """
+    """Converts the std of a gaussian to the fwhm.
 
     :param sigma:
     :return:

--- a/jaxtronomy/Util/util.py
+++ b/jaxtronomy/Util/util.py
@@ -15,7 +15,6 @@ from lenstronomy.Util.package_util import exporter
 export, __all__ = exporter()
 
 
-@export
 @partial(jit, static_argnums=(1, 2))
 def array2image(array, nx=0, ny=0):
     """Returns the information contained in a 1d array into an n*n 2d array (only works
@@ -38,7 +37,6 @@ def array2image(array, nx=0, ny=0):
     return image
 
 
-@export
 @jit
 def displaceAbs(x, y, sourcePos_x, sourcePos_y):
     """Calculates a grid of distances to the observer in angel.
@@ -59,8 +57,16 @@ def displaceAbs(x, y, sourcePos_x, sourcePos_y):
     absmapped = jnp.sqrt(x_mapped**2 + y_mapped**2)
     return absmapped
 
+@jit
+def fwhm2sigma(fwhm):
+    """
 
-@export
+    :param fwhm: full-width-half-max value
+    :return: gaussian sigma (sqrt(var))
+    """
+    sigma = fwhm / (2 * jnp.sqrt(2 * jnp.log(2)))
+    return sigma
+
 @jit
 def image2array(image):
     """Returns the information contained in a 2d array into an n*n 1d array.
@@ -73,8 +79,6 @@ def image2array(image):
     imgh = jnp.reshape(image, jnp.size(image))  # change the shape to be 1d
     return imgh
 
-
-@export
 @jit
 def rotate(xcoords, ycoords, angle):
     """
@@ -86,3 +90,13 @@ def rotate(xcoords, ycoords, angle):
     return xcoords * jnp.cos(angle) + ycoords * jnp.sin(angle), -xcoords * jnp.sin(
         angle
     ) + ycoords * jnp.cos(angle)
+
+@jit
+def sigma2fwhm(sigma):
+    """
+
+    :param sigma:
+    :return:
+    """
+    fwhm = sigma * (2 * jnp.sqrt(2 * jnp.log(2)))
+    return fwhm

--- a/test/test_ImSim/test_Numerics/test_convolution.py
+++ b/test/test_ImSim/test_Numerics/test_convolution.py
@@ -5,10 +5,12 @@ import numpy.testing as npt
 from jaxtronomy.ImSim.Numerics.convolution import (
     PixelKernelConvolution,
     SubgridKernelConvolution,
+    MultiGaussianConvolution
 )
 from lenstronomy.ImSim.Numerics.convolution import (
     PixelKernelConvolution as PixelKernelConvolution_ref,
     SubgridKernelConvolution as SubgridKernelConvolution_ref,
+    MultiGaussianConvolution as MultiGaussianConvolution_ref
 )
 from lenstronomy.LightModel.light_model import LightModel
 import lenstronomy.Util.util as util
@@ -18,9 +20,9 @@ import pytest
 class TestPixelKernelConvolution(object):
     def setup_method(self):
         lightModel = LightModel(light_model_list=["GAUSSIAN"])
-        self.delta_pix = 1
+        self.delta_pix = 1.2345
         x, y = util.make_grid(10, deltapix=self.delta_pix)
-        kwargs = [{"amp": 1, "sigma": 1, "center_x": 0, "center_y": 0}]
+        kwargs = [{"amp": 26.102394, "sigma": 1.3452384, "center_x": 0, "center_y": 0}]
         flux = lightModel.surface_brightness(x, y, kwargs)
         self.model = util.array2image(flux)
 
@@ -33,28 +35,22 @@ class TestPixelKernelConvolution(object):
             ValueError,
             PixelKernelConvolution,
             kernel=kernel,
-            convolution_type="fft_static",
-        )
-        npt.assert_raises(
-            ValueError,
-            PixelKernelConvolution,
-            kernel=kernel,
             convolution_type="incorrect",
         )
 
     def test_convolve2d_fft(self):
-        kernel = np.ones((3, 3)) * 2
+        kernel = np.ones((7, 7)) * 2
         kernel[1, 1] = 1
         kernel = kernel / np.sum(kernel)
 
-        pixel_conv = PixelKernelConvolution(kernel=kernel)
-        pixel_conv_ref = PixelKernelConvolution_ref(kernel=kernel)
+        pixel_conv = PixelKernelConvolution(kernel=kernel, convolution_type="fft")
+        pixel_conv_ref = PixelKernelConvolution_ref(kernel=kernel, convolution_type="fft")
         image_convolved = pixel_conv.convolution2d(self.model)
         image_convolved_ref = pixel_conv_ref.convolution2d(self.model)
         npt.assert_almost_equal(image_convolved, image_convolved_ref, decimal=5)
 
     def test_convolve2d_grid(self):
-        kernel = np.ones((3, 3)) * 2
+        kernel = np.ones((5, 5)) * 2
         kernel[1, 1] = 1
         kernel = kernel / np.sum(kernel)
 
@@ -64,7 +60,22 @@ class TestPixelKernelConvolution(object):
         )
         image_convolved = pixel_conv.convolution2d(self.model)
         image_convolved_ref = pixel_conv_ref.convolution2d(self.model)
-        npt.assert_almost_equal(image_convolved, image_convolved_ref, decimal=8)
+        npt.assert_almost_equal(image_convolved, image_convolved_ref, decimal=7)
+
+    def test_convolve2d_fft_static(self):
+        kernel = np.ones((3, 3)) * 2
+        kernel[1, 1] = 1
+        kernel = kernel / np.sum(kernel)
+
+        pixel_conv = PixelKernelConvolution(kernel=kernel, convolution_type="fft_static")
+        pixel_conv_ref = PixelKernelConvolution_ref(kernel=kernel, convolution_type="fft_static")
+        image_convolved = pixel_conv.convolution2d(self.model)
+        image_convolved_ref = pixel_conv_ref.convolution2d(self.model)
+        npt.assert_almost_equal(image_convolved, image_convolved_ref, decimal=5)
+
+        image_convolved = pixel_conv.convolution2d(self.model * 2 + 0.1)
+        image_convolved_ref = pixel_conv_ref.convolution2d(self.model * 2 + 0.1)
+        npt.assert_almost_equal(image_convolved, image_convolved_ref, decimal=5)
 
     def test_convolve2d_incorrect(self):
         kernel = np.ones((3, 3)) * 2
@@ -113,20 +124,20 @@ class TestSubgridKernelConvolution(object):
     def setup_method(self):
         self.supersampling_factor = 3
         lightModel = LightModel(light_model_list=["GAUSSIAN"])
-        self.delta_pix = 1.0
-        x, y = util.make_grid(20, deltapix=self.delta_pix)
+        self.delta_pix = 1.6534
+        x, y = util.make_grid(30, deltapix=self.delta_pix)
         x_sub, y_sub = util.make_grid(
-            20 * self.supersampling_factor,
+            30 * self.supersampling_factor,
             deltapix=self.delta_pix / self.supersampling_factor,
         )
-        kwargs = [{"amp": 1, "sigma": 2, "center_x": 0, "center_y": 0}]
+        kwargs = [{"amp": 31.235, "sigma": 2, "center_x": 0, "center_y": 0}]
         flux = lightModel.surface_brightness(x, y, kwargs)
         self.model = util.array2image(flux)
         flux_sub = lightModel.surface_brightness(x_sub, y_sub, kwargs)
         self.model_sub = util.array2image(flux_sub)
 
         x, y = util.make_grid(5, deltapix=self.delta_pix)
-        kwargs_kernel = [{"amp": 1, "sigma": 1, "center_x": 0, "center_y": 0}]
+        kwargs_kernel = [{"amp": 21, "sigma": 1, "center_x": 0, "center_y": 0}]
         kernel = lightModel.surface_brightness(x, y, kwargs_kernel)
         self.kernel = util.array2image(kernel) / np.sum(kernel)
 
@@ -216,6 +227,134 @@ class TestSubgridKernelConvolution(object):
         re_size_conv_ref = subgrid_conv_ref.re_size_convolve(self.model, self.model_sub)
 
         npt.assert_array_almost_equal(re_size_conv, re_size_conv_ref, decimal=6)
+
+
+class TestMultiGaussianConvolution(object):
+    def setup_method(self):
+        self.supersampling_factor = 3
+        lightModel = LightModel(light_model_list=["GAUSSIAN"])
+        self.delta_pix = 0.04
+        x, y = util.make_grid(30, deltapix=self.delta_pix)
+        x_sub, y_sub = util.make_grid(
+            30 * self.supersampling_factor,
+            deltapix=self.delta_pix / self.supersampling_factor,
+        )
+        kwargs = [{"amp": 31.345982834, "sigma": 2.123784, "center_x": 0, "center_y": 0}]
+        flux = lightModel.surface_brightness(x, y, kwargs)
+        self.model = util.array2image(flux)
+        flux_sub = lightModel.surface_brightness(x_sub, y_sub, kwargs)
+        self.model_sub = util.array2image(flux_sub)
+
+    def test_init_and_pixel_kernel(self):
+        sigma_list = [0.333, 0.75, 2]
+        fraction_list = [0.5, 0.2, 0.3]
+        mg_conv = MultiGaussianConvolution(
+            sigma_list=sigma_list,
+            fraction_list=fraction_list,
+            pixel_scale=1.0,
+        )
+
+        kernel = mg_conv.pixel_kernel(num_pix=3)
+        npt.assert_array_equal(kernel, mg_conv.kernel_list[0])
+
+        kernel = mg_conv.pixel_kernel(num_pix=5)
+        npt.assert_array_equal(kernel, mg_conv.kernel_list[1])
+
+        kernel = mg_conv.pixel_kernel(num_pix=9)
+        npt.assert_array_equal(kernel, mg_conv.kernel_list[2])
+
+        npt.assert_raises(ValueError, mg_conv.pixel_kernel, num_pix=1)
+        npt.assert_raises(ValueError, mg_conv.pixel_kernel, num_pix=2)
+
+    def test_convolve2d(self):
+        sigma_list = [0.5, 1, 2]
+        fraction_list = [0.5, 0.2, 0.3]
+        mg_conv = MultiGaussianConvolution(
+            sigma_list=sigma_list,
+            fraction_list=fraction_list,
+            pixel_scale=self.delta_pix,
+        )
+        mg_conv_ref = MultiGaussianConvolution_ref(
+            sigma_list=sigma_list,
+            fraction_list=fraction_list,
+            pixel_scale=self.delta_pix,
+        )
+        image_convolved = mg_conv.convolution2d(self.model)
+        image_convolved_ref = mg_conv_ref.convolution2d(self.model)
+        npt.assert_array_almost_equal(image_convolved, image_convolved_ref, decimal=6)
+
+        image_convolved = mg_conv.convolution2d(self.model * 1.3422 - 1)
+        image_convolved_ref = mg_conv_ref.convolution2d(self.model * 1.3422 - 1)
+        npt.assert_array_almost_equal(image_convolved, image_convolved_ref, decimal=6)
+        
+    def test_convolve2d_supersampled(self):
+        sigma_list = [3, 1, 2]
+        fraction_list = [0.5, 0.2, 0.3]
+        mg_conv = MultiGaussianConvolution(
+            sigma_list=sigma_list,
+            fraction_list=fraction_list,
+            pixel_scale=self.delta_pix,
+            supersampling_factor=self.supersampling_factor,
+            supersampling_convolution=True,
+            truncation=4
+        )
+        mg_conv_ref = MultiGaussianConvolution_ref(
+            sigma_list=sigma_list,
+            fraction_list=fraction_list,
+            pixel_scale=self.delta_pix,
+            supersampling_factor=self.supersampling_factor,
+            supersampling_convolution=True,
+            truncation=4
+        )
+        image_convolved = mg_conv.convolution2d(self.model)
+        image_convolved_ref = mg_conv_ref.convolution2d(self.model)
+        npt.assert_array_almost_equal(image_convolved, image_convolved_ref, decimal=6)
+
+    def test_re_size_convolve(self):
+        sigma_list = [5, 1, 2]
+        fraction_list = [0.5, 0.2, 0.3]
+        mg_conv = MultiGaussianConvolution(
+            sigma_list=sigma_list,
+            fraction_list=fraction_list,
+            pixel_scale=self.delta_pix,
+            supersampling_factor=self.supersampling_factor,
+            supersampling_convolution=True
+        )
+        mg_conv_ref = MultiGaussianConvolution_ref(
+            sigma_list=sigma_list,
+            fraction_list=fraction_list,
+            pixel_scale=self.delta_pix,
+            supersampling_factor=self.supersampling_factor,
+            supersampling_convolution=True
+        )
+        image_convolved = mg_conv.re_size_convolve(self.model, self.model_sub)
+        image_convolved_ref = mg_conv_ref.re_size_convolve(self.model, self.model_sub)
+        npt.assert_array_almost_equal(image_convolved, image_convolved_ref, decimal=6)
+
+        image_convolved = mg_conv.re_size_convolve(self.model+2.923, self.model_sub+1.923)
+        image_convolved_ref = mg_conv_ref.re_size_convolve(self.model+2.923, self.model_sub+1.923)
+        npt.assert_array_almost_equal(image_convolved, image_convolved_ref, decimal=6)
+
+    def test_re_size_convolve_low_res(self):
+        sigma_list = [0.5, 1, 2]
+        fraction_list = [0.5, 0.2, 0.3]
+        mg_conv = MultiGaussianConvolution(
+            sigma_list=sigma_list,
+            fraction_list=fraction_list,
+            pixel_scale=self.delta_pix,
+        )
+        mg_conv_ref = MultiGaussianConvolution_ref(
+            sigma_list=sigma_list,
+            fraction_list=fraction_list,
+            pixel_scale=self.delta_pix,
+        )
+        image_convolved = mg_conv.re_size_convolve(self.model, self.model_sub)
+        image_convolved_ref = mg_conv_ref.re_size_convolve(self.model, self.model_sub)
+        npt.assert_array_almost_equal(image_convolved, image_convolved_ref, decimal=6)
+
+        image_convolved = mg_conv.re_size_convolve(self.model+2.923, self.model_sub+1.923)
+        image_convolved_ref = mg_conv_ref.re_size_convolve(self.model+2.923, self.model_sub+1.923)
+        npt.assert_array_almost_equal(image_convolved, image_convolved_ref, decimal=6)
 
 
 if __name__ == "__main__":

--- a/test/test_ImSim/test_Numerics/test_convolution.py
+++ b/test/test_ImSim/test_Numerics/test_convolution.py
@@ -272,7 +272,7 @@ class TestGaussianConvolution(object):
         npt.assert_raises(ValueError, g_conv.pixel_kernel, num_pix=2)
 
     def test_convolve2d(self):
-        sigma = 0.5
+        sigma = 0.001
         g_conv = GaussianConvolution(
             sigma=sigma,
             pixel_scale=self.delta_pix,

--- a/test/test_ImSim/test_Numerics/test_numerics.py
+++ b/test/test_ImSim/test_Numerics/test_numerics.py
@@ -185,7 +185,7 @@ class TestNumerics(object):
             compute_mode="regular",
             supersampling_convolution=True,
             supersampling_kernel_size=5,
-            convolution_kernel_size=9,
+            convolution_kernel_size=8,
             convolution_type="fft",
         )
         assert numerics.grid_supersampling_factor == 5
@@ -199,7 +199,7 @@ class TestNumerics(object):
             compute_mode="regular",
             supersampling_convolution=True,
             supersampling_kernel_size=5,
-            convolution_kernel_size=9,
+            convolution_kernel_size=8,
             convolution_type="fft",
         )
         npt.assert_array_equal(

--- a/test/test_ImSim/test_Numerics/test_numerics.py
+++ b/test/test_ImSim/test_Numerics/test_numerics.py
@@ -8,7 +8,7 @@ import lenstronomy.Util.kernel_util as kernel_util
 from jaxtronomy.ImSim.Numerics.convolution import (
     PixelKernelConvolution,
     SubgridKernelConvolution,
-    MultiGaussianConvolution,
+    GaussianConvolution,
 )
 from jaxtronomy.ImSim.Numerics.grid import RegularGrid
 
@@ -231,7 +231,7 @@ class TestNumerics(object):
             convolution_kernel_size=None,
         )
         assert numerics.grid_supersampling_factor == 1
-        assert isinstance(numerics.convolution_class, MultiGaussianConvolution)
+        assert isinstance(numerics.convolution_class, GaussianConvolution)
         assert isinstance(numerics.grid_class, RegularGrid)
 
         numerics_ref = Numerics_ref(
@@ -266,7 +266,7 @@ class TestNumerics(object):
             supersampling_convolution=True,
         )
         assert numerics.grid_supersampling_factor == 5
-        assert isinstance(numerics.convolution_class, MultiGaussianConvolution)
+        assert isinstance(numerics.convolution_class, GaussianConvolution)
         assert isinstance(numerics.grid_class, RegularGrid)
 
         numerics_ref = Numerics_ref(

--- a/test/test_ImSim/test_Numerics/test_numerics.py
+++ b/test/test_ImSim/test_Numerics/test_numerics.py
@@ -1,0 +1,291 @@
+import pytest
+import jax
+import numpy.testing as npt
+
+import lenstronomy.Util.util as util
+import lenstronomy.Util.kernel_util as kernel_util
+
+from jaxtronomy.ImSim.Numerics.convolution import PixelKernelConvolution, SubgridKernelConvolution, MultiGaussianConvolution
+from jaxtronomy.ImSim.Numerics.grid import RegularGrid
+
+from jaxtronomy.ImSim.Numerics.numerics import Numerics
+from lenstronomy.ImSim.Numerics.numerics import Numerics as Numerics_ref
+
+from lenstronomy.Data.pixel_grid import PixelGrid
+from lenstronomy.Data.psf import PSF
+from lenstronomy.LightModel.light_model import LightModel
+
+jax.config.update("jax_enable_x64", True)
+
+class TestNumerics(object):
+    def setup_method(self):
+        # we define a model consisting of a single Sersic profile
+
+        light_model_list = ["SERSIC_ELLIPSE"]
+        self.lightModel = LightModel(light_model_list=light_model_list)
+        self.kwargs_light = [
+            {
+                "amp": 100,
+                "R_sersic": 0.5,
+                "n_sersic": 3,
+                "e1": -0.3123,
+                "e2": 0.1234,
+                "center_x": 0.02,
+                "center_y": 0,
+            }
+        ]
+
+        # we define a pixel grid and a higher resolution super sampling factor
+        self._supersampling_factor = 5
+        numPix = 60  # cutout pixel size
+        deltaPix = 0.05  # pixel size in arcsec (area per pixel = deltaPix**2)
+        (
+            x,
+            y,
+            ra_at_xy_0,
+            dec_at_xy_0,
+            x_at_radec_0,
+            y_at_radec_0,
+            Mpix2coord,
+            Mcoord2pix,
+        ) = util.make_grid_with_coordtransform(
+            numPix=numPix,
+            deltapix=deltaPix,
+            subgrid_res=1,
+            left_lower=False,
+            inverse=False,
+        )
+        self.flux = self.lightModel.surface_brightness(x, y, kwargs_list=self.kwargs_light)
+
+        (
+            x,
+            y,
+            ra_at_xy_0,
+            dec_at_xy_0,
+            x_at_radec_0,
+            y_at_radec_0,
+            Mpix2coord,
+            Mcoord2pix,
+        ) = util.make_grid_with_coordtransform(
+            numPix=numPix*self._supersampling_factor,
+            deltapix=deltaPix/self._supersampling_factor,
+            subgrid_res=1,
+            left_lower=False,
+            inverse=False,
+        )
+        self.flux_supersampled = self.lightModel.surface_brightness(x, y, kwargs_list=self.kwargs_light)
+
+        self.kernel_super = kernel_util.kernel_gaussian(
+            num_pix=11 * self._supersampling_factor,
+            delta_pix=deltaPix / self._supersampling_factor,
+            fwhm=0.1,
+        )
+
+        kwargs_grid = {
+            "nx": numPix,
+            "ny": numPix,
+            "transform_pix2angle": Mpix2coord,
+            "ra_at_xy_0": ra_at_xy_0,
+            "dec_at_xy_0": dec_at_xy_0,
+        }
+        self.pixel_grid = PixelGrid(**kwargs_grid)
+
+        kwargs_psf_pixel = {
+            "psf_type": "PIXEL",
+            "kernel_point_source": self.kernel_super,
+            "point_source_supersampling_factor": self._supersampling_factor,
+            "kernel_point_source_normalisation": True,
+        }
+        self.psf_class_pixel = PSF(**kwargs_psf_pixel)
+
+        kwargs_psf_gaussian = {
+            "psf_type": "GAUSSIAN",
+            "fwhm": 0.5,
+            "kernel_point_source_normalisation": True,
+        }
+        self.psf_class_gaussian = PSF(**kwargs_psf_gaussian)
+        kwargs_psf_none = {
+            "psf_type": "NONE",
+        }
+        self.psf_class_none = PSF(**kwargs_psf_none)
+
+
+    def test_supersampling_cut_kernel(self):
+        numerics = Numerics(
+            pixel_grid=self.pixel_grid,
+            psf=self.psf_class_pixel,
+        )
+        numerics_ref = Numerics_ref(
+            pixel_grid=self.pixel_grid,
+            psf=self.psf_class_pixel,
+        )
+        cut_kernel = numerics._supersampling_cut_kernel(self.kernel_super, 5, self._supersampling_factor)
+        cut_kernel_ref = numerics_ref._supersampling_cut_kernel(self.kernel_super, 5, self._supersampling_factor)
+        npt.assert_array_almost_equal(cut_kernel, cut_kernel_ref, decimal=8)
+
+        cut_kernel = numerics._supersampling_cut_kernel(self.kernel_super, None, self._supersampling_factor)
+        cut_kernel_ref = numerics_ref._supersampling_cut_kernel(self.kernel_super, None, self._supersampling_factor)
+        npt.assert_array_equal(cut_kernel, cut_kernel_ref)
+
+
+    def test_no_supersampling_pixel_psf(self):
+        numerics = Numerics(
+            pixel_grid=self.pixel_grid,
+            psf=self.psf_class_pixel,
+            supersampling_factor=1,
+            compute_mode="regular",
+            supersampling_convolution=False,
+            convolution_kernel_size=7,
+            convolution_type="fft",
+        )
+        assert numerics.grid_supersampling_factor == 1
+        assert isinstance(numerics.convolution_class, PixelKernelConvolution)
+        assert isinstance(numerics.grid_class, RegularGrid)
+
+        numerics_ref = Numerics_ref(
+            pixel_grid=self.pixel_grid,
+            psf=self.psf_class_pixel,
+            supersampling_factor=1,
+            compute_mode="regular",
+            supersampling_convolution=False,
+            convolution_kernel_size=7,
+            convolution_type="fft",
+        )
+
+        re_size_convolve = numerics.re_size_convolve(self.flux)
+        re_size_convolve_ref = numerics_ref.re_size_convolve(self.flux)
+        npt.assert_array_almost_equal(re_size_convolve, re_size_convolve_ref, decimal=8)
+
+        re_size_convolve = numerics.re_size_convolve(self.flux, unconvolved=True)
+        re_size_convolve_ref = numerics_ref.re_size_convolve(self.flux, unconvolved=True)
+        npt.assert_array_equal(re_size_convolve, re_size_convolve_ref)
+
+
+    def test_supersampling_pixel_psf(self):
+        numerics = Numerics(
+            pixel_grid=self.pixel_grid,
+            psf=self.psf_class_pixel,
+            supersampling_factor=self._supersampling_factor,
+            compute_mode="regular",
+            supersampling_convolution=True,
+            supersampling_kernel_size=5,
+            convolution_kernel_size=9,
+            convolution_type="fft",
+        )
+        assert numerics.grid_supersampling_factor == 5
+        assert isinstance(numerics.convolution_class, SubgridKernelConvolution)
+        assert isinstance(numerics.grid_class, RegularGrid)
+
+        numerics_ref = Numerics_ref(
+            pixel_grid=self.pixel_grid,
+            psf=self.psf_class_pixel,
+            supersampling_factor=self._supersampling_factor,
+            compute_mode="regular",
+            supersampling_convolution=True,
+            supersampling_kernel_size=5,
+            convolution_kernel_size=9,
+            convolution_type="fft",
+        )
+        npt.assert_array_equal(numerics.coordinates_evaluate, numerics_ref.coordinates_evaluate)
+
+        re_size_convolve = numerics.re_size_convolve(self.flux_supersampled)
+        re_size_convolve_ref = numerics_ref.re_size_convolve(self.flux_supersampled)
+        npt.assert_array_almost_equal(re_size_convolve, re_size_convolve_ref, decimal=8)
+
+        re_size_convolve = numerics.re_size_convolve(self.flux_supersampled, unconvolved=True)
+        re_size_convolve_ref = numerics_ref.re_size_convolve(self.flux_supersampled, unconvolved=True)
+        # These should actually be equal but there's some floating point precision nonsense happening
+        npt.assert_array_almost_equal(re_size_convolve, re_size_convolve_ref, decimal=16)
+
+
+    def test_no_supersampling_gaussian_psf(self):
+        numerics = Numerics(
+            pixel_grid=self.pixel_grid,
+            psf=self.psf_class_gaussian,
+            compute_mode="regular",
+            supersampling_factor=1,
+            supersampling_convolution=False,
+            convolution_kernel_size=None,
+        )
+        assert numerics.grid_supersampling_factor == 1
+        assert isinstance(numerics.convolution_class, MultiGaussianConvolution)
+        assert isinstance(numerics.grid_class, RegularGrid)
+
+        numerics_ref = Numerics_ref(
+            pixel_grid=self.pixel_grid,
+            psf=self.psf_class_gaussian,
+            compute_mode="regular",
+            supersampling_factor=1,
+            supersampling_convolution=False,
+            convolution_kernel_size=None,
+        )
+
+        re_size_convolve = numerics.re_size_convolve(self.flux)
+        re_size_convolve_ref = numerics_ref.re_size_convolve(self.flux)
+        npt.assert_array_almost_equal(re_size_convolve, re_size_convolve_ref, decimal=5)
+
+        re_size_convolve = numerics.re_size_convolve(self.flux+5.12838)
+        re_size_convolve_ref = numerics_ref.re_size_convolve(self.flux+5.12838)
+        npt.assert_array_almost_equal(re_size_convolve, re_size_convolve_ref, decimal=5)
+
+        re_size_convolve = numerics.re_size_convolve(self.flux, unconvolved=True)
+        re_size_convolve_ref = numerics_ref.re_size_convolve(self.flux, unconvolved=True)
+        npt.assert_array_equal(re_size_convolve, re_size_convolve_ref)
+
+
+    def test_supersampling_gaussian_psf(self):
+        numerics = Numerics(
+            pixel_grid=self.pixel_grid,
+            psf=self.psf_class_gaussian,
+            supersampling_factor=self._supersampling_factor,
+            compute_mode="regular",
+            supersampling_convolution=True,
+        )
+        assert numerics.grid_supersampling_factor == 5
+        assert isinstance(numerics.convolution_class, MultiGaussianConvolution)
+        assert isinstance(numerics.grid_class, RegularGrid)
+
+        numerics_ref = Numerics_ref(
+            pixel_grid=self.pixel_grid,
+            psf=self.psf_class_gaussian,
+            supersampling_factor=self._supersampling_factor,
+            compute_mode="regular",
+            supersampling_convolution=True,
+        )
+
+        re_size_convolve = numerics.re_size_convolve(self.flux_supersampled)
+        re_size_convolve_ref = numerics_ref.re_size_convolve(self.flux_supersampled)
+        npt.assert_array_almost_equal(re_size_convolve, re_size_convolve_ref, decimal=5)
+
+        re_size_convolve = numerics.re_size_convolve(self.flux_supersampled, unconvolved=True)
+        re_size_convolve_ref = numerics_ref.re_size_convolve(self.flux_supersampled, unconvolved=True)
+        # These should actually be equal but there's some floating point precision nonsense happening
+        npt.assert_array_almost_equal(re_size_convolve, re_size_convolve_ref, decimal=16)
+
+    def test_psf_none(self):
+        numerics = Numerics(
+            pixel_grid=self.pixel_grid,
+            psf=self.psf_class_none,
+        )
+        assert (numerics.convolution_class is None)
+        assert isinstance(numerics.grid_class, RegularGrid)
+
+        numerics_ref = Numerics_ref(
+            pixel_grid=self.pixel_grid,
+            psf=self.psf_class_none,
+        )
+
+        re_size_convolve = numerics.re_size_convolve(self.flux)
+        re_size_convolve_ref = numerics_ref.re_size_convolve(self.flux)
+        npt.assert_array_equal(re_size_convolve, re_size_convolve_ref)
+
+    def test_init_raise_errors(self):
+        npt.assert_raises(TypeError, Numerics, pixel_grid=self.pixel_grid, psf=self.psf_class_none, supersampling_factor=1.0)
+        npt.assert_raises(ValueError, Numerics, pixel_grid=self.pixel_grid, psf=self.psf_class_none, compute_mode="incorrect")
+        npt.assert_raises(ValueError, Numerics, pixel_grid=self.pixel_grid, psf=self.psf_class_none, compute_mode="adaptive")
+        self.psf_class_none.psf_type = "incorrect"
+        npt.assert_raises(ValueError, Numerics, pixel_grid=self.pixel_grid, psf=self.psf_class_none)
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/test/test_ImSim/test_Numerics/test_numerics_subframe.py
+++ b/test/test_ImSim/test_Numerics/test_numerics_subframe.py
@@ -1,0 +1,277 @@
+import pytest
+import jax
+import numpy as np
+import numpy.testing as npt
+
+import lenstronomy.Util.util as util
+import lenstronomy.Util.kernel_util as kernel_util
+
+from jaxtronomy.ImSim.Numerics.convolution import PixelKernelConvolution, SubgridKernelConvolution, MultiGaussianConvolution
+from jaxtronomy.ImSim.Numerics.grid import RegularGrid
+
+from jaxtronomy.ImSim.Numerics.numerics_subframe import NumericsSubFrame
+from lenstronomy.ImSim.Numerics.numerics_subframe import NumericsSubFrame as NumericsSubFrame_ref
+
+from lenstronomy.Data.pixel_grid import PixelGrid
+from lenstronomy.Data.psf import PSF
+from lenstronomy.LightModel.light_model import LightModel
+
+jax.config.update("jax_enable_x64", True)
+
+class TestNumericsSubFrame(object):
+    def setup_method(self):
+        # we define a model consisting of a single Sersic profile
+
+        light_model_list = ["SERSIC_ELLIPSE"]
+        self.lightModel = LightModel(light_model_list=light_model_list)
+        self.kwargs_light = [
+            {
+                "amp": 100,
+                "R_sersic": 0.5,
+                "n_sersic": 3,
+                "e1": -0.3123,
+                "e2": 0.1234,
+                "center_x": 0.02,
+                "center_y": 0,
+            }
+        ]
+
+        # we define a pixel grid and a higher resolution super sampling factor
+        self._supersampling_factor = 5
+        numPix = 60  # cutout pixel size
+        deltaPix = 0.05  # pixel size in arcsec (area per pixel = deltaPix**2)
+        (
+            x,
+            y,
+            ra_at_xy_0,
+            dec_at_xy_0,
+            x_at_radec_0,
+            y_at_radec_0,
+            Mpix2coord,
+            Mcoord2pix,
+        ) = util.make_grid_with_coordtransform(
+            numPix=numPix,
+            deltapix=deltaPix,
+            subgrid_res=1,
+            left_lower=False,
+            inverse=False,
+        )
+        self.flux = self.lightModel.surface_brightness(x, y, kwargs_list=self.kwargs_light)
+
+        (
+            x,
+            y,
+            ra_at_xy_0,
+            dec_at_xy_0,
+            x_at_radec_0,
+            y_at_radec_0,
+            Mpix2coord,
+            Mcoord2pix,
+        ) = util.make_grid_with_coordtransform(
+            numPix=numPix*self._supersampling_factor,
+            deltapix=deltaPix/self._supersampling_factor,
+            subgrid_res=1,
+            left_lower=False,
+            inverse=False,
+        )
+        self.flux_supersampled = self.lightModel.surface_brightness(x, y, kwargs_list=self.kwargs_light)
+
+        self.kernel_super = kernel_util.kernel_gaussian(
+            num_pix=11 * self._supersampling_factor,
+            delta_pix=deltaPix / self._supersampling_factor,
+            fwhm=0.1,
+        )
+
+        kwargs_grid = {
+            "nx": numPix,
+            "ny": numPix,
+            "transform_pix2angle": Mpix2coord,
+            "ra_at_xy_0": ra_at_xy_0,
+            "dec_at_xy_0": dec_at_xy_0,
+        }
+        self.pixel_grid = PixelGrid(**kwargs_grid)
+
+        kwargs_psf_pixel = {
+            "psf_type": "PIXEL",
+            "kernel_point_source": self.kernel_super,
+            "point_source_supersampling_factor": self._supersampling_factor,
+            "kernel_point_source_normalisation": True,
+        }
+        self.psf_class_pixel = PSF(**kwargs_psf_pixel)
+
+        kwargs_psf_gaussian = {
+            "psf_type": "GAUSSIAN",
+            "fwhm": 0.5,
+            "kernel_point_source_normalisation": True,
+        }
+        self.psf_class_gaussian = PSF(**kwargs_psf_gaussian)
+        kwargs_psf_none = {
+            "psf_type": "NONE",
+        }
+        self.psf_class_none = PSF(**kwargs_psf_none)
+
+        self.flux_evaluate_indexes = np.zeros((numPix, numPix), dtype=bool)
+        self.flux_evaluate_indexes[15:45, 15:45] = np.ones((30, 30),dtype=bool)
+        self.flux_evaluate_indexes[30, 30] = False
+
+    def test_no_supersampling_pixel_psf(self):
+        numerics = NumericsSubFrame(
+            pixel_grid=self.pixel_grid,
+            psf=self.psf_class_pixel,
+            flux_evaluate_indexes=self.flux_evaluate_indexes,
+            supersampling_factor=1,
+            compute_mode="regular",
+            supersampling_convolution=False,
+            convolution_kernel_size=7,
+            convolution_type="fft",
+        )
+        assert numerics.grid_supersampling_factor == 1
+        assert isinstance(numerics.convolution_class, PixelKernelConvolution)
+        assert isinstance(numerics.grid_class, RegularGrid)
+
+        numerics_ref = NumericsSubFrame_ref(
+            pixel_grid=self.pixel_grid,
+            psf=self.psf_class_pixel,
+            flux_evaluate_indexes=self.flux_evaluate_indexes,
+            supersampling_factor=1,
+            compute_mode="regular",
+            supersampling_convolution=False,
+            convolution_kernel_size=7,
+            convolution_type="fft",
+        )
+
+        re_size_convolve = numerics.re_size_convolve(self.flux[0:899])
+        re_size_convolve_ref = numerics_ref.re_size_convolve(self.flux[0:899])
+        npt.assert_array_almost_equal(re_size_convolve, re_size_convolve_ref, decimal=8)
+
+        re_size_convolve = numerics.re_size_convolve(self.flux[0:899], unconvolved=True)
+        re_size_convolve_ref = numerics_ref.re_size_convolve(self.flux[0:899], unconvolved=True)
+        npt.assert_array_equal(re_size_convolve, re_size_convolve_ref)
+
+
+    def test_supersampling_pixel_psf(self):
+        numerics = NumericsSubFrame(
+            pixel_grid=self.pixel_grid,
+            psf=self.psf_class_pixel,
+            flux_evaluate_indexes=self.flux_evaluate_indexes,
+            supersampling_factor=self._supersampling_factor,
+            compute_mode="regular",
+            supersampling_convolution=True,
+            supersampling_kernel_size=5,
+            convolution_kernel_size=9,
+            convolution_type="fft",
+        )
+        assert numerics.grid_supersampling_factor == 5
+        assert isinstance(numerics.convolution_class, SubgridKernelConvolution)
+        assert isinstance(numerics.grid_class, RegularGrid)
+
+        numerics_ref = NumericsSubFrame_ref(
+            pixel_grid=self.pixel_grid,
+            psf=self.psf_class_pixel,
+            flux_evaluate_indexes=self.flux_evaluate_indexes,
+            supersampling_factor=self._supersampling_factor,
+            compute_mode="regular",
+            supersampling_convolution=True,
+            supersampling_kernel_size=5,
+            convolution_kernel_size=9,
+            convolution_type="fft",
+        )
+        npt.assert_array_equal(numerics.coordinates_evaluate, numerics_ref.coordinates_evaluate)
+
+        re_size_convolve = numerics.re_size_convolve(self.flux_supersampled[0:22475])
+        re_size_convolve_ref = numerics_ref.re_size_convolve(self.flux_supersampled[0:22475])
+        npt.assert_array_almost_equal(re_size_convolve, re_size_convolve_ref, decimal=8)
+
+        re_size_convolve = numerics.re_size_convolve(self.flux_supersampled[0:22475], unconvolved=True)
+        re_size_convolve_ref = numerics_ref.re_size_convolve(self.flux_supersampled[0:22475], unconvolved=True)
+        # These should actually be equal but there's some floating point precision nonsense happening
+        npt.assert_array_almost_equal(re_size_convolve, re_size_convolve_ref, decimal=16)
+
+
+    def test_no_supersampling_gaussian_psf(self):
+        numerics = NumericsSubFrame(
+            pixel_grid=self.pixel_grid,
+            psf=self.psf_class_gaussian,
+            compute_mode="regular",
+            supersampling_factor=1,
+            supersampling_convolution=False,
+            convolution_kernel_size=None,
+        )
+        assert numerics.grid_supersampling_factor == 1
+        assert isinstance(numerics.convolution_class, MultiGaussianConvolution)
+        assert isinstance(numerics.grid_class, RegularGrid)
+
+        numerics_ref = NumericsSubFrame_ref(
+            pixel_grid=self.pixel_grid,
+            psf=self.psf_class_gaussian,
+            compute_mode="regular",
+            supersampling_factor=1,
+            supersampling_convolution=False,
+            convolution_kernel_size=None,
+        )
+
+        re_size_convolve = numerics.re_size_convolve(self.flux)
+        re_size_convolve_ref = numerics_ref.re_size_convolve(self.flux)
+        npt.assert_array_almost_equal(re_size_convolve, re_size_convolve_ref, decimal=5)
+
+        re_size_convolve = numerics.re_size_convolve(self.flux, unconvolved=True)
+        re_size_convolve_ref = numerics_ref.re_size_convolve(self.flux, unconvolved=True)
+        npt.assert_array_equal(re_size_convolve, re_size_convolve_ref)
+
+
+    def test_supersampling_gaussian_psf(self):
+        numerics = NumericsSubFrame(
+            pixel_grid=self.pixel_grid,
+            psf=self.psf_class_gaussian,
+            supersampling_factor=self._supersampling_factor,
+            compute_mode="regular",
+            supersampling_convolution=True,
+        )
+        assert numerics.grid_supersampling_factor == 5
+        assert isinstance(numerics.convolution_class, MultiGaussianConvolution)
+        assert isinstance(numerics.grid_class, RegularGrid)
+
+        numerics_ref = NumericsSubFrame_ref(
+            pixel_grid=self.pixel_grid,
+            psf=self.psf_class_gaussian,
+            supersampling_factor=self._supersampling_factor,
+            compute_mode="regular",
+            supersampling_convolution=True,
+        )
+
+        re_size_convolve = numerics.re_size_convolve(self.flux_supersampled)
+        re_size_convolve_ref = numerics_ref.re_size_convolve(self.flux_supersampled)
+        npt.assert_array_almost_equal(re_size_convolve, re_size_convolve_ref, decimal=5)
+
+        re_size_convolve = numerics.re_size_convolve(self.flux_supersampled, unconvolved=True)
+        re_size_convolve_ref = numerics_ref.re_size_convolve(self.flux_supersampled, unconvolved=True)
+        # These should actually be equal but there's some floating point precision nonsense happening
+        npt.assert_array_almost_equal(re_size_convolve, re_size_convolve_ref, decimal=16)
+
+    def test_psf_none(self):
+        numerics = NumericsSubFrame(
+            pixel_grid=self.pixel_grid,
+            psf=self.psf_class_none,
+        )
+        assert (numerics.convolution_class is None)
+        assert isinstance(numerics.grid_class, RegularGrid)
+
+        numerics_ref = NumericsSubFrame_ref(
+            pixel_grid=self.pixel_grid,
+            psf=self.psf_class_none,
+        )
+
+        re_size_convolve = numerics.re_size_convolve(self.flux)
+        re_size_convolve_ref = numerics_ref.re_size_convolve(self.flux)
+        npt.assert_array_equal(re_size_convolve, re_size_convolve_ref)
+
+    def test_init_raise_errors(self):
+        npt.assert_raises(TypeError, NumericsSubFrame, pixel_grid=self.pixel_grid, psf=self.psf_class_none, supersampling_factor=1.0)
+        npt.assert_raises(ValueError, NumericsSubFrame, pixel_grid=self.pixel_grid, psf=self.psf_class_none, compute_mode="incorrect")
+        npt.assert_raises(ValueError, NumericsSubFrame, pixel_grid=self.pixel_grid, psf=self.psf_class_none, compute_mode="adaptive")
+        self.psf_class_none.psf_type = "incorrect"
+        npt.assert_raises(ValueError, NumericsSubFrame, pixel_grid=self.pixel_grid, psf=self.psf_class_none)
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/test/test_ImSim/test_Numerics/test_numerics_subframe.py
+++ b/test/test_ImSim/test_Numerics/test_numerics_subframe.py
@@ -9,7 +9,7 @@ import lenstronomy.Util.kernel_util as kernel_util
 from jaxtronomy.ImSim.Numerics.convolution import (
     PixelKernelConvolution,
     SubgridKernelConvolution,
-    MultiGaussianConvolution,
+    GaussianConvolution,
 )
 from jaxtronomy.ImSim.Numerics.grid import RegularGrid
 
@@ -219,7 +219,7 @@ class TestNumericsSubFrame(object):
             convolution_kernel_size=None,
         )
         assert numerics.grid_supersampling_factor == 1
-        assert isinstance(numerics.convolution_class, MultiGaussianConvolution)
+        assert isinstance(numerics.convolution_class, GaussianConvolution)
         assert isinstance(numerics.grid_class, RegularGrid)
 
         numerics_ref = NumericsSubFrame_ref(
@@ -250,7 +250,7 @@ class TestNumericsSubFrame(object):
             supersampling_convolution=True,
         )
         assert numerics.grid_supersampling_factor == 5
-        assert isinstance(numerics.convolution_class, MultiGaussianConvolution)
+        assert isinstance(numerics.convolution_class, GaussianConvolution)
         assert isinstance(numerics.grid_class, RegularGrid)
 
         numerics_ref = NumericsSubFrame_ref(

--- a/test/test_LightModel/test_Profiles/test_gaussian.py
+++ b/test/test_LightModel/test_Profiles/test_gaussian.py
@@ -1,0 +1,289 @@
+__author__ = "sibirrer"
+
+import jax
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from lenstronomy.LightModel.Profiles.gaussian import (
+    Gaussian as Gaussian_ref,
+    GaussianEllipse as GaussianEllipse_ref,
+    MultiGaussian as MultiGaussian_ref,
+    MultiGaussianEllipse as MultiGaussianEllipse_ref
+)
+from jaxtronomy.LightModel.Profiles.gaussian import (
+    Gaussian,
+    GaussianEllipse,
+    MultiGaussian,
+    MultiGaussianEllipse
+)
+
+
+class TestGaussian(object):
+    def setup_method(self):
+        self.profile_ref = Gaussian_ref()
+        self.profile = Gaussian()
+
+    def test_function(self):
+        x = np.array([1])
+        y = np.array([2])
+        amp = 1.3
+        sigma = 0.5
+        values_ref = self.profile_ref.function(x, y, amp, sigma)
+        values = self.profile.function(x, y, amp, sigma)
+        npt.assert_array_almost_equal(values_ref, values, decimal=8)
+
+        x = np.array([0])
+        y = np.array([0])
+        values_ref = self.profile_ref.function(x, y, amp, sigma)
+        values = self.profile.function(x, y, amp, sigma)
+        npt.assert_array_almost_equal(values_ref, values, decimal=7)
+
+        x = np.array([2.0, 3.0, 4.0])
+        y = np.array([1.0, 1.0, 1.0])
+        values_ref = self.profile_ref.function(x, y, amp, sigma)
+        values = self.profile.function(x, y, amp, sigma)
+        npt.assert_array_almost_equal(values_ref, values, decimal=8)
+
+    def test_total_flux(self):
+        amp = 1.3
+        sigma = 0.5
+        values_ref = self.profile_ref.total_flux(amp, sigma)
+        values = self.profile.total_flux(amp, sigma)
+        npt.assert_equal(values_ref, values)
+        npt.assert_equal(amp, values)
+
+    def test_light_3d(self):
+        r = np.array([2])
+        amp = 1.387344
+        sigma = 0.74385
+        values_ref = self.profile_ref.light_3d(r, amp, sigma)
+        values = self.profile.light_3d(r, amp, sigma)
+        npt.assert_array_almost_equal(values_ref, values, decimal=8)
+
+        r = np.array([3.534])
+        amp = 1.387344
+        sigma = 0.74385
+        values_ref = self.profile_ref.light_3d(r, amp, sigma)
+        values = self.profile.light_3d(r, amp, sigma)
+        npt.assert_array_almost_equal(values_ref, values, decimal=8)
+
+        r = np.array([2, 9.2398, 2.183])
+        amp = 2.387344
+        sigma = 1.74385
+        values_ref = self.profile_ref.light_3d(r, amp, sigma)
+        values = self.profile.light_3d(r, amp, sigma)
+        npt.assert_array_almost_equal(values_ref, values, decimal=8)
+
+class TestGaussianEllipse(object):
+    def setup_method(self):
+        self.profile_ref = GaussianEllipse_ref()
+        self.profile = GaussianEllipse()
+
+    def test_function(self):
+        x = np.array([1])
+        y = np.array([2])
+        amp = 1.3
+        sigma = 0.5
+        e1 = 0.1
+        e2 = -0.3
+        values_ref = self.profile_ref.function(x, y, amp, sigma, e1, e2)
+        values = self.profile.function(x, y, amp, sigma, e1, e2)
+        npt.assert_array_almost_equal(values_ref, values, decimal=8)
+
+        x = np.array([0])
+        y = np.array([0])
+        values_ref = self.profile_ref.function(x, y, amp, sigma, e1, e2)
+        values = self.profile.function(x, y, amp, sigma, e1, e2)
+        npt.assert_array_almost_equal(values_ref, values, decimal=7)
+
+        x = np.array([2.0, 3.0, 4.0])
+        y = np.array([1.0, 1.0, 1.0])
+        values_ref = self.profile_ref.function(x, y, amp, sigma, e1, e2)
+        values = self.profile.function(x, y, amp, sigma, e1, e2)
+        npt.assert_array_almost_equal(values_ref, values, decimal=8)
+
+    def test_total_flux(self):
+        amp = 1.3
+        sigma = 0.5
+        values_ref = self.profile_ref.total_flux(amp, sigma)
+        values = self.profile.total_flux(amp, sigma)
+        npt.assert_equal(values_ref, values)
+        npt.assert_equal(amp, values)
+
+    def test_light_3d(self):
+        r = np.array([2])
+        amp = 1.387344
+        sigma = 0.74385
+        values_ref = self.profile_ref.light_3d(r, amp, sigma)
+        values = self.profile.light_3d(r, amp, sigma)
+        npt.assert_array_almost_equal(values_ref, values, decimal=8)
+
+        r = np.array([3.534])
+        values_ref = self.profile_ref.light_3d(r, amp, sigma)
+        values = self.profile.light_3d(r, amp, sigma)
+        npt.assert_array_almost_equal(values_ref, values, decimal=8)
+
+        r = np.array([2, 9.2398, 2.183])
+        amp = 2.387344
+        sigma = 1.74385
+        values_ref = self.profile_ref.light_3d(r, amp, sigma)
+        values = self.profile.light_3d(r, amp, sigma)
+        npt.assert_array_almost_equal(values_ref, values, decimal=8)
+
+class TestMultiGaussian(object):
+    def setup_method(self):
+        self.profile_ref = MultiGaussian_ref()
+        self.profile = MultiGaussian()
+
+    def test_function(self):
+        x = np.array([1.])
+        y = np.array([2.])
+        amp = [1.3, 1.5, 2.3]
+        sigma = [0.5, 1.1, 3.7]
+        values_ref = self.profile_ref.function(x, y, amp, sigma)
+        values = self.profile.function(x, y, amp, sigma)
+        npt.assert_array_almost_equal(values_ref, values, decimal=8)
+
+        x = np.array([0.])
+        y = np.array([0.])
+        values_ref = self.profile_ref.function(x, y, amp, sigma)
+        values = self.profile.function(x, y, amp, sigma)
+        npt.assert_array_almost_equal(values_ref, values, decimal=7)
+
+        x = np.array([2.0, 3.0, 4.0])
+        y = np.array([1.0, 1.0, 1.0])
+        values_ref = self.profile_ref.function(x, y, amp, sigma)
+        values = self.profile.function(x, y, amp, sigma)
+        npt.assert_array_almost_equal(values_ref, values, decimal=8)
+
+    def test_function_split(self):
+        x = np.array([1.2345])
+        y = np.array([2.2345123])
+        amp = [1.3656, 1.51432, 2.34123]
+        sigma = [0.55678, 1.19876, 3.745567]
+        values_ref = self.profile_ref.function_split(x, y, amp, sigma)
+        values = self.profile.function_split(x, y, amp, sigma)
+        npt.assert_array_almost_equal(values_ref, values, decimal=8)
+
+        x = np.array([0.])
+        y = np.array([0.])
+        values_ref = self.profile_ref.function_split(x, y, amp, sigma)
+        values = self.profile.function_split(x, y, amp, sigma)
+        npt.assert_array_almost_equal(values_ref, values, decimal=7)
+
+        x = np.array([2.0354, 3.0567, 4.0345])
+        y = np.array([1.0456, 1.0876, 1.0876])
+        values_ref = self.profile_ref.function_split(x, y, amp, sigma)
+        values = self.profile.function_split(x, y, amp, sigma)
+        npt.assert_array_almost_equal(values_ref, values, decimal=8)
+
+    def test_total_flux(self):
+        amp = [1.3, 1.5, 2.3]
+        sigma = [0.5, 1.1, 3.7]
+        values_ref = self.profile_ref.total_flux(amp, sigma)
+        values = self.profile.total_flux(amp, sigma)
+        npt.assert_array_almost_equal(values_ref, values, decimal=7)
+        npt.assert_array_almost_equal(np.sum(amp), values, decimal=7)
+
+    def test_light_3d(self):
+        r = np.array([2.])
+        amp = [1.3, 1.5, 2.3]
+        sigma = [0.5, 1.1, 3.7]
+        values_ref = self.profile_ref.light_3d(r, amp, sigma)
+        values = self.profile.light_3d(r, amp, sigma)
+        npt.assert_array_almost_equal(values_ref, values, decimal=8)
+
+        r = np.array([3.534])
+        values_ref = self.profile_ref.light_3d(r, amp, sigma)
+        values = self.profile.light_3d(r, amp, sigma)
+        npt.assert_array_almost_equal(values_ref, values, decimal=8)
+
+        r = np.array([2, 9.2398, 2.183])
+        values_ref = self.profile_ref.light_3d(r, amp, sigma)
+        values = self.profile.light_3d(r, amp, sigma)
+        npt.assert_array_almost_equal(values_ref, values, decimal=8)
+
+class TestMultiGaussianEllipse(object):
+    def setup_method(self):
+        self.profile_ref = MultiGaussianEllipse_ref()
+        self.profile = MultiGaussianEllipse()
+
+    def test_function(self):
+        x = np.array([1.])
+        y = np.array([2.])
+        amp = [1.3, 1.5, 2.3]
+        sigma = [0.5, 1.1, 3.7]
+        e1 = 0.1345236
+        e2 = -0.33452
+        values_ref = self.profile_ref.function(x, y, amp, sigma, e1, e2)
+        values = self.profile.function(x, y, amp, sigma, e1, e2)
+        npt.assert_array_almost_equal(values_ref, values, decimal=8)
+
+        x = np.array([0.])
+        y = np.array([0.])
+        values_ref = self.profile_ref.function(x, y, amp, sigma, e1, e2)
+        values = self.profile.function(x, y, amp, sigma, e1, e2)
+        npt.assert_array_almost_equal(values_ref, values, decimal=7)
+
+        x = np.array([2.0, 3.0, 4.0])
+        y = np.array([1.0, 1.0, 1.0])
+        values_ref = self.profile_ref.function(x, y, amp, sigma, e1, e2)
+        values = self.profile.function(x, y, amp, sigma, e1, e2)
+        npt.assert_array_almost_equal(values_ref, values, decimal=8)
+
+    def test_function_split(self):
+        x = np.array([1.4568])
+        y = np.array([2.8567])
+        amp = [1.3, 1.5, 2.3]
+        sigma = [0.5, 1.1, 3.7]
+        e1 = 0.1345236
+        e2 = -0.33452
+        values_ref = self.profile_ref.function_split(x, y, amp, sigma, e1, e2)
+        values = self.profile.function_split(x, y, amp, sigma, e1, e2)
+        npt.assert_array_almost_equal(values_ref, values, decimal=8)
+
+        x = np.array([0.])
+        y = np.array([0.])
+        values_ref = self.profile_ref.function_split(x, y, amp, sigma, e1, e2)
+        values = self.profile.function_split(x, y, amp, sigma, e1, e2)
+        npt.assert_array_almost_equal(values_ref, values, decimal=7)
+
+        x = np.array([2.02345, 3.01234, 4.02345])
+        y = np.array([1.01234, 1.05234, 1.02345])
+        values_ref = self.profile_ref.function_split(x, y, amp, sigma, e1, e2)
+        values = self.profile.function_split(x, y, amp, sigma, e1, e2)
+        npt.assert_array_almost_equal(values_ref, values, decimal=8)
+
+    def test_total_flux(self):
+        amp = [1.3, 1.5, 2.3]
+        sigma = [0.5, 1.1, 3.7]
+        e1 = 0.1345236
+        e2 = -0.33452
+        values_ref = self.profile_ref.total_flux(amp, sigma, e1, e2)
+        values = self.profile.total_flux(amp, sigma, e1, e2)
+        npt.assert_array_almost_equal(values_ref, values, decimal=7)
+        npt.assert_array_almost_equal(np.sum(amp), values, decimal=7)
+
+    def test_light_3d(self):
+        r = np.array([2.])
+        amp = [1.3, 1.5, 2.3]
+        sigma = [0.5, 1.1, 3.7]
+        values_ref = self.profile_ref.light_3d(r, amp, sigma)
+        values = self.profile.light_3d(r, amp, sigma)
+        npt.assert_array_almost_equal(values_ref, values, decimal=8)
+
+        r = np.array([3.534])
+        values_ref = self.profile_ref.light_3d(r, amp, sigma)
+        values = self.profile.light_3d(r, amp, sigma)
+        npt.assert_array_almost_equal(values_ref, values, decimal=8)
+
+        r = np.array([2, 9.2398, 2.183])
+        values_ref = self.profile_ref.light_3d(r, amp, sigma)
+        values = self.profile.light_3d(r, amp, sigma)
+        npt.assert_array_almost_equal(values_ref, values, decimal=8)
+
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/test/test_LightModel/test_light_model.py
+++ b/test/test_LightModel/test_light_model.py
@@ -112,17 +112,18 @@ class TestLightModel(object):
         light_model_list = [
             "SERSIC",
             "SERSIC_ELLIPSE",
+            "MULTI_GAUSSIAN"
         ]
         kwargs_list = [
             {
-                "amp": 1,
+                "amp": 1.1234,
                 "R_sersic": 0.5,
                 "n_sersic": 1,
                 "center_x": 0,
                 "center_y": 0,
             },  # 'SERSIC'
             {
-                "amp": 1,
+                "amp": 1.345,
                 "R_sersic": 0.5,
                 "n_sersic": 1,
                 "e1": 0.1,
@@ -130,13 +131,19 @@ class TestLightModel(object):
                 "center_x": 0,
                 "center_y": 0,
             },  # 'SERSIC_ELLIPSE'
+            {
+                "amp": [1.3894, 32.298324, 21.23498],
+                "sigma": [0.5, 1.5, 2],
+                "center_x": 0.234,
+                "center_y": -1.98342
+            } # MULTI_GAUSSIAN
         ]
         lightModel = LightModel(light_model_list=light_model_list)
         lightModel_ref = LightModel_ref(light_model_list=light_model_list)
         total_flux_list = lightModel.total_flux(kwargs_list)
         total_flux_list_ref = lightModel_ref.total_flux(kwargs_list)
         npt.assert_array_almost_equal(
-            np.array(total_flux_list), np.array(total_flux_list_ref)
+            np.array(total_flux_list), np.array(total_flux_list_ref), decimal=5
         )
 
         lightModel = LightModel(light_model_list=light_model_list)

--- a/test/test_LightModel/test_light_model.py
+++ b/test/test_LightModel/test_light_model.py
@@ -1,6 +1,7 @@
 __author__ = "sibirrer"
 
 from jaxtronomy.LightModel.light_model import LightModel
+from jaxtronomy.LightModel.light_model_base import _JAXXED_MODELS
 from lenstronomy.LightModel.light_model import LightModel as LightModel_ref
 
 import numpy as np
@@ -57,6 +58,9 @@ class TestLightModel(object):
             light_model_list=self.light_model_list, sersic_major_axis=False
         )
         test_sersic_ellipse_qphi = LightModel(["SERSIC_ELLIPSE_Q_PHI"])
+
+    def test_import_profiles(self):
+        lightModel = LightModel(light_model_list=_JAXXED_MODELS)
 
     def test_surface_brightness(self):
         x = 1.0

--- a/test/test_Util/test_util.py
+++ b/test/test_Util/test_util.py
@@ -35,6 +35,11 @@ def test_displaceAbs():
     result_ref = util_ref.displaceAbs(x, y, sourcePos_x, sourcePos_y)
     npt.assert_array_almost_equal(result, result_ref, decimal=7)
 
+def test_fwhm2sigma():
+    fwhm = np.array([0.32345, 1.0, 2.3, 3.5, 4.7])
+    sigma = util.fwhm2sigma(fwhm)
+    sigma_ref = util_ref.fwhm2sigma(fwhm)
+    npt.assert_array_almost_equal(sigma, sigma_ref, decimal=8)
 
 def test_image2array():
     x = np.array([[0, 1, 2], [5, 7, 3], [1, 5, 8]], dtype=float)
@@ -50,6 +55,12 @@ def test_rotate():
     result = util.rotate(x, y, angle)
     result_ref = util_ref.rotate(x, y, angle)
     npt.assert_array_almost_equal(result, result_ref, decimal=8)
+
+def test_sigma2fwhm():
+    sigma = np.array([0.32345, 1.0, 2.3, 3.5, 4.7])
+    fwhm = util.sigma2fwhm(sigma)
+    fwhm_ref = util_ref.sigma2fwhm(sigma)
+    npt.assert_array_almost_equal(fwhm, fwhm_ref, decimal=8)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR accomplishes 3 things:

1. Gaussian light models have been implemented
2. Gaussian convolution is now implemented in jaxtronomy. Previously, it was not implemented due to the jax.scipy library not having the scipy.ndimage.gaussian_filter function which is used in lenstronomy. In jaxtronomy, the gaussian convolution is done without this function. It is a quite a bit slower than the lenstronomy version due to the jnp.pad function being very slow, but it is now compatible with autodifferentiation.
3. Numerics and NumericsSubFrame have been implemented.