### PR TITLE
implement image likelihood and likelihood module

### DIFF
--- a/jaxtronomy/ImSim/MultiBand/single_band_multi_model.py
+++ b/jaxtronomy/ImSim/MultiBand/single_band_multi_model.py
@@ -269,8 +269,8 @@ class SingleBandMultiModel(ImageModel):
         check_positive_flux=False,
         linear_solver=False,
     ):
-        """Computes the log likelihood of the data given a model. The model kwargs are used
-        to simulate an image which is compared to the data image.
+        """Computes the log likelihood of the data given a model. The model kwargs are
+        used to simulate an image which is compared to the data image.
 
         :param kwargs_lens: list of keyword arguments corresponding to the superposition
             of different lens profiles

--- a/jaxtronomy/ImSim/MultiBand/single_band_multi_model.py
+++ b/jaxtronomy/ImSim/MultiBand/single_band_multi_model.py
@@ -269,8 +269,8 @@ class SingleBandMultiModel(ImageModel):
         check_positive_flux=False,
         linear_solver=False,
     ):
-        """Computes the likelihood of the data given a model. This is specified with the
-        non-linear parameters and a linear inversion and prior marginalisation.
+        """Computes the log likelihood of the data given a model. The model kwargs are used
+        to simulate an image which is compared to the data image.
 
         :param kwargs_lens: list of keyword arguments corresponding to the superposition
             of different lens profiles

--- a/jaxtronomy/ImSim/image_model.py
+++ b/jaxtronomy/ImSim/image_model.py
@@ -107,7 +107,7 @@ class ImageModel(object):
                 self.PointSource.point_source_type_list
             )
         self._psf_error_map_bool_list = psf_error_map_bool_list
-        self._psf_error_map = self.PSF.psf_error_map_bool
+        self._psf_error_map = self.PSF.psf_variance_map_bool
         if self._psf_error_map:
             raise ValueError("psf error map not supported in jaxtronomy")
 

--- a/jaxtronomy/Sampling/Likelihoods/image_likelihood.py
+++ b/jaxtronomy/Sampling/Likelihoods/image_likelihood.py
@@ -69,16 +69,22 @@ class ImageLikelihood(object):
         kwargs_extinction=None,
         **kwargs,
     ):
-        """Computes the log likelihood of the data given a model. The model kwargs are used
-        to simulate an image which is compared to the data image.
+        """Computes the log likelihood of the data given a model. The model kwargs are
+        used to simulate an image which is compared to the data image.
 
-        :param kwargs_lens: lens model keyword argument list according to LensModel module
-        :param kwargs_source: source light keyword argument list according to LightModel module
-        :param kwargs_lens_light: deflector light (not lensed) keyword argument list according to LightModel module
-        :param kwargs_ps: point source keyword argument list according to PointSource module
+        :param kwargs_lens: lens model keyword argument list according to LensModel
+            module
+        :param kwargs_source: source light keyword argument list according to LightModel
+            module
+        :param kwargs_lens_light: deflector light (not lensed) keyword argument list
+            according to LightModel module
+        :param kwargs_ps: point source keyword argument list according to PointSource
+            module
         :param kwargs_special: special keyword argument list as part of the Param module
-        :param kwargs_extinction: extinction parameter keyword argument list according to LightModel module
-        :return: log likelihood of the data given the model, linear parameter inversion list (None in jaxtronomy)
+        :param kwargs_extinction: extinction parameter keyword argument list according
+            to LightModel module
+        :return: log likelihood of the data given the model, linear parameter inversion
+            list (None in jaxtronomy)
         """
         logL, param = self.imSim.likelihood_data_given_model(
             kwargs_lens,

--- a/jaxtronomy/Sampling/Likelihoods/image_likelihood.py
+++ b/jaxtronomy/Sampling/Likelihoods/image_likelihood.py
@@ -1,0 +1,103 @@
+from functools import partial
+from jax import jit, numpy as jnp
+from jaxtronomy.Util import class_creator
+
+__all__ = ["ImageLikelihood"]
+
+
+class ImageLikelihood(object):
+    """Manages imaging data likelihoods."""
+
+    def __init__(
+        self,
+        multi_band_list,
+        multi_band_type,
+        kwargs_model,
+        bands_compute=None,
+        image_likelihood_mask_list=None,
+        source_marg=False,
+        linear_prior=None,
+        check_positive_flux=False,
+        kwargs_pixelbased=None,
+        linear_solver=False,
+    ):
+        """
+        :param multi_band_list: list of imaging band configurations [[kwargs_data, kwargs_psf, kwargs_numerics],[...], ...]
+        :param multi_band_type: string, can be "single-band" only in jaxtronomy. "multi-linear" and "joint-liner" not supported yet
+        :param kwargs_model: dict containing model option keyword arguments. See arguments to class_creator.create_class_instances() for options.
+        :param bands_compute: list of bools with same length as multi_band_list, indicates which "band" to include in the
+            fitting. Only relevant for joint-linear and multi-liner. For single-band, the band index is zero by default.
+        :param image_likelihood_mask_list: list of boolean 2d arrays of size of images marking the pixels to be
+            evaluated in the likelihood
+        :param source_marg: should be None; not supported in jaxtronomy
+        :param linear_prior: should be None; not supported in jaxtronomy
+        :param check_positive_flux: bool, should be False. True is not supported in jaxtronomy
+        :param kwargs_pixelbased: should be None; not supported in jaxtronomy
+        :param linear_solver: bool, should be False. True is not supported in jaxtronomy
+        """
+
+        self.imSim = class_creator.create_im_sim(
+            multi_band_list,
+            multi_band_type,
+            kwargs_model,
+            bands_compute=bands_compute,
+            image_likelihood_mask_list=image_likelihood_mask_list,
+            kwargs_pixelbased=kwargs_pixelbased,
+            linear_solver=linear_solver,
+        )
+        self._model_type = self.imSim.type
+        self._source_marg = source_marg
+        self._linear_prior = linear_prior
+        self._check_positive_flux = check_positive_flux
+
+    @partial(jit, static_argnums=0)
+    def logL(
+        self,
+        kwargs_lens=None,
+        kwargs_source=None,
+        kwargs_lens_light=None,
+        kwargs_ps=None,
+        kwargs_special=None,
+        kwargs_extinction=None,
+        **kwargs,
+    ):
+        """
+
+        :param kwargs_lens: lens model keyword argument list according to LensModel module
+        :param kwargs_source: source light keyword argument list according to LightModel module
+        :param kwargs_lens_light: deflector light (not lensed) keyword argument list according to LightModel module
+        :param kwargs_ps: point source keyword argument list according to PointSource module
+        :param kwargs_special: special keyword argument list as part of the Param module
+        :param kwargs_extinction: extinction parameter keyword argument list according to LightModel module
+        :return: log likelihood of the data given the model, linear parameter inversion list
+        """
+        logL, param = self.imSim.likelihood_data_given_model(
+            kwargs_lens,
+            kwargs_source,
+            kwargs_lens_light,
+            kwargs_ps,
+            kwargs_extinction=kwargs_extinction,
+            kwargs_special=kwargs_special,
+            source_marg=self._source_marg,
+            linear_prior=self._linear_prior,
+            check_positive_flux=self._check_positive_flux,
+        )
+        logL = jnp.nan_to_num(logL, nan=-(10**15))
+        return logL, param
+
+    @property
+    def num_data(self):
+        """
+
+        :return: number of image data points
+        """
+        return self.imSim.num_data_evaluate
+
+    # TODO: Implement point source
+    #def reset_point_source_cache(self, cache=True):
+    #    """
+
+    #    :param cache: boolean
+    #    :return: None
+    #    """
+    #    self.imSim.reset_point_source_cache(cache=cache)

--- a/jaxtronomy/Sampling/Likelihoods/image_likelihood.py
+++ b/jaxtronomy/Sampling/Likelihoods/image_likelihood.py
@@ -69,7 +69,8 @@ class ImageLikelihood(object):
         kwargs_extinction=None,
         **kwargs,
     ):
-        """
+        """Computes the log likelihood of the data given a model. The model kwargs are used
+        to simulate an image which is compared to the data image.
 
         :param kwargs_lens: lens model keyword argument list according to LensModel module
         :param kwargs_source: source light keyword argument list according to LightModel module

--- a/jaxtronomy/Sampling/Likelihoods/image_likelihood.py
+++ b/jaxtronomy/Sampling/Likelihoods/image_likelihood.py
@@ -88,7 +88,7 @@ class ImageLikelihood(object):
             kwargs_special=kwargs_special,
             source_marg=False,
             linear_prior=None,
-            check_positive_flux=False
+            check_positive_flux=False,
         )
         logL = jnp.nan_to_num(logL, nan=-(10**15))
         return logL, param

--- a/jaxtronomy/Sampling/Likelihoods/image_likelihood.py
+++ b/jaxtronomy/Sampling/Likelihoods/image_likelihood.py
@@ -25,8 +25,8 @@ class ImageLikelihood(object):
         :param multi_band_list: list of imaging band configurations [[kwargs_data, kwargs_psf, kwargs_numerics],[...], ...]
         :param multi_band_type: string, can be "single-band" only in jaxtronomy. "multi-linear" and "joint-liner" not supported yet
         :param kwargs_model: dict containing model option keyword arguments. See arguments to class_creator.create_class_instances() for options.
-        :param bands_compute: list of bools with same length as multi_band_list, indicates which "band" to include in the
-            fitting. Only relevant for joint-linear and multi-liner. For single-band, the band index is zero by default.
+        :param bands_compute: Should be None. Only relevant for joint-linear and multi-linear, which are not supported in jaxtronomy.
+            For single-band, the band index is zero by default.
         :param image_likelihood_mask_list: list of boolean 2d arrays of size of images marking the pixels to be
             evaluated in the likelihood
         :param source_marg: should be False; not supported in jaxtronomy
@@ -77,7 +77,7 @@ class ImageLikelihood(object):
         :param kwargs_ps: point source keyword argument list according to PointSource module
         :param kwargs_special: special keyword argument list as part of the Param module
         :param kwargs_extinction: extinction parameter keyword argument list according to LightModel module
-        :return: log likelihood of the data given the model, linear parameter inversion list
+        :return: log likelihood of the data given the model, linear parameter inversion list (None in jaxtronomy)
         """
         logL, param = self.imSim.likelihood_data_given_model(
             kwargs_lens,

--- a/jaxtronomy/Sampling/Likelihoods/image_likelihood.py
+++ b/jaxtronomy/Sampling/Likelihoods/image_likelihood.py
@@ -29,12 +29,23 @@ class ImageLikelihood(object):
             fitting. Only relevant for joint-linear and multi-liner. For single-band, the band index is zero by default.
         :param image_likelihood_mask_list: list of boolean 2d arrays of size of images marking the pixels to be
             evaluated in the likelihood
-        :param source_marg: should be None; not supported in jaxtronomy
+        :param source_marg: should be False; not supported in jaxtronomy
         :param linear_prior: should be None; not supported in jaxtronomy
         :param check_positive_flux: bool, should be False. True is not supported in jaxtronomy
         :param kwargs_pixelbased: should be None; not supported in jaxtronomy
         :param linear_solver: bool, should be False. True is not supported in jaxtronomy
         """
+
+        if source_marg != False:
+            raise ValueError("source_marg not supported in jaxtronomy")
+        if linear_prior is not None:
+            raise ValueError("linear_prior not supported in jaxtronomy")
+        if check_positive_flux != False:
+            raise ValueError("check_positive_flux not supported in jaxtronomy")
+        if kwargs_pixelbased is not None:
+            raise ValueError("pixelbased solver not supported in jaxtronomy")
+        if linear_solver != False:
+            raise ValueError("linear_solver not supported in jaxtronomy")
 
         self.imSim = class_creator.create_im_sim(
             multi_band_list,
@@ -46,9 +57,6 @@ class ImageLikelihood(object):
             linear_solver=linear_solver,
         )
         self._model_type = self.imSim.type
-        self._source_marg = source_marg
-        self._linear_prior = linear_prior
-        self._check_positive_flux = check_positive_flux
 
     @partial(jit, static_argnums=0)
     def logL(
@@ -78,9 +86,9 @@ class ImageLikelihood(object):
             kwargs_ps,
             kwargs_extinction=kwargs_extinction,
             kwargs_special=kwargs_special,
-            source_marg=self._source_marg,
-            linear_prior=self._linear_prior,
-            check_positive_flux=self._check_positive_flux,
+            source_marg=False,
+            linear_prior=None,
+            check_positive_flux=False
         )
         logL = jnp.nan_to_num(logL, nan=-(10**15))
         return logL, param

--- a/jaxtronomy/Sampling/likelihood.py
+++ b/jaxtronomy/Sampling/likelihood.py
@@ -308,7 +308,7 @@ class LikelihoodModule(object):
         kwargs_return = self.param.args2kwargs(args, jax=True)
 
         logL = jnp.where(
-            bound_hit, -(10.0**10), self.log_likelihood(kwargs_return, verbose=verbose)
+            bound_hit, -(10.0**18), self.log_likelihood(kwargs_return, verbose=verbose)
         )
         return logL
 

--- a/jaxtronomy/Sampling/likelihood.py
+++ b/jaxtronomy/Sampling/likelihood.py
@@ -132,7 +132,9 @@ class LikelihoodModule(object):
             or astrometric_likelihood
         ):
             raise ValueError(
-                "Only image_likelihood is currently supported in JAXtronomy"
+                "Only image_likelihood is currently supported in JAXtronomy.\n"
+                "tracer, image_position, source_position, flux_ratio, kinematic_2d, and astrometric \n"
+                "likelihoods are not currently supported and should be set to False."
             )
         # TODO unpack also tracer model from kwargs_data
         (

--- a/jaxtronomy/Sampling/likelihood.py
+++ b/jaxtronomy/Sampling/likelihood.py
@@ -305,7 +305,7 @@ class LikelihoodModule(object):
             )
 
         # extract parameters
-        kwargs_return = self.param.args2kwargs(args)
+        kwargs_return = self.param.args2kwargs(args, jax=True)
 
         logL = jnp.where(
             bound_hit, -(10.0**10), self.log_likelihood(kwargs_return, verbose=verbose)

--- a/jaxtronomy/Sampling/likelihood.py
+++ b/jaxtronomy/Sampling/likelihood.py
@@ -123,15 +123,17 @@ class LikelihoodModule(object):
             derived from imaging or spectroscopy
         """
         if (
-            time_delay_likelihood or 
-            tracer_likelihood or 
-            image_position_likelihood or
-            source_position_likelihood or
-            flux_ratio_likelihood or 
-            kinematic_2d_likelihood or
-            astrometric_likelihood
+            time_delay_likelihood
+            or tracer_likelihood
+            or image_position_likelihood
+            or source_position_likelihood
+            or flux_ratio_likelihood
+            or kinematic_2d_likelihood
+            or astrometric_likelihood
         ):
-            raise ValueError("Only image_likelihood is currently supported in JAXtronomy")
+            raise ValueError(
+                "Only image_likelihood is currently supported in JAXtronomy"
+            )
         # TODO unpack also tracer model from kwargs_data
         (
             multi_band_list,
@@ -285,7 +287,7 @@ class LikelihoodModule(object):
     def __call__(self, a):
         return self.logL(a)
 
-    @partial(jit, static_argnums=(0,2))
+    @partial(jit, static_argnums=(0, 2))
     def logL(self, args, verbose=False):
         """Routine to compute X2 given variable parameters for a MCMC/PSO chain.
 
@@ -305,10 +307,12 @@ class LikelihoodModule(object):
         # extract parameters
         kwargs_return = self.param.args2kwargs(args)
 
-        logL = jnp.where(bound_hit, -(10.0**10), self.log_likelihood(kwargs_return, verbose=verbose))
+        logL = jnp.where(
+            bound_hit, -(10.0**10), self.log_likelihood(kwargs_return, verbose=verbose)
+        )
         return logL
 
-    @partial(jit, static_argnums=(0,2))
+    @partial(jit, static_argnums=(0, 2))
     def log_likelihood(self, kwargs_return, verbose=False):
         """
 
@@ -365,16 +369,22 @@ class LikelihoodModule(object):
         lowerLimit = jnp.atleast_1d(jnp.array(lowerLimit))
         upperLimit = jnp.atleast_1d(jnp.array(upperLimit))
 
-        bound_hit_array = jnp.where(args < lowerLimit, True, jnp.where(args > upperLimit, True, False))
+        bound_hit_array = jnp.where(
+            args < lowerLimit, True, jnp.where(args > upperLimit, True, False)
+        )
         bound_hit = jnp.any(bound_hit_array)
         penalty = jnp.where(bound_hit, 10.0**5, 0.0)
 
         if verbose is True:
+
             def true_fun():
                 i = jnp.nonzero(bound_hit_array, size=1)[0][0]
                 jax.debug.print(
-                    "parameter args[{}] with value {} hit the bounds [{}, {}] "
-                    , i, args[i], lowerLimit[i], upperLimit[i]
+                    "parameter args[{}] with value {} hit the bounds [{}, {}] ",
+                    i,
+                    args[i],
+                    lowerLimit[i],
+                    upperLimit[i],
                 )
 
             def false_fun():
@@ -458,9 +468,8 @@ class LikelihoodModule(object):
             tracer_data,
         )
 
-    #def _reset_point_source_cache(self, bool_input=True):
+    # def _reset_point_source_cache(self, bool_input=True):
     #    self.PointSource.delete_lens_model_cache()
     #    self.PointSource.set_save_cache(bool_input)
     #    if self._image_likelihood is True:
     #        self.image_likelihood.reset_point_source_cache(bool_input)
-

--- a/jaxtronomy/Sampling/likelihood.py
+++ b/jaxtronomy/Sampling/likelihood.py
@@ -1,0 +1,466 @@
+__author__ = "sibirrer"
+
+from jaxtronomy.Sampling.Likelihoods.image_likelihood import ImageLikelihood
+from lenstronomy.Sampling.Likelihoods.prior_likelihood import PriorLikelihood
+
+# TODO: Implement other Likelihood classes intro jaxtronomy
+# Currently, only image likelihood is supported.
+
+import jaxtronomy.Util.class_creator as class_creator
+import jax
+from jax import jit, lax, numpy as jnp
+from functools import partial
+
+__all__ = ["LikelihoodModule"]
+
+
+class LikelihoodModule(object):
+    """This class contains the routines to run a MCMC process.
+
+    the key components are:
+    - imSim_class: an instance of a class that simulates one (or more) images and returns the likelihood, such as
+    ImageModel(), Multiband(), MultiExposure()
+    - param_class: instance of a Param() class that can cast the sorted list of parameters that are sampled into the
+    conventions of the imSim_class
+
+    Additional arguments are supported for adding a time-delay likelihood etc (see __init__ definition)
+    """
+
+    def __init__(
+        self,
+        kwargs_data_joint,
+        kwargs_model,
+        param_class,
+        image_likelihood=True,
+        check_bounds=False,
+        astrometric_likelihood=False,
+        image_position_likelihood=False,
+        source_position_likelihood=False,
+        image_position_uncertainty=0.004,
+        check_positive_flux=False,
+        source_position_tolerance=0.001,
+        source_position_sigma=0.001,
+        force_no_add_image=False,
+        source_marg=False,
+        linear_prior=None,
+        restrict_image_number=False,
+        max_num_images=None,
+        bands_compute=None,
+        time_delay_likelihood=False,
+        image_likelihood_mask_list=None,
+        flux_ratio_likelihood=False,
+        kwargs_flux_compute=None,
+        prior_lens=None,
+        prior_source=None,
+        prior_extinction=None,
+        prior_lens_light=None,
+        prior_ps=None,
+        prior_special=None,
+        prior_lens_kde=None,
+        prior_source_kde=None,
+        prior_lens_light_kde=None,
+        prior_ps_kde=None,
+        prior_special_kde=None,
+        prior_extinction_kde=None,
+        prior_lens_lognormal=None,
+        prior_source_lognormal=None,
+        prior_extinction_lognormal=None,
+        prior_lens_light_lognormal=None,
+        prior_ps_lognormal=None,
+        prior_special_lognormal=None,
+        custom_logL_addition=None,
+        kwargs_pixelbased=None,
+        kinematic_2d_likelihood=False,
+        kin_lens_idx=0,
+        kin_lens_light_idx=0,
+        tracer_likelihood=False,
+        tracer_likelihood_mask=None,
+    ):
+        """Initializing class.
+
+        :param param_class: instance of a Param() class that can cast the sorted list of
+            parameters that are sampled into the conventions of the imSim_class
+        :param image_likelihood: bool, option to compute the imaging likelihood
+        :param source_position_likelihood: bool, if True, ray-traces image positions
+            back to source plane and evaluates relative errors in respect ot the
+            position_uncertainties in the image plane
+        :param check_bounds: bool, option to punish the hard bounds in parameter space
+        :param astrometric_likelihood: bool, additional likelihood term of the predicted
+            vs modelled point source position
+        :param image_position_uncertainty: float, 1-sigma Gaussian uncertainty on the
+            point source position (only used if point_source_likelihood=True)
+        :param check_positive_flux: bool, option to punish models that do not have all
+            positive linear amplitude parameters
+        :param source_position_tolerance: float, punishment of check_solver occurs when
+            image positions are predicted further away than this number
+        :param image_likelihood_mask_list: list of boolean 2d arrays of size of images
+            marking the pixels to be evaluated in the likelihood
+        :param force_no_add_image: bool, if True: computes ALL image positions of the
+            point source. If there are more images predicted than modelled, a punishment
+            occurs
+        :param source_marg: marginalization addition on the imaging likelihood based on
+            the covariance of the inferred linear coefficients
+        :param linear_prior: float or list of floats (when multi-linear setting is
+            chosen) indicating the range of linear amplitude priors when computing the
+            marginalization term.
+        :param restrict_image_number: bool, if True: computes ALL image positions of the
+            point source. If there are more images predicted than indicated in
+            max_num_images, a punishment occurs
+        :param max_num_images: int, see restrict_image_number
+        :param bands_compute: list of bools with same length as data objects, indicates
+            which "band" to include in the fitting
+        :param time_delay_likelihood: bool, if True computes the time-delay likelihood
+            of the FIRST point source
+        :param kwargs_flux_compute: keyword arguments of how to compute the image
+            position fluxes (see FluxRatioLikeliood)
+        :param custom_logL_addition: a definition taking as arguments (kwargs_lens,
+            kwargs_source, kwargs_lens_light, kwargs_ps, kwargs_special,
+            kwargs_extinction) and returns a logL (punishing) value.
+        :param kwargs_pixelbased: keyword arguments with various settings related to the
+            pixel-based solver (see SLITronomy documentation)
+        :param kinematic_2d_likelihood: bool, option to compute the kinematic likelihood
+        :param tracer_likelihood: option to perform likelihood on tracer quantity
+            derived from imaging or spectroscopy
+        """
+        if (
+            time_delay_likelihood or 
+            tracer_likelihood or 
+            image_position_likelihood or
+            source_position_likelihood or
+            flux_ratio_likelihood or 
+            kinematic_2d_likelihood or
+            astrometric_likelihood
+        ):
+            raise ValueError("Only image_likelihood is currently supported in JAXtronomy")
+        # TODO unpack also tracer model from kwargs_data
+        (
+            multi_band_list,
+            multi_band_type,
+            time_delays_measured,
+            time_delays_uncertainties,
+            flux_ratios,
+            flux_ratio_errors,
+            ra_image_list,
+            dec_image_list,
+            kinematic_data,
+            tracer_data,
+        ) = self._unpack_data(**kwargs_data_joint)
+        if len(multi_band_list) == 0:
+            image_likelihood = False
+        self.kinematic_data = kinematic_data
+        self.param = param_class
+        self._lower_limit, self._upper_limit = self.param.param_limits()
+        self._prior_likelihood = PriorLikelihood(
+            prior_lens,
+            prior_source,
+            prior_lens_light,
+            prior_ps,
+            prior_special,
+            prior_extinction,
+            prior_lens_kde,
+            prior_source_kde,
+            prior_lens_light_kde,
+            prior_ps_kde,
+            prior_special_kde,
+            prior_extinction_kde,
+            prior_lens_lognormal,
+            prior_source_lognormal,
+            prior_lens_light_lognormal,
+            prior_ps_lognormal,
+            prior_special_lognormal,
+            prior_extinction_lognormal,
+        )
+        self._time_delay_likelihood = time_delay_likelihood
+        self._image_likelihood = image_likelihood
+        self._flux_ratio_likelihood = flux_ratio_likelihood
+        self._tracer_likelihood = tracer_likelihood
+        self._kinematic_2D_likelihood = kinematic_2d_likelihood
+        if kwargs_flux_compute is None:
+            kwargs_flux_compute = {}
+        linear_solver = self.param.linear_solver
+        self._kwargs_flux_compute = kwargs_flux_compute
+        self._check_bounds = check_bounds
+        self._custom_logL_addition = custom_logL_addition
+        self._kwargs_time_delay = {
+            "time_delays_measured": time_delays_measured,
+            "time_delays_uncertainties": time_delays_uncertainties,
+        }
+        self._kwargs_image_likelihood = {
+            "source_marg": source_marg,
+            "linear_prior": linear_prior,
+            "check_positive_flux": check_positive_flux,
+            "kwargs_pixelbased": kwargs_pixelbased,
+            "linear_solver": linear_solver,
+        }
+        self._kwargs_image_sim = {
+            "multi_band_list": multi_band_list,
+            "multi_band_type": multi_band_type,
+            "bands_compute": bands_compute,
+            "image_likelihood_mask_list": image_likelihood_mask_list,
+        }
+        self._kwargs_position = {
+            "astrometric_likelihood": astrometric_likelihood,
+            "image_position_likelihood": image_position_likelihood,
+            "source_position_likelihood": source_position_likelihood,
+            "ra_image_list": ra_image_list,
+            "dec_image_list": dec_image_list,
+            "image_position_uncertainty": image_position_uncertainty,
+            "source_position_tolerance": source_position_tolerance,
+            "source_position_sigma": source_position_sigma,
+            "force_no_add_image": force_no_add_image,
+            "restrict_image_number": restrict_image_number,
+            "max_num_images": max_num_images,
+        }
+        self._kwargs_tracer = {
+            "tracer_data": tracer_data,
+            "tracer_likelihood_mask": tracer_likelihood_mask,
+            "linear_solver": linear_solver,
+        }
+        self._kwargs_flux = {
+            "flux_ratios": flux_ratios,
+            "flux_ratio_errors": flux_ratio_errors,
+        }
+        self._kwargs_flux.update(self._kwargs_flux_compute)
+
+        self._class_instances(
+            kwargs_model=kwargs_model,
+            kwargs_image_sim=self._kwargs_image_sim,
+            kwargs_image_likelihood=self._kwargs_image_likelihood,
+            kwargs_position=self._kwargs_position,
+            kwargs_flux=self._kwargs_flux,
+            kwargs_time_delay=self._kwargs_time_delay,
+            kinematic_data=self.kinematic_data,
+            kwargs_tracer=self._kwargs_tracer,
+        )
+
+    @property
+    def kwargs_imaging(self):
+        """Dictionary of imaging model keyword arguments.
+
+        :return: kwargs_imaging
+        """
+        kwargs_imaging = {**self._kwargs_image_likelihood, **self._kwargs_image_sim}
+        return kwargs_imaging
+
+    def _class_instances(
+        self,
+        kwargs_model,
+        kwargs_image_sim,
+        kwargs_image_likelihood,
+        kwargs_position,
+        kwargs_flux,
+        kwargs_time_delay,
+        kinematic_data,
+        kwargs_tracer,
+    ):
+        """
+
+        :param kwargs_model: lenstronomy model keyword arguments
+        :param kwargs_image_sim: keyword arguments for imaging likelihood
+        :param kwargs_image_likelihood: image likelihood dictionary
+        :param kwargs_position: keyword arguments for positional likelihood
+        :param kwargs_flux: keyword arguments for flux ratio likelihood
+        :param kwargs_time_delay: keyword arguments for time delay likelihood
+        :param kinematic_data: kinematic class for kinematic likelihood
+        :return: updated model instances of this class
+        """
+
+        # TODO: in case lens model or point source models are only applied on partial images, then this current class
+        # has ambiguities when it comes to position likelihood, time-delay likelihood and flux ratio likelihood
+        (
+            lens_model_class,
+            _,
+            lens_light_model_class,
+            point_source_class,
+            _,
+        ) = class_creator.create_class_instances(all_models=True, **kwargs_model)
+        self.PointSource = point_source_class
+
+        if self._image_likelihood is True:
+            kwargs_imaging = {**kwargs_image_likelihood, **kwargs_image_sim}
+            self.image_likelihood = ImageLikelihood(
+                kwargs_model=kwargs_model, **kwargs_imaging
+            )
+
+    def __call__(self, a):
+        return self.logL(a)
+
+    @partial(jit, static_argnums=(0,2))
+    def logL(self, args, verbose=False):
+        """Routine to compute X2 given variable parameters for a MCMC/PSO chain.
+
+        :param args: ordered parameter values that are being sampled
+        :type args: tuple or list of floats
+        :param verbose: if True, makes print statements about individual likelihood
+            components
+        :type verbose: boolean
+        :returns: log likelihood of the data given the model (natural logarithm)
+        """
+        bound_hit = False
+        if self._check_bounds is True:
+            penalty, bound_hit = self.check_bounds(
+                args, self._lower_limit, self._upper_limit, verbose=verbose
+            )
+
+        # extract parameters
+        kwargs_return = self.param.args2kwargs(args)
+
+        logL = jnp.where(bound_hit, -(10.0**10), self.log_likelihood(kwargs_return, verbose=verbose))
+        return logL
+
+    @partial(jit, static_argnums=(0,2))
+    def log_likelihood(self, kwargs_return, verbose=False):
+        """
+
+
+        :param kwargs_return: need to contain 'kwargs_lens', 'kwargs_source', 'kwargs_lens_light', 'kwargs_ps',
+         'kwargs_special'. These entries themselves are lists of keyword argument of the parameters entering the model
+         to be evaluated
+        :type kwargs_return: keyword arguments
+        :param verbose: if True, makes print statements about individual likelihood components
+        :type verbose: boolean
+
+        :returns:
+         - logL (float) log likelihood of the data given the model (natural logarithm)
+        """
+        kwargs_lens, kwargs_source, kwargs_lens_light, kwargs_ps, kwargs_special = (
+            kwargs_return["kwargs_lens"],
+            kwargs_return["kwargs_source"],
+            kwargs_return["kwargs_lens_light"],
+            kwargs_return["kwargs_ps"],
+            kwargs_return["kwargs_special"],
+        )
+        kwargs_tracer_source = kwargs_return["kwargs_tracer_source"]
+        # generate image and computes likelihood
+        logL = 0
+
+        # computing custom loglikelihood function first so that the full
+        # likelihood evaluation is skipped if it returns -inf
+        if self._custom_logL_addition is not None:
+            logL_cond = self._custom_logL_addition(**kwargs_return)
+            logL += logL_cond
+            if verbose is True:
+                jax.debug.print("custom added logL = {}", logL_cond)
+
+        logL_prior = self._prior_likelihood.logL(**kwargs_return)
+        logL += logL_prior
+        if verbose is True:
+            jax.debug.print("Prior likelihood = {}", logL_prior)
+
+        if self._image_likelihood is True:
+            logL_image, param = self.image_likelihood.logL(**kwargs_return)
+            logL += logL_image
+            if verbose is True:
+                jax.debug.print("image logL = {}", logL_image)
+
+        logL = jnp.nan_to_num(logL, nan=1e-18)
+        return logL
+
+    @staticmethod
+    @partial(jit, static_argnums=3)
+    def check_bounds(args, lowerLimit, upperLimit, verbose=False):
+        """Checks whether the parameter vector has left its bound, if so, adds a big
+        number."""
+        args = jnp.atleast_1d(jnp.array(args))
+        lowerLimit = jnp.atleast_1d(jnp.array(lowerLimit))
+        upperLimit = jnp.atleast_1d(jnp.array(upperLimit))
+
+        bound_hit_array = jnp.where(args < lowerLimit, True, jnp.where(args > upperLimit, True, False))
+        bound_hit = jnp.any(bound_hit_array)
+        penalty = jnp.where(bound_hit, 10.0**5, 0.0)
+
+        if verbose is True:
+            def true_fun():
+                i = jnp.nonzero(bound_hit_array, size=1)[0][0]
+                jax.debug.print(
+                    "parameter args[{}] with value {} hit the bounds [{}, {}] "
+                    , i, args[i], lowerLimit[i], upperLimit[i]
+                )
+
+            def false_fun():
+                pass
+
+            lax.cond(bound_hit, true_fun, false_fun)
+
+        return penalty, bound_hit
+
+    @property
+    def num_data(self):
+        """
+
+        :return: number of independent data points in the combined fitting
+        """
+        num_data = 0
+        if self._image_likelihood is True:
+            num_data += self.image_likelihood.num_data
+        return num_data
+
+    @property
+    def param_limits(self):
+        return self._lower_limit, self._upper_limit
+
+    def effective_num_data_points(self, **kwargs):
+        """Returns the effective number of data points considered in the X2 estimation
+        to compute the reduced X2 value."""
+        num_param, param_names = self.param.num_param()
+        return self.num_data - num_param
+
+    def likelihood(self, a):
+        return self.logL(a)
+
+    def negativelogL(self, a):
+        """For minimizer function, the negative value of the logl value is requested.
+
+        :param a: array of parameters
+        :return: -logL
+        """
+        return -self.logL(a)
+
+    @staticmethod
+    def _unpack_data(
+        multi_band_list=None,
+        multi_band_type="multi-linear",
+        time_delays_measured=None,
+        time_delays_uncertainties=None,
+        flux_ratios=None,
+        flux_ratio_errors=None,
+        ra_image_list=None,
+        dec_image_list=None,
+        kinematic_data=None,
+        tracer_data=None,
+    ):
+        """
+
+        :param multi_band_list: list of [[kwargs_data, kwargs_psf, kwargs_numerics], [], ...]
+        :param multi_band_type: string, type of multi-plane settings (multi-linear or joint-linear)
+        :param time_delays_measured: measured time delays (units of days)
+        :param time_delays_uncertainties: uncertainties in time-delay measurement
+        :param flux_ratios: flux ratios of point sources
+        :param flux_ratio_errors: error in flux ratio measurement
+        :return:
+        """
+        if multi_band_list is None:
+            multi_band_list = []
+        if ra_image_list is None:
+            ra_image_list = []
+        if dec_image_list is None:
+            dec_image_list = []
+        return (
+            multi_band_list,
+            multi_band_type,
+            time_delays_measured,
+            time_delays_uncertainties,
+            flux_ratios,
+            flux_ratio_errors,
+            ra_image_list,
+            dec_image_list,
+            kinematic_data,
+            tracer_data,
+        )
+
+    #def _reset_point_source_cache(self, bool_input=True):
+    #    self.PointSource.delete_lens_model_cache()
+    #    self.PointSource.set_save_cache(bool_input)
+    #    if self._image_likelihood is True:
+    #        self.image_likelihood.reset_point_source_cache(bool_input)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-lenstronomy @ "https://github.com/lenstronomy/lenstronomy/archive/1.12.4.tar.gz"
+lenstronomy @ https://github.com/lenstronomy/lenstronomy/archive/refs/tags/v1.12.4.tar.gz
 numpy>=1.17.0
 scipy>=0.19.1
 jax>=0.4.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-lenstronomy @ https://github.com/lenstronomy/lenstronomy/archive/refs/tags/v1.12.4.tar.gz
+lenstronomy @ https://github.com/lenstronomy/lenstronomy/archive/refs/heads/main.zip
 numpy>=1.17.0
 scipy>=0.19.1
 jax>=0.4.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-lenstronomy>=1.12.1
+lenstronomy @ "https://github.com/lenstronomy/lenstronomy/archive/1.12.4.tar.gz"
 numpy>=1.17.0
 scipy>=0.19.1
 jax>=0.4.12

--- a/test/test_ImSim/test_image_model.py
+++ b/test/test_ImSim/test_image_model.py
@@ -195,7 +195,7 @@ class TestImageModel(object):
         kwargs_psf = {
             "psf_type": "PIXEL",
             "kernel_point_source": kernel,
-            "psf_error_map": np.ones_like(kernel) * 0.001 * kernel**2,
+            "psf_variance_map": np.ones_like(kernel) * 0.001 * kernel**2,
         }
         psf_class = PSF(**kwargs_psf)
         npt.assert_raises(ValueError, ImageModel, self.data_class, psf_class)

--- a/test/test_Sampling/test_Likelihoods/test_image_likelihood.py
+++ b/test/test_Sampling/test_Likelihoods/test_image_likelihood.py
@@ -1,0 +1,180 @@
+from jaxtronomy.Sampling.Likelihoods.image_likelihood import ImageLikelihood
+
+from lenstronomy.Sampling.Likelihoods.image_likelihood import ImageLikelihood as ImageLikelihood_ref
+from lenstronomy.Util import simulation_util as sim_util, param_util
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+
+class TestImageLikelihood(object):
+    def setup_method(self):
+        # data specifics
+        sigma_bkg = 0.05  # background noise per pixel
+        exp_time = 100  # exposure time (arbitrary units, flux per pixel is in units #photons/exp_time unit)
+        numPix = 100  # cutout pixel size
+        numPix2 = 120
+        deltaPix = 0.05  # pixel size in arcsec (area per pixel = deltaPix**2)
+        fwhm = 0.5  # full width half max of PSF
+
+        kwargs_data = sim_util.data_configure_simple(
+            numPix, deltaPix, exp_time, sigma_bkg, inverse=True
+        )
+
+        kwargs_data2 = sim_util.data_configure_simple(
+            numPix2, deltaPix, exp_time + 30, sigma_bkg + 0.01, inverse=True
+        )
+        kwargs_data['image_data'] = np.ones((numPix, numPix)) * 0.9392
+        kwargs_data2['image_data'] = np.ones((numPix, numPix)) * 0.3262
+
+
+
+        # Create likelihood masks
+        # Likelihood mask 1 will mask out 70 pixels
+        likelihood_mask = np.ones((numPix, numPix))
+        likelihood_mask[50][::2] -= likelihood_mask[50][::2]
+        likelihood_mask[25][::5] -= likelihood_mask[25][::5]
+
+        # Likelihood mask 1 will mask out 83 pixels
+        likelihood_mask2 = np.ones((numPix2, numPix2))
+        likelihood_mask2[60][::3] -= likelihood_mask2[60][::3]
+        likelihood_mask2[30][::2] -= likelihood_mask2[30][::2]
+        likelihood_mask_list = [likelihood_mask, likelihood_mask2]
+
+        kwargs_psf = {
+            "psf_type": "GAUSSIAN",
+            "fwhm": fwhm,
+            "truncation": 5,
+            "pixel_size": deltaPix,
+        }
+        kwargs_psf2 = {
+            "psf_type": "GAUSSIAN",
+            "fwhm": fwhm,
+            "truncation": 4,
+            "pixel_size": deltaPix,
+        }
+
+        # 'EXERNAL_SHEAR': external shear
+        kwargs_shear = {
+            "gamma1": 0.01,
+            "gamma2": 0.03,
+        }  # gamma_ext: shear strength, psi_ext: shear angel (in radian)
+        phi, q = 0.2, 0.8
+        e1, e2 = param_util.phi_q2_ellipticity(phi, q)
+        kwargs_spemd = {
+            "theta_E": 1.234,
+            "center_x": 0,
+            "center_y": 0,
+            "e1": e1,
+            "e2": e2,
+        }
+        kwargs_epl = {
+            "theta_E": 3.0,
+            "gamma": 1.7,
+            "center_x": -0.5,
+            "center_y": 1.2,
+            "e1": e1,
+            "e2": e2,
+        }
+
+        lens_model_list = ["SIE", "EPL", "SHEAR"]
+        self.kwargs_lens = [kwargs_spemd, kwargs_epl, kwargs_shear]
+
+        # list of light profiles (for lens and source)
+        # 'SERSIC': spherical Sersic profile
+        kwargs_sersic = {
+            "amp": 31.354,
+            "R_sersic": 0.1,
+            "n_sersic": 2,
+            "center_x": 0.3,
+            "center_y": 0.4,
+        }
+        # 'SERSIC_ELLIPSE': elliptical Sersic profile
+        phi, q = 0.2, 0.9
+        e1, e2 = param_util.phi_q2_ellipticity(phi, q)
+        kwargs_sersic_ellipse = {
+            "amp": 73.0,
+            "R_sersic": 0.7,
+            "n_sersic": 7,
+            "center_x": 0.1,
+            "center_y": -0.3,
+            "e1": e1,
+            "e2": e2,
+        }
+
+        lens_light_model_list = ["SERSIC"]
+        self.kwargs_lens_light = [kwargs_sersic]
+
+        source_model_list = ["SERSIC_ELLIPSE"]
+        self.kwargs_source = [kwargs_sersic_ellipse]
+
+        kwargs_numerics = {
+            "supersampling_factor": 3,
+            "supersampling_convolution": True,
+        }
+        kwargs_numerics2 = {
+            "supersampling_factor": 3,
+            "supersampling_convolution": False,
+        }
+
+        multi_band_list = [
+            [kwargs_data, kwargs_psf, kwargs_numerics],
+            [kwargs_data2, kwargs_psf2, kwargs_numerics2],
+        ]
+        # band 0 involves the SIE + SHEAR lens models, a SERSIC lens light model, and a SERSIC_ELLIPSE source model
+        # band 1 involves the EPL + SHEAR lens models, the same SERSIC lens light model, and the same SERSIC_ELLIPSE source model
+        kwargs_model = {
+            "lens_model_list": lens_model_list,
+            "source_light_model_list": source_model_list,
+            "lens_light_model_list": lens_light_model_list,
+            "index_lens_model_list": [[0, 2], [1, 2]],
+            # The next line is not needed if the models are the same for both bands
+            "index_source_light_model_list": [[0], [0]],
+        }
+        self.image_likelihood = ImageLikelihood(
+            multi_band_list,
+            "single-band",
+            kwargs_model,
+            image_likelihood_mask_list=likelihood_mask_list,
+        )
+        self.image_likelihood_ref = ImageLikelihood_ref(
+            multi_band_list,
+            "single-band",
+            kwargs_model,
+            image_likelihood_mask_list=likelihood_mask_list,
+            linear_solver=False
+        )
+
+    def test_logL(self):
+        logL, _ = self.image_likelihood.logL(
+            self.kwargs_lens,
+            self.kwargs_source,
+            self.kwargs_lens_light
+        )
+        logL_ref, _ = self.image_likelihood_ref.logL(
+            self.kwargs_lens,
+            self.kwargs_source,
+            self.kwargs_lens_light
+        )
+        npt.assert_almost_equal(logL, logL_ref, decimal=8)
+
+        self.kwargs_lens[2]['gamma1'] = 0.05
+
+        logL, _ = self.image_likelihood.logL(
+            self.kwargs_lens,
+            self.kwargs_source,
+            self.kwargs_lens_light
+        )
+        logL_ref, _ = self.image_likelihood_ref.logL(
+            self.kwargs_lens,
+            self.kwargs_source,
+            self.kwargs_lens_light
+        )
+        npt.assert_almost_equal(logL, logL_ref, decimal=8)
+
+    def test_num_data(self):
+        assert self.image_likelihood.num_data == self.image_likelihood_ref.num_data
+        assert self.image_likelihood.num_data == 100 * 100 - 70
+
+if __name__ == "__main__":
+    pytest.main()

--- a/test/test_Sampling/test_Likelihoods/test_image_likelihood.py
+++ b/test/test_Sampling/test_Likelihoods/test_image_likelihood.py
@@ -154,7 +154,7 @@ class TestImageLikelihood(object):
             self.multi_band_list,
             "single-band",
             self.kwargs_model,
-            source_marg=True
+            source_marg=True,
         )
         npt.assert_raises(
             ValueError,
@@ -162,7 +162,7 @@ class TestImageLikelihood(object):
             self.multi_band_list,
             "single-band",
             self.kwargs_model,
-            linear_solver=True
+            linear_solver=True,
         )
         npt.assert_raises(
             ValueError,
@@ -170,7 +170,7 @@ class TestImageLikelihood(object):
             self.multi_band_list,
             "single-band",
             self.kwargs_model,
-            check_positive_flux=True
+            check_positive_flux=True,
         )
         npt.assert_raises(
             ValueError,
@@ -178,7 +178,7 @@ class TestImageLikelihood(object):
             self.multi_band_list,
             "single-band",
             self.kwargs_model,
-            kwargs_pixelbased={"error": 1}
+            kwargs_pixelbased={"error": 1},
         )
         npt.assert_raises(
             ValueError,
@@ -186,7 +186,7 @@ class TestImageLikelihood(object):
             self.multi_band_list,
             "single-band",
             self.kwargs_model,
-            linear_prior=1
+            linear_prior=1,
         )
 
     def test_logL(self):

--- a/test/test_Sampling/test_Likelihoods/test_image_likelihood.py
+++ b/test/test_Sampling/test_Likelihoods/test_image_likelihood.py
@@ -117,13 +117,14 @@ class TestImageLikelihood(object):
             "supersampling_convolution": False,
         }
 
-        multi_band_list = [
+        self.multi_band_list = [
             [kwargs_data, kwargs_psf, kwargs_numerics],
             [kwargs_data2, kwargs_psf2, kwargs_numerics2],
         ]
+
         # band 0 involves the SIE + SHEAR lens models, a SERSIC lens light model, and a SERSIC_ELLIPSE source model
         # band 1 involves the EPL + SHEAR lens models, the same SERSIC lens light model, and the same SERSIC_ELLIPSE source model
-        kwargs_model = {
+        self.kwargs_model = {
             "lens_model_list": lens_model_list,
             "source_light_model_list": source_model_list,
             "lens_light_model_list": lens_light_model_list,
@@ -131,18 +132,61 @@ class TestImageLikelihood(object):
             # The next line is not needed if the models are the same for both bands
             "index_source_light_model_list": [[0], [0]],
         }
+
         self.image_likelihood = ImageLikelihood(
-            multi_band_list,
+            self.multi_band_list,
             "single-band",
-            kwargs_model,
+            self.kwargs_model,
             image_likelihood_mask_list=likelihood_mask_list,
         )
         self.image_likelihood_ref = ImageLikelihood_ref(
-            multi_band_list,
+            self.multi_band_list,
             "single-band",
-            kwargs_model,
+            self.kwargs_model,
             image_likelihood_mask_list=likelihood_mask_list,
             linear_solver=False
+        )
+
+    def test_raises(self):
+        npt.assert_raises(
+            ValueError,
+            ImageLikelihood,
+            self.multi_band_list,
+            "single-band",
+            self.kwargs_model,
+            source_marg=True
+        )
+        npt.assert_raises(
+            ValueError,
+            ImageLikelihood,
+            self.multi_band_list,
+            "single-band",
+            self.kwargs_model,
+            linear_solver=True
+        )
+        npt.assert_raises(
+            ValueError,
+            ImageLikelihood,
+            self.multi_band_list,
+            "single-band",
+            self.kwargs_model,
+            check_positive_flux=True
+        )
+        npt.assert_raises(
+            ValueError,
+            ImageLikelihood,
+            self.multi_band_list,
+            "single-band",
+            self.kwargs_model,
+            kwargs_pixelbased={"error": 1}
+        )
+        npt.assert_raises(
+            ValueError,
+            ImageLikelihood,
+            self.multi_band_list,
+            "single-band",
+            self.kwargs_model,
+            linear_prior=1
         )
 
     def test_logL(self):

--- a/test/test_Sampling/test_likelihood.py
+++ b/test/test_Sampling/test_likelihood.py
@@ -254,12 +254,8 @@ class TestLikelihoodModule(object):
     def test_check_bounds(self):
         lower_limit, upper_limit = self.Likelihood.param_limits
         lower_limit_ref, upper_limit_ref = self.Likelihood_ref.param_limits
-        npt.assert_array_equal(
-            lower_limit, lower_limit_ref
-        )
-        npt.assert_array_equal(
-            upper_limit, upper_limit_ref
-        )
+        npt.assert_array_equal(lower_limit, lower_limit_ref)
+        npt.assert_array_equal(upper_limit, upper_limit_ref)
 
         penalty, bound_hit = self.Likelihood.check_bounds(
             args=[0, 1], lowerLimit=[1, 0], upperLimit=[2, 2], verbose=True
@@ -288,18 +284,18 @@ class TestLikelihoodModule(object):
             kwargs_lens_light=self.kwargs_lens_light,
         )
 
-        self.kwargs_data_joint['multi_band_list'] = None
+        self.kwargs_data_joint["multi_band_list"] = None
         Likelihood = LikelihoodModule(
             kwargs_data_joint=self.kwargs_data_joint,
             kwargs_model=self.kwargs_model,
             param_class=self.param_class,
-            check_bounds=True
+            check_bounds=True,
         )
         Likelihood_ref = LikelihoodModule_ref(
             kwargs_data_joint=self.kwargs_data_joint,
             kwargs_model=self.kwargs_model,
             param_class=self.param_class,
-            check_bounds=True
+            check_bounds=True,
         )
 
         assert Likelihood.logL(args) == 0
@@ -307,7 +303,6 @@ class TestLikelihoodModule(object):
         args[0] = 1000000
         assert Likelihood.logL(args) == -1e18
         assert Likelihood.logL(args) == Likelihood_ref.logL(args)
-
 
 
 if __name__ == "__main__":

--- a/test/test_Sampling/test_likelihood.py
+++ b/test/test_Sampling/test_likelihood.py
@@ -1,0 +1,270 @@
+__author__ = "sibirrer"
+
+from jax import numpy as jnp
+import pytest
+import numpy as np
+import numpy.testing as npt
+import lenstronomy.Util.simulation_util as sim_util
+import lenstronomy.Util.class_creator as class_creator
+from lenstronomy.ImSim.image_model import ImageModel
+from lenstronomy.Sampling.parameters import Param
+from lenstronomy.Data.imaging_data import ImageData
+from lenstronomy.Data.psf import PSF
+
+from jaxtronomy.Sampling.likelihood import LikelihoodModule
+from lenstronomy.Sampling.likelihood import LikelihoodModule as LikelihoodModule_ref
+
+
+class TestLikelihoodModule(object):
+    """Test the fitting sequences."""
+
+    def setup_method(self):
+        np.random.seed(42)
+
+        # data specifics
+        sigma_bkg = 0.05  # background noise per pixel
+        exp_time = 100  # exposure time (arbitrary units, flux per pixel is in units #photons/exp_time unit)
+        numPix = 50  # cutout pixel size
+        deltaPix = 0.1  # pixel size in arcsec (area per pixel = deltaPix**2)
+        fwhm = 0.5  # full width half max of PSF
+
+        kwargs_model = {
+            "lens_model_list": ["EPL"],
+            "lens_light_model_list": ["SERSIC"],
+            "source_light_model_list": ["SERSIC"],
+        }
+
+        # PSF specification
+        kwargs_data = sim_util.data_configure_simple(
+            numPix, deltaPix, exp_time, sigma_bkg
+        )
+        data_class = ImageData(**kwargs_data)
+        kwargs_psf = {"psf_type": "GAUSSIAN", "fwhm": fwhm, "pixel_size": deltaPix}
+        psf_class = PSF(**kwargs_psf)
+        print(np.shape(psf_class.kernel_point_source), "test kernel shape -")
+        kwargs_spep = {
+            "theta_E": 1.0,
+            "gamma": 1.95,
+            "center_x": 0,
+            "center_y": 0,
+            "e1": 0.1,
+            "e2": 0.1,
+        }
+
+        self.kwargs_lens = [kwargs_spep]
+        kwargs_sersic = {
+            "amp": 21.3,
+            "R_sersic": 0.1,
+            "n_sersic": 2,
+            "center_x": 0,
+            "center_y": 0,
+        }
+        # 'SERSIC_ELLIPSE': elliptical Sersic profile
+        kwargs_sersic_ellipse = {
+            "amp": 11.7,
+            "R_sersic": 0.6,
+            "n_sersic": 3,
+            "center_x": 0,
+            "center_y": 0,
+        }
+
+        self.kwargs_lens_light = [kwargs_sersic]
+        self.kwargs_source = [kwargs_sersic_ellipse]
+
+        kwargs_numerics = {
+            "supersampling_factor": 3,
+            "supersampling_convolution": True,
+        }
+        (
+            lens_model_class,
+            source_model_class,
+            lens_light_model_class,
+            point_source_class,
+            extinction_class,
+        ) = class_creator.create_class_instances(**kwargs_model)
+        imageModel = ImageModel(
+            data_class,
+            psf_class,
+            lens_model_class,
+            source_model_class,
+            lens_light_model_class,
+            point_source_class,
+            extinction_class,
+            kwargs_numerics=kwargs_numerics,
+        )
+        image_sim = sim_util.simulate_simple(
+            imageModel,
+            self.kwargs_lens,
+            self.kwargs_source,
+            self.kwargs_lens_light,
+        )
+
+        data_class.update_data(image_sim)
+        kwargs_data["image_data"] = image_sim
+
+        self.data_class = data_class
+        self.psf_class = psf_class
+        self.kwargs_model = kwargs_model
+        self.kwargs_numerics = kwargs_numerics
+
+        
+        def condition_definition(
+            kwargs_lens,
+            kwargs_source,
+            kwargs_lens_light,
+            kwargs_ps=None,
+            kwargs_special=None,
+            kwargs_extinction=None,
+            **kwargs,
+        ):
+            logL = jnp.where(
+                kwargs_lens_light[0]["R_sersic"] > kwargs_source[0]["R_sersic"],
+                -10**15, 0
+            )
+            return logL
+
+        kwargs_likelihood = {
+            "prior_lens": [[0, "theta_E", 1, 0.1]],
+            "custom_logL_addition": condition_definition,
+        }
+        self.kwargs_data_joint = {
+            "multi_band_list": [[kwargs_data, kwargs_psf, kwargs_numerics]],
+            "multi_band_type": "single-band"
+        }
+
+        self.param_class = Param(self.kwargs_model, linear_solver=False)
+        self.imageModel = ImageModel(
+            data_class,
+            psf_class,
+            lens_model_class,
+            source_model_class,
+            lens_light_model_class,
+            point_source_class,
+            kwargs_numerics=kwargs_numerics,
+        )
+        self.Likelihood = LikelihoodModule(
+            kwargs_data_joint=self.kwargs_data_joint,
+            kwargs_model=kwargs_model,
+            param_class=self.param_class,
+            **kwargs_likelihood,
+        )
+        self.Likelihood_ref = LikelihoodModule_ref(
+            kwargs_data_joint=self.kwargs_data_joint,
+            kwargs_model=kwargs_model,
+            param_class=self.param_class,
+            **kwargs_likelihood,
+        )
+        self.kwargs_data = kwargs_data
+        self.kwargs_psf = kwargs_psf
+        self.numPix = numPix
+
+    def test_raises(self):
+        npt.assert_raises(
+            ValueError,
+            LikelihoodModule,
+            self.kwargs_data_joint,
+            self.kwargs_model,
+            self.param_class,
+            time_delay_likelihood=True
+        )
+        npt.assert_raises(
+            ValueError,
+            LikelihoodModule,
+            self.kwargs_data_joint,
+            self.kwargs_model,
+            self.param_class,
+            tracer_likelihood=True
+        )
+        npt.assert_raises(
+            ValueError,
+            LikelihoodModule,
+            self.kwargs_data_joint,
+            self.kwargs_model,
+            self.param_class,
+            image_position_likelihood=True
+        )
+        npt.assert_raises(
+            ValueError,
+            LikelihoodModule,
+            self.kwargs_data_joint,
+            self.kwargs_model,
+            self.param_class,
+            source_position_likelihood=True
+        )
+        npt.assert_raises(
+            ValueError,
+            LikelihoodModule,
+            self.kwargs_data_joint,
+            self.kwargs_model,
+            self.param_class,
+            flux_ratio_likelihood=True
+        )
+        npt.assert_raises(
+            ValueError,
+            LikelihoodModule,
+            self.kwargs_data_joint,
+            self.kwargs_model,
+            self.param_class,
+            kinematic_2d_likelihood=True
+        )
+        npt.assert_raises(
+            ValueError,
+            LikelihoodModule,
+            self.kwargs_data_joint,
+            self.kwargs_model,
+            self.param_class,
+            astrometric_likelihood=True
+        )
+
+    def test_logL(self):
+        args = self.param_class.kwargs2args(
+            kwargs_lens=self.kwargs_lens,
+            kwargs_source=self.kwargs_source,
+            kwargs_lens_light=self.kwargs_lens_light,
+        )
+
+        logL = self.Likelihood.logL(args, verbose=True)
+        logL_ref = self.Likelihood_ref.logL(args, verbose=True)
+        npt.assert_almost_equal(logL, logL_ref, decimal=8)
+
+        args[3] += 0.1
+
+        logL = self.Likelihood.likelihood(args)
+        npt.assert_raises(AssertionError, npt.assert_almost_equal, logL, logL_ref)
+        logL_ref = self.Likelihood_ref.likelihood(args)
+        npt.assert_almost_equal(logL, logL_ref, decimal=8)
+
+        logL = self.Likelihood.negativelogL(args)
+        logL_ref = self.Likelihood_ref.negativelogL(args)
+        npt.assert_almost_equal(logL, logL_ref, decimal=8)
+
+        num_data = self.Likelihood.num_data
+        num_data_ref = self.Likelihood_ref.num_data
+        assert num_data == num_data_ref
+
+        num_data_effective = self.Likelihood.effective_num_data_points()
+        num_data_effective_ref = self.Likelihood_ref.effective_num_data_points()
+        assert num_data_effective == num_data_effective_ref
+
+    def test_check_bounds(self):
+        npt.assert_array_equal(self.Likelihood._lower_limit, self.Likelihood_ref._lower_limit)
+        npt.assert_array_equal(self.Likelihood._upper_limit, self.Likelihood_ref._upper_limit)
+
+        penalty, bound_hit = self.Likelihood.check_bounds(
+            args=[0, 1], lowerLimit=[1, 0], upperLimit=[2, 2], verbose=True
+        )
+        assert bound_hit
+
+        penalty, bound_hit = self.Likelihood.check_bounds(
+            args=[1, 3], lowerLimit=[1, 0], upperLimit=[2, 2], verbose=True
+        )
+        assert bound_hit
+
+        penalty, bound_hit = self.Likelihood.check_bounds(
+            args=[1, 2], lowerLimit=[1, 0], upperLimit=[2, 2], verbose=True
+        )
+        assert not bound_hit
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/test/test_Sampling/test_likelihood.py
+++ b/test/test_Sampling/test_likelihood.py
@@ -1,6 +1,6 @@
 __author__ = "sibirrer"
 
-from jax import numpy as jnp
+from jax import numpy as jnp, grad
 import pytest
 import numpy as np
 import numpy.testing as npt
@@ -250,6 +250,16 @@ class TestLikelihoodModule(object):
         num_data_effective = self.Likelihood.effective_num_data_points()
         num_data_effective_ref = self.Likelihood_ref.effective_num_data_points()
         assert num_data_effective == num_data_effective_ref
+
+    def test_grad_logL(self):
+        args = self.param_class.kwargs2args(
+            kwargs_lens=self.kwargs_lens,
+            kwargs_source=self.kwargs_source,
+            kwargs_lens_light=self.kwargs_lens_light,
+        )
+        grad_func = grad(self.Likelihood.logL)
+        assert len(args) == len(grad_func(args))
+
 
     def test_check_bounds(self):
         lower_limit, upper_limit = self.Likelihood.param_limits

--- a/test/test_Sampling/test_likelihood.py
+++ b/test/test_Sampling/test_likelihood.py
@@ -107,7 +107,6 @@ class TestLikelihoodModule(object):
         self.kwargs_model = kwargs_model
         self.kwargs_numerics = kwargs_numerics
 
-        
         def condition_definition(
             kwargs_lens,
             kwargs_source,
@@ -119,7 +118,8 @@ class TestLikelihoodModule(object):
         ):
             logL = jnp.where(
                 kwargs_lens_light[0]["R_sersic"] > kwargs_source[0]["R_sersic"],
-                -10**15, 0
+                -(10**15),
+                0,
             )
             return logL
 
@@ -129,7 +129,7 @@ class TestLikelihoodModule(object):
         }
         self.kwargs_data_joint = {
             "multi_band_list": [[kwargs_data, kwargs_psf, kwargs_numerics]],
-            "multi_band_type": "single-band"
+            "multi_band_type": "single-band",
         }
 
         self.param_class = Param(self.kwargs_model, linear_solver=False)
@@ -165,7 +165,7 @@ class TestLikelihoodModule(object):
             self.kwargs_data_joint,
             self.kwargs_model,
             self.param_class,
-            time_delay_likelihood=True
+            time_delay_likelihood=True,
         )
         npt.assert_raises(
             ValueError,
@@ -173,7 +173,7 @@ class TestLikelihoodModule(object):
             self.kwargs_data_joint,
             self.kwargs_model,
             self.param_class,
-            tracer_likelihood=True
+            tracer_likelihood=True,
         )
         npt.assert_raises(
             ValueError,
@@ -181,7 +181,7 @@ class TestLikelihoodModule(object):
             self.kwargs_data_joint,
             self.kwargs_model,
             self.param_class,
-            image_position_likelihood=True
+            image_position_likelihood=True,
         )
         npt.assert_raises(
             ValueError,
@@ -189,7 +189,7 @@ class TestLikelihoodModule(object):
             self.kwargs_data_joint,
             self.kwargs_model,
             self.param_class,
-            source_position_likelihood=True
+            source_position_likelihood=True,
         )
         npt.assert_raises(
             ValueError,
@@ -197,7 +197,7 @@ class TestLikelihoodModule(object):
             self.kwargs_data_joint,
             self.kwargs_model,
             self.param_class,
-            flux_ratio_likelihood=True
+            flux_ratio_likelihood=True,
         )
         npt.assert_raises(
             ValueError,
@@ -205,7 +205,7 @@ class TestLikelihoodModule(object):
             self.kwargs_data_joint,
             self.kwargs_model,
             self.param_class,
-            kinematic_2d_likelihood=True
+            kinematic_2d_likelihood=True,
         )
         npt.assert_raises(
             ValueError,
@@ -213,7 +213,7 @@ class TestLikelihoodModule(object):
             self.kwargs_data_joint,
             self.kwargs_model,
             self.param_class,
-            astrometric_likelihood=True
+            astrometric_likelihood=True,
         )
 
     def test_logL(self):
@@ -247,8 +247,12 @@ class TestLikelihoodModule(object):
         assert num_data_effective == num_data_effective_ref
 
     def test_check_bounds(self):
-        npt.assert_array_equal(self.Likelihood._lower_limit, self.Likelihood_ref._lower_limit)
-        npt.assert_array_equal(self.Likelihood._upper_limit, self.Likelihood_ref._upper_limit)
+        npt.assert_array_equal(
+            self.Likelihood._lower_limit, self.Likelihood_ref._lower_limit
+        )
+        npt.assert_array_equal(
+            self.Likelihood._upper_limit, self.Likelihood_ref._upper_limit
+        )
 
         penalty, bound_hit = self.Likelihood.check_bounds(
             args=[0, 1], lowerLimit=[1, 0], upperLimit=[2, 2], verbose=True


### PR DESCRIPTION
Implements the ImageLikelihood and LikelihoodModule classes.
Also renames psf_error_map to psf_variance_map in ImageModel to remain consistent with a recent lenstronomy PR.
Also updated requirements.txt so that when running tests, lenstronomy is installed from GitHub rather than PyPi