### PR TITLE
implement shapelets lightprofile

### DIFF
--- a/jaxtronomy/LensModel/LineOfSight/LOSModels/los.py
+++ b/jaxtronomy/LensModel/LineOfSight/LOSModels/los.py
@@ -1,5 +1,7 @@
 __author__ = "pierrefleury"
 
+from jax import jit
+
 __all__ = ["LOS"]
 
 
@@ -45,6 +47,7 @@ class LOS(object):
         self._static = False
 
     @staticmethod
+    @jit
     def distort_vector(x, y, kappa=0, gamma1=0, gamma2=0, omega=0):
         """This function applies a distortion matrix to a vector (x, y) and returns (x',
         y') as follows:
@@ -82,6 +85,7 @@ class LOS(object):
         return x_, y_
 
     @staticmethod
+    @jit
     def left_multiply(f_xx, f_xy, f_yx, f_yy, kappa=0, gamma1=0, gamma2=0, omega=0):
         """Left-multiplies the Hessian matrix of a lens with a distortion matrix with
         convergence kappa, shear gamma1, gamma2, and rotation omega:
@@ -115,6 +119,7 @@ class LOS(object):
         return f__xx, f__xy, f__yx, f__yy
 
     @staticmethod
+    @jit
     def right_multiply(f_xx, f_xy, f_yx, f_yy, kappa=0, gamma1=0, gamma2=0, omega=0):
         """Right-multiplies the Hessian matrix of a lens with a distortion matrix with
         convergence kappa and shear gamma1, gamma2:

--- a/jaxtronomy/LensModel/lens_model.py
+++ b/jaxtronomy/LensModel/lens_model.py
@@ -3,8 +3,8 @@ from jaxtronomy.LensModel.single_plane import SinglePlane
 from jaxtronomy.LensModel.LineOfSight.single_plane_los import SinglePlaneLOS
 
 # TODO: Implement multi plane
-#from lenstronomy.Cosmo.lens_cosmo import LensCosmo
-#from lenstronomy.Util import constants as const
+# from lenstronomy.Cosmo.lens_cosmo import LensCosmo
+# from lenstronomy.Util import constants as const
 
 from functools import partial
 from jax import jit
@@ -167,7 +167,7 @@ class LensModel(object):
                     kwargs_synthesis=kwargs_synthesis,
                 )
 
-        #if z_lens is not None and z_source is not None:
+        # if z_lens is not None and z_source is not None:
         #    self._lensCosmo = LensCosmo(z_lens, z_source, cosmo=cosmo)
 
     @partial(jit, static_argnums=(0, 4))
@@ -292,10 +292,10 @@ class LensModel(object):
         """
         if diff is None:
             return self.lens_model.alpha(x, y, kwargs, k=k)
-        #elif self.multi_plane is False:
+        # elif self.multi_plane is False:
         else:
             return self._deflection_differential(x, y, kwargs, k=k, diff=diff)
-        #else:
+        # else:
         #    raise ValueError(
         #        "numerical differentiation of lensing potential is not available in the multi-plane "
         #        "setting as analytical form of lensing potential is not available."

--- a/jaxtronomy/LensModel/lens_model.py
+++ b/jaxtronomy/LensModel/lens_model.py
@@ -110,11 +110,6 @@ class LensModel(object):
                 raise ValueError(
                     "LOS effects and multi-plane lensing are incompatible."
                 )
-
-            if decouple_multi_plane:
-                raise ValueError(
-                    "decouple multi plane lens model not supported in jaxtronomy yet"
-                )
                 # self.lens_model = MultiPlaneDecoupled(
                 #    z_source,
                 #    lens_model_list,

--- a/jaxtronomy/LensModel/lens_model.py
+++ b/jaxtronomy/LensModel/lens_model.py
@@ -166,8 +166,8 @@ class LensModel(object):
                     kwargs_synthesis=kwargs_synthesis,
                 )
 
-        if z_lens is not None and z_source is not None:
-            self._lensCosmo = LensCosmo(z_lens, z_source, cosmo=cosmo)
+        #if z_lens is not None and z_source is not None:
+        #    self._lensCosmo = LensCosmo(z_lens, z_source, cosmo=cosmo)
 
     @partial(jit, static_argnums=(0, 4))
     def ray_shooting(self, x, y, kwargs, k=None):
@@ -203,10 +203,10 @@ class LensModel(object):
         :return: fermat potential in arcsec**2 without geometry term (second part of Eqn
             1 in Suyu et al. 2013) as a list
         """
-        if hasattr(self.lens_model, "fermat_potential"):
-            return self.lens_model.fermat_potential(
-                x_image, y_image, kwargs_lens, x_source, y_source
-            )
+        # if hasattr(self.lens_model, "fermat_potential"):
+        return self.lens_model.fermat_potential(
+            x_image, y_image, kwargs_lens, x_source, y_source
+        )
         # elif hasattr(self.lens_model, "arrival_time") and hasattr(self, "_lensCosmo"):
         #    dt = self.lens_model.arrival_time(x_image, y_image, kwargs_lens)
         #    fermat_pot_eff = (
@@ -218,11 +218,11 @@ class LensModel(object):
         #        / const.arcsec**2
         #    )
         #    return fermat_pot_eff
-        else:
-            raise ValueError(
-                "In multi-plane lensing you need to provide a specific z_lens and z_source for which the "
-                "effective Fermat potential is evaluated"
-            )
+        # else:
+        #     raise ValueError(
+        #         "In multi-plane lensing you need to provide a specific z_lens and z_source for which the "
+        #         "effective Fermat potential is evaluated"
+        #     )
 
     # def arrival_time(
     #    self, x_image, y_image, kwargs_lens, kappa_ext=0, x_source=None, y_source=None
@@ -291,13 +291,14 @@ class LensModel(object):
         """
         if diff is None:
             return self.lens_model.alpha(x, y, kwargs, k=k)
-        elif self.multi_plane is False:
-            return self._deflection_differential(x, y, kwargs, k=k, diff=diff)
+        #elif self.multi_plane is False:
         else:
-            raise ValueError(
-                "numerical differentiation of lensing potential is not available in the multi-plane "
-                "setting as analytical form of lensing potential is not available."
-            )
+            return self._deflection_differential(x, y, kwargs, k=k, diff=diff)
+        #else:
+        #    raise ValueError(
+        #        "numerical differentiation of lensing potential is not available in the multi-plane "
+        #        "setting as analytical form of lensing potential is not available."
+        #    )
 
     @partial(jit, static_argnums=(0, 4, 6))
     def hessian(self, x, y, kwargs, k=None, diff=None, diff_method="square"):

--- a/jaxtronomy/LensModel/lens_model.py
+++ b/jaxtronomy/LensModel/lens_model.py
@@ -1,11 +1,12 @@
 __author__ = "sibirrer"
-from jaxtronomy.LensModel.single_plane import SinglePlane  # NH: import from jaxtronomy
+from jaxtronomy.LensModel.single_plane import SinglePlane
 from jaxtronomy.LensModel.LineOfSight.single_plane_los import SinglePlaneLOS
-from lenstronomy.LensModel.MultiPlane.multi_plane import MultiPlane
 
-from lenstronomy.LensModel.MultiPlane.decoupled_multi_plane import MultiPlaneDecoupled
 from lenstronomy.Cosmo.lens_cosmo import LensCosmo
 from lenstronomy.Util import constants as const
+
+from functools import partial
+from jax import jit
 
 __all__ = ["LensModel"]
 
@@ -111,37 +112,39 @@ class LensModel(object):
                 )
 
             if decouple_multi_plane:
-                self.lens_model = MultiPlaneDecoupled(
-                    z_source,
-                    lens_model_list,
-                    lens_redshift_list,
-                    cosmo=cosmo,
-                    numerical_alpha_class=numerical_alpha_class,
-                    observed_convention_index=observed_convention_index,
-                    z_source_convention=z_source_convention,
-                    cosmo_interp=cosmo_interp,
-                    z_interp_stop=z_interp_stop,
-                    num_z_interp=num_z_interp,
-                    kwargs_interp=kwargs_interp,
-                    kwargs_synthesis=kwargs_synthesis,
-                    **kwargs_multiplane_model
-                )
+                raise ValueError("decouple multi plane lens model not supported in jaxtronomy yet")
+                #self.lens_model = MultiPlaneDecoupled(
+                #    z_source,
+                #    lens_model_list,
+                #    lens_redshift_list,
+                #    cosmo=cosmo,
+                #    numerical_alpha_class=numerical_alpha_class,
+                #    observed_convention_index=observed_convention_index,
+                #    z_source_convention=z_source_convention,
+                #    cosmo_interp=cosmo_interp,
+                #    z_interp_stop=z_interp_stop,
+                #    num_z_interp=num_z_interp,
+                #    kwargs_interp=kwargs_interp,
+                #    kwargs_synthesis=kwargs_synthesis,
+                #    **kwargs_multiplane_model
+                #)
             else:
-                self.lens_model = MultiPlane(
-                    z_source,
-                    lens_model_list,
-                    lens_redshift_list,
-                    cosmo=cosmo,
-                    numerical_alpha_class=numerical_alpha_class,
-                    observed_convention_index=observed_convention_index,
-                    z_source_convention=z_source_convention,
-                    cosmo_interp=cosmo_interp,
-                    z_interp_stop=z_interp_stop,
-                    num_z_interp=num_z_interp,
-                    kwargs_interp=kwargs_interp,
-                    kwargs_synthesis=kwargs_synthesis,
-                    distance_ratio_sampling=distance_ratio_sampling,
-                )
+                raise ValueError("multi plane lens model not supported in jaxtronomy yet")
+                #self.lens_model = MultiPlane(
+                #    z_source,
+                #    lens_model_list,
+                #    lens_redshift_list,
+                #    cosmo=cosmo,
+                #    numerical_alpha_class=numerical_alpha_class,
+                #    observed_convention_index=observed_convention_index,
+                #    z_source_convention=z_source_convention,
+                #    cosmo_interp=cosmo_interp,
+                #    z_interp_stop=z_interp_stop,
+                #    num_z_interp=num_z_interp,
+                #    kwargs_interp=kwargs_interp,
+                #    kwargs_synthesis=kwargs_synthesis,
+                #    distance_ratio_sampling=distance_ratio_sampling,
+                #)
 
         else:
             if los_effects is True:
@@ -167,6 +170,7 @@ class LensModel(object):
         if z_lens is not None and z_source is not None:
             self._lensCosmo = LensCosmo(z_lens, z_source, cosmo=cosmo)
 
+    @partial(jit, static_argnums=(0, 4))
     def ray_shooting(self, x, y, kwargs, k=None):
         """Maps image to source position (inverse deflection)
 
@@ -177,10 +181,12 @@ class LensModel(object):
         :param kwargs: list of keyword arguments of lens model parameters matching the
             lens model classes
         :param k: only evaluate the k-th lens model
+        :type k: None, int, or tuple of ints
         :return: source plane positions corresponding to (x, y) in the image plane
         """
         return self.lens_model.ray_shooting(x, y, kwargs, k=k)
 
+    @partial(jit, static_argnums=(0))
     def fermat_potential(
         self, x_image, y_image, kwargs_lens, x_source=None, y_source=None
     ):
@@ -202,54 +208,55 @@ class LensModel(object):
             return self.lens_model.fermat_potential(
                 x_image, y_image, kwargs_lens, x_source, y_source
             )
-        elif hasattr(self.lens_model, "arrival_time") and hasattr(self, "_lensCosmo"):
-            dt = self.lens_model.arrival_time(x_image, y_image, kwargs_lens)
-            fermat_pot_eff = (
-                dt
-                * const.c
-                / self._lensCosmo.ddt
-                / const.Mpc
-                * const.day_s
-                / const.arcsec**2
-            )
-            return fermat_pot_eff
+        #elif hasattr(self.lens_model, "arrival_time") and hasattr(self, "_lensCosmo"):
+        #    dt = self.lens_model.arrival_time(x_image, y_image, kwargs_lens)
+        #    fermat_pot_eff = (
+        #        dt
+        #        * const.c
+        #        / self._lensCosmo.ddt
+        #        / const.Mpc
+        #        * const.day_s
+        #        / const.arcsec**2
+        #    )
+        #    return fermat_pot_eff
         else:
             raise ValueError(
                 "In multi-plane lensing you need to provide a specific z_lens and z_source for which the "
                 "effective Fermat potential is evaluated"
             )
 
-    def arrival_time(
-        self, x_image, y_image, kwargs_lens, kappa_ext=0, x_source=None, y_source=None
-    ):
-        """Arrival time of images relative to a straight line without lensing. Negative
-        values correspond to images arriving earlier, and positive signs correspond to
-        images arriving later.
+    #def arrival_time(
+    #    self, x_image, y_image, kwargs_lens, kappa_ext=0, x_source=None, y_source=None
+    #):
+    #    """Arrival time of images relative to a straight line without lensing. Negative
+    #    values correspond to images arriving earlier, and positive signs correspond to
+    #    images arriving later.
 
-        :param x_image: image position
-        :param y_image: image position
-        :param kwargs_lens: lens model parameter keyword argument list
-        :param kappa_ext: external convergence contribution not accounted in the lens
-            model that leads to the same observables in position and relative fluxes but
-            rescales the time delays
-        :param x_source: source position (optional), otherwise computed with ray-tracing
-        :param y_source: source position (optional), otherwise computed with ray-tracing
-        :return: arrival time of image positions in units of days
-        """
-        if hasattr(self.lens_model, "arrival_time"):
-            arrival_time = self.lens_model.arrival_time(x_image, y_image, kwargs_lens)
-        else:
-            fermat_pot = self.lens_model.fermat_potential(
-                x_image, y_image, kwargs_lens, x_source=x_source, y_source=y_source
-            )
-            if not hasattr(self, "_lensCosmo"):
-                raise ValueError(
-                    "LensModel class was not initialized with lens and source redshifts!"
-                )
-            arrival_time = self._lensCosmo.time_delay_units(fermat_pot)
-        arrival_time *= 1 - kappa_ext
-        return arrival_time
+    #    :param x_image: image position
+    #    :param y_image: image position
+    #    :param kwargs_lens: lens model parameter keyword argument list
+    #    :param kappa_ext: external convergence contribution not accounted in the lens
+    #        model that leads to the same observables in position and relative fluxes but
+    #        rescales the time delays
+    #    :param x_source: source position (optional), otherwise computed with ray-tracing
+    #    :param y_source: source position (optional), otherwise computed with ray-tracing
+    #    :return: arrival time of image positions in units of days
+    #    """
+    #    if hasattr(self.lens_model, "arrival_time"):
+    #        arrival_time = self.lens_model.arrival_time(x_image, y_image, kwargs_lens)
+    #    else:
+    #        fermat_pot = self.lens_model.fermat_potential(
+    #            x_image, y_image, kwargs_lens, x_source=x_source, y_source=y_source
+    #        )
+    #        if not hasattr(self, "_lensCosmo"):
+    #            raise ValueError(
+    #                "LensModel class was not initialized with lens and source redshifts!"
+    #            )
+    #        arrival_time = self._lensCosmo.time_delay_units(fermat_pot)
+    #    arrival_time *= 1 - kappa_ext
+    #    return arrival_time
 
+    @partial(jit, static_argnums=(0, 4))
     def potential(self, x, y, kwargs, k=None):
         """Lensing potential.
 
@@ -260,10 +267,12 @@ class LensModel(object):
         :param kwargs: list of keyword arguments of lens model parameters matching the
             lens model classes
         :param k: only evaluate the k-th lens model
+        :type k: None, int, or tuple of ints
         :return: lensing potential in units of arcsec^2
         """
         return self.lens_model.potential(x, y, kwargs, k=k)
 
+    @partial(jit, static_argnums=(0, 4))
     def alpha(self, x, y, kwargs, k=None, diff=None):
         """Deflection angles.
 
@@ -274,6 +283,7 @@ class LensModel(object):
         :param kwargs: list of keyword arguments of lens model parameters matching the
             lens model classes
         :param k: only evaluate the k-th lens model
+        :type k: None, int, or tuple of ints
         :param diff: None or float. If set, computes the deflection as a finite
             numerical differential of the lensing potential. This differential is only
             applicable in the single lensing plane where the form of the lensing
@@ -290,6 +300,7 @@ class LensModel(object):
                 "setting as analytical form of lensing potential is not available."
             )
 
+    @partial(jit, static_argnums=(0, 4, 6))
     def hessian(self, x, y, kwargs, k=None, diff=None, diff_method="square"):
         """Hessian matrix.
 
@@ -300,6 +311,7 @@ class LensModel(object):
         :param kwargs: list of keyword arguments of lens model parameters matching the
             lens model classes
         :param k: only evaluate the k-th lens model
+        :type k: None, int, or tuple of ints
         :param diff: float, scale over which the finite numerical differential is
             computed. If None, then using the exact (if available) differentials.
         :param diff_method: string, 'square' or 'cross', indicating whether finite
@@ -318,6 +330,7 @@ class LensModel(object):
                 % diff_method
             )
 
+    @partial(jit, static_argnums=(0, 4, 6))
     def kappa(self, x, y, kwargs, k=None, diff=None, diff_method="square"):
         """Lensing convergence k = 1/2 laplacian(phi)
 
@@ -328,6 +341,7 @@ class LensModel(object):
         :param kwargs: list of keyword arguments of lens model parameters matching the
             lens model classes
         :param k: only evaluate the k-th lens model
+        :type k: None, int, or tuple of ints
         :param diff: float, scale over which the finite numerical differential is
             computed. If None, then using the exact (if available) differentials.
         :param diff_method: string, 'square' or 'cross', indicating whether finite
@@ -341,6 +355,7 @@ class LensModel(object):
         kappa = 1.0 / 2 * (f_xx + f_yy)
         return kappa
 
+    @partial(jit, static_argnums=(0, 4, 6))
     def curl(self, x, y, kwargs, k=None, diff=None, diff_method="square"):
         """
         curl computation F_xy - F_yx
@@ -351,6 +366,7 @@ class LensModel(object):
         :type y: numpy array
         :param kwargs: list of keyword arguments of lens model parameters matching the lens model classes
         :param k: only evaluate the k-th lens model
+        :type k: None, int, or tuple of ints
         :param diff: float, scale over which the finite numerical differential is computed. If None, then using the
          exact (if available) differentials.
         :param diff_method: string, 'square' or 'cross', indicating whether finite differentials are computed from a
@@ -362,6 +378,7 @@ class LensModel(object):
         )
         return f_xy - f_yx
 
+    @partial(jit, static_argnums=(0, 4, 6))
     def gamma(self, x, y, kwargs, k=None, diff=None, diff_method="square"):
         """
         shear computation
@@ -374,6 +391,7 @@ class LensModel(object):
         :type y: numpy array
         :param kwargs: list of keyword arguments of lens model parameters matching the lens model classes
         :param k: only evaluate the k-th lens model
+        :type k: None, int, or tuple of ints
         :param diff: float, scale over which the finite numerical differential is computed. If None, then using the
          exact (if available) differentials.
         :param diff_method: string, 'square' or 'cross', indicating whether finite differentials are computed from a
@@ -388,6 +406,7 @@ class LensModel(object):
         gamma2 = f_xy
         return gamma1, gamma2
 
+    @partial(jit, static_argnums=(0, 4, 6))
     def magnification(self, x, y, kwargs, k=None, diff=None, diff_method="square"):
         """magnification.
 
@@ -400,6 +419,7 @@ class LensModel(object):
         :type y: numpy array
         :param kwargs: list of keyword arguments of lens model parameters matching the lens model classes
         :param k: only evaluate the k-th lens model
+        :type k: None, int, or tuple of ints
         :param diff: float, scale over which the finite numerical differential is computed. If None, then using the
          exact (if available) differentials.
         :param diff_method: string, 'square' or 'cross', indicating whether finite differentials are computed from a
@@ -413,7 +433,8 @@ class LensModel(object):
         det_A = (1 - f_xx) * (1 - f_yy) - f_xy * f_yx
         return 1.0 / det_A  # attention, if dividing by zero
 
-    def flexion(self, x, y, kwargs, k=None, diff=0.000001, hessian_diff=True):
+    @partial(jit, static_argnums=(0, 4, 6))
+    def flexion(self, x, y, kwargs, k=None, diff=0.0001, hessian_diff=False):
         """Third derivatives (flexion)
 
         :param x: x-position (preferentially arcsec)
@@ -422,27 +443,29 @@ class LensModel(object):
         :type y: numpy array
         :param kwargs: list of keyword arguments of lens model parameters matching the
             lens model classes
-        :param k: int or None, if set, only evaluates the differential from one model
-            component
+        :param k: if set, only evaluates the differential from one model component
+        :type k: None, int, or tuple of ints
         :param diff: numerical differential length of Flexion
         :param hessian_diff: boolean, if true also computes the numerical differential
             length of Hessian (optional)
         :return: f_xxx, f_xxy, f_xyy, f_yyy
         """
-        if hessian_diff is not True:
-            hessian_diff = None
+        if hessian_diff:
+            hessian_diff_ = diff/4
+        else:
+            hessian_diff_ = None
         f_xx_dx, f_xy_dx, f_yx_dx, f_yy_dx = self.hessian(
-            x + diff / 2, y, kwargs, k=k, diff=hessian_diff
+            x + diff / 2, y, kwargs, k=k, diff=hessian_diff_
         )
         f_xx_dy, f_xy_dy, f_yx_dy, f_yy_dy = self.hessian(
-            x, y + diff / 2, kwargs, k=k, diff=hessian_diff
+            x, y + diff / 2, kwargs, k=k, diff=hessian_diff_
         )
 
         f_xx_dx_, f_xy_dx_, f_yx_dx_, f_yy_dx_ = self.hessian(
-            x - diff / 2, y, kwargs, k=k, diff=hessian_diff
+            x - diff / 2, y, kwargs, k=k, diff=hessian_diff_
         )
         f_xx_dy_, f_xy_dy_, f_yx_dy_, f_yy_dy_ = self.hessian(
-            x, y - diff / 2, kwargs, k=k, diff=hessian_diff
+            x, y - diff / 2, kwargs, k=k, diff=hessian_diff_
         )
 
         f_xxx = (f_xx_dx - f_xx_dx_) / diff
@@ -472,6 +495,7 @@ class LensModel(object):
         """
         self.lens_model.set_dynamic()
 
+    @partial(jit, static_argnums=(0, 4))
     def _deflection_differential(self, x, y, kwargs, k=None, diff=0.00001):
         """
 
@@ -479,6 +503,7 @@ class LensModel(object):
         :param y: y-coordinate
         :param kwargs: keyword argument list
         :param k: int or None, if set, only evaluates the differential from one model component
+        :type k: None, int, or tuple of ints
         :param diff: finite differential length
         :return: f_x, f_y
         """
@@ -490,6 +515,7 @@ class LensModel(object):
         f_y = (phi_dy - phi_dy_) / diff
         return f_x, f_y
 
+    @partial(jit, static_argnums=(0, 4))
     def _hessian_differential_cross(self, x, y, kwargs, k=None, diff=0.00001):
         """Computes the numerical differentials over a finite range for f_xx, f_yy, f_xy
         from f_x and f_y The differentials are computed along the cross centered at (x,
@@ -498,7 +524,7 @@ class LensModel(object):
         :param x: x-coordinate
         :param y: y-coordinate
         :param kwargs: lens model keyword argument list
-        :param k: int, list of bools or None, indicating a subset of lens models to be
+        :param k: int, tuple of ints or None, indicating a subset of lens models to be
             evaluated
         :param diff: float, scale of the finite differential (diff/2 in each direction
             used to compute the differential
@@ -521,6 +547,7 @@ class LensModel(object):
         f_yx = dalpha_decra
         return f_xx, f_xy, f_yx, f_yy
 
+    @partial(jit, static_argnums=(0, 4))
     def _hessian_differential_square(self, x, y, kwargs, k=None, diff=0.00001):
         """Computes the numerical differentials over a finite range for f_xx, f_yy, f_xy
         from f_x and f_y The differentials are computed on the square around (x, y).
@@ -529,7 +556,7 @@ class LensModel(object):
         :param x: x-coordinate
         :param y: y-coordinate
         :param kwargs: lens model keyword argument list
-        :param k: int, list of booleans or None, indicating a subset of lens models to
+        :param k: int, list of ints or None, indicating a subset of lens models to
             be evaluated
         :param diff: float, scale of the finite differential (diff/2 in each direction
             used to compute the differential
@@ -548,26 +575,28 @@ class LensModel(object):
 
         return f_xx, f_xy, f_yx, f_yy
 
-    def hessian_z1z2(self, z1, z2, theta_x, theta_y, kwargs_lens, diff=0.00000001):
-        """Computes Hessian matrix when Observed at z1 with rays going to z2 with z1 <
-        z2 for multi_plane.
+    #@partial(jit, static_argnums=(0,))
+    #def hessian_z1z2(self, z1, z2, theta_x, theta_y, kwargs_lens, diff=0.00000001):
+    #    """Computes Hessian matrix when Observed at z1 with rays going to z2 with z1 <
+    #    z2 for multi_plane.
 
-        :param z1: Observer redshift
-        :param z2: source redshift
-        :param theta_x: angular position and direction of the ray
-        :param theta_y: angular position and direction of the ray
-        :param kwargs_lens: list of keyword arguments of lens model parameters matching
-            the lens model classes
-        :param diff: numerical differential step (float)
-        :return: f_xx, f_xy, f_yx, f_yy
-        """
-        if self.multi_plane is False:
-            raise ValueError("Hessian z1z2 need to be compute in multi-plane mode")
-        if z1 >= z2:
-            raise ValueError("z1 needs to be smaller than z2")
+    #    :param z1: Observer redshift
+    #    :param z2: source redshift
+    #    :param theta_x: angular position and direction of the ray
+    #    :param theta_y: angular position and direction of the ray
+    #    :param kwargs_lens: list of keyword arguments of lens model parameters matching
+    #        the lens model classes
+    #    :param diff: numerical differential step (float)
+    #    :return: f_xx, f_xy, f_yx, f_yy
+    #    """
+    #    if self.multi_plane is False:
+    #        raise ValueError("Hessian z1z2 need to be compute in multi-plane mode")
+    #    # TODO: This doesn't work. Replace with jax.experimental.checkify
+    #    #if z1 >= z2:
+    #    #    raise ValueError("z1 needs to be smaller than z2")
 
-        f_xx, f_xy, f_yx, f_yy = self.lens_model.hessian_z1z2(
-            z1, z2, theta_x, theta_y, kwargs_lens, diff=diff
-        )
+    #    f_xx, f_xy, f_yx, f_yy = self.lens_model.hessian_z1z2(
+    #        z1, z2, theta_x, theta_y, kwargs_lens, diff=diff
+    #    )
 
-        return f_xx, f_xy, f_yx, f_yy
+    #    return f_xx, f_xy, f_yx, f_yy

--- a/jaxtronomy/LensModel/lens_model.py
+++ b/jaxtronomy/LensModel/lens_model.py
@@ -2,8 +2,9 @@ __author__ = "sibirrer"
 from jaxtronomy.LensModel.single_plane import SinglePlane
 from jaxtronomy.LensModel.LineOfSight.single_plane_los import SinglePlaneLOS
 
-from lenstronomy.Cosmo.lens_cosmo import LensCosmo
-from lenstronomy.Util import constants as const
+# TODO: Implement multi plane
+#from lenstronomy.Cosmo.lens_cosmo import LensCosmo
+#from lenstronomy.Util import constants as const
 
 from functools import partial
 from jax import jit

--- a/jaxtronomy/LensModel/single_plane.py
+++ b/jaxtronomy/LensModel/single_plane.py
@@ -31,6 +31,7 @@ class SinglePlane(ProfileListBase):
         dx, dy = self.alpha(x, y, kwargs, k=k)
         return x - dx, y - dy
 
+    @partial(jit, static_argnums=(0, 6))
     def fermat_potential(
         self, x_image, y_image, kwargs_lens, x_source=None, y_source=None, k=None
     ):

--- a/jaxtronomy/LightModel/Profiles/shapelets.py
+++ b/jaxtronomy/LightModel/Profiles/shapelets.py
@@ -121,9 +121,7 @@ class Shapelets(object):
         """
 
         if self._precalc:
-            x = jnp.array(x)
-            y = jnp.array(y)
-            return amp * x.at[n1].get() * y.at[n2].get()
+            return amp * x[n1] * y[n2]
 
         x_ = x - center_x
         y_ = y - center_y

--- a/jaxtronomy/LightModel/Profiles/shapelets.py
+++ b/jaxtronomy/LightModel/Profiles/shapelets.py
@@ -1,0 +1,264 @@
+__author__ = "sibirrer"
+
+from functools import partial
+from jax import lax, jit, numpy as jnp
+import math
+import numpy as np
+
+from jaxtronomy.Util.herm_util import eval_hermite, hermval
+
+class Shapelets(object):
+    """Class for 2d cartesian Shapelets.
+
+    Sources:
+    Refregier 2003: Shapelets: I. A Method for Image Analysis https://arxiv.org/abs/astro-ph/0105178
+    Refregier 2003: Shapelets: II. A Method for Weak Lensing Measurements https://arxiv.org/abs/astro-ph/0105179
+
+    For one dimension, the shapelets are defined as
+
+    .. math::
+        \\phi_n(x) \\equiv \\left[2^n \\pi^{1/2} n!  \\right]]^{-1/2}H_n(x) e^{-\\frac{x^2}{2}}
+
+    This basis is orthonormal. The dimensional basis function is
+
+    .. math::
+        B_n(x;\\beta) \\equiv \\beta^{-1/2} \\phi_n(\\beta^{-1}x)
+
+    which are orthonormal as well.
+
+    The two-dimensional basis function is
+
+    .. math::
+        \\phi_{\\bf n}({\\bf x}) \\equiv \\phi_{n1}(x1) \\phi_{n2}(x2)
+
+    where :math:`{\\bf n} \\equiv (n1, n2)` and :math:`{\\bf x} \\equiv (x1, x2)`.
+
+    The dimensional two-dimentional basis function is
+
+    .. math::
+        B_{\\bf n}({\\bf x};\\beta) \\equiv \\beta^{-1/2} \\phi_{\\bf n}(\\beta^{-1}{\\bf x}).
+    """
+
+    param_names = ["amp", "beta", "n1", "n2", "center_x", "center_y"]
+    lower_limit_default = {
+        "amp": 0,
+        "beta": 0.01,
+        "n1": 0,
+        "n2": 0,
+        "center_x": -100,
+        "center_y": -100,
+    }
+    upper_limit_default = {
+        "amp": 100,
+        "beta": 100,
+        "n1": 150,
+        "n2": 150,
+        "center_x": 100,
+        "center_y": 100,
+    }
+
+    def __init__(
+        self, interpolation=False, precalc=False, stable_cut=True, cut_scale=5
+    ):
+        """
+
+        :param interpolation: boolean; False in jaxtronomy
+        :param precalc: boolean; if True interprets as input (x, y) as pre-calculated
+            normalized shapelets
+        :param stable_cut: boolean; if True, sets the values outside of
+            :math:`\\sqrt\\left(n_{\\rm max} + 1 \\right) \\beta s_{\\rm cut scale} =
+            0`.
+        :param cut_scale: float, scaling parameter where to cut the shapelets. This is
+            for numerical reasons such that the polynomials in the Hermite function do
+            not get unstable.
+        """
+        # Interpolation is actually slower than calculating the hermite polynomials normally using JAX
+        if interpolation:
+            raise ValueError("interpolation feature for Shapelets is not supported in jaxtronomy")
+
+        self._precalc = precalc
+        self._stable_cut = stable_cut
+        self._cut_scale = cut_scale
+
+    @partial(jit, static_argnums=(0, 3))
+    def hermval(self, x, n_array, tensor=True):
+        """
+        computes the Hermit polynomial as numpy.polynomial.hermite.hermval
+        difference: for values more than sqrt(n_max + 1) * cut_scale, the value is set to zero
+        this should be faster and numerically stable
+
+        :param x: array of values
+        :param n_array: 1d list of coeffs in H_n
+        :param tensor: see numpy.polynomial.hermite.hermval
+        :return: see numpy.polynomial.hermite.hermval
+        """
+        result = hermval(x, n_array)
+        if self._stable_cut:
+            n_max = len(n_array)
+            x_cut = np.sqrt(n_max + 1) * self._cut_scale
+            result = jnp.where(x < x_cut, result, 0)
+        return result
+
+    # This function needs to recompile for different values of n1 and n2
+    # This is required in order to use reverse-mode autodifferentiation
+    # Fortunately, this function compiles quickly
+    @partial(jit, static_argnums=(0, 5, 6))
+    def function(self, x, y, amp, beta, n1, n2, center_x, center_y):
+        """2d cartesian shapelet.
+
+        :param x: x-coordinate
+        :param y: y-coordinate
+        :param amp: amplitude of shapelet
+        :param beta: scale factor of shapelet
+        :param n1: x-order of Hermite polynomial
+        :param n2: y-order of Hermite polynomial
+        :param center_x: center in x
+        :param center_y: center in y
+        :return: flux surface brightness at (x, y)
+        """
+
+        if self._precalc:
+            x = jnp.array(x)
+            y = jnp.array(y)
+            return amp * x.at[n1].get() * y.at[n2].get()
+        
+        x_ = x - center_x
+        y_ = y - center_y
+        return jnp.nan_to_num(
+            amp * self.phi_n(n1, x_ / beta) * self.phi_n(n2, y_ / beta)
+        )
+
+    @partial(jit, static_argnums=(0, 1))
+    def H_n(self, n, x):
+        """Constructs the Hermite polynomial of order n at position x (dimensionless)
+
+        :param n: The n'the basis function.
+        :param x: 1-dim position (dimensionless)
+        :type x: float or jax.numpy array.
+        :returns: array-- H_n(x).
+        """
+        result = eval_hermite(n, x)
+        if self._stable_cut:
+            x_cut = np.sqrt(n + 2) * self._cut_scale
+            result = jnp.where(x < x_cut, result, 0)
+        return result
+
+    @partial(jit, static_argnums=(0, 1))
+    def phi_n(self, n, x):
+        """Constructs the 1-dim basis function (formula (1) in Refregier et al. 2001)
+
+        :param n: The n'the basis function.
+        :type n: int.
+        :param x: 1-dim position (dimensionless)
+        :type x: float or numpy array.
+        :returns: array-- phi_n(x).
+        """
+        prefactor = 1.0 / np.sqrt(2**n * np.sqrt(np.pi) * math.factorial(n))
+        return prefactor * self.H_n(n, x) * jnp.exp(-(x**2) / 2.0)
+
+    @partial(jit, static_argnums=(0, 4))
+    def pre_calc(self, x, y, beta, n_order, center_x, center_y):
+        """Calculates the phi_n(x) and phi_n(y) for a given x-array and y-array for the full
+        order in the polynomials.
+
+        :param x: x-coordinates (jax.numpy array)
+        :param y: y-coordinates (jax.numpy array)
+        :param beta: shapelet scale
+        :param n_order: order of shapelets
+        :param center_x: shapelet center
+        :param center_y: shapelet center
+        :return: jnp.arrays of phi_n(x) and phi_n(y)
+        """
+        if n_order > 170:
+            raise ValueError(f"polynomial order {n_order} too large")
+
+        x_ = jnp.atleast_1d(x - center_x) / beta
+        y_ = jnp.atleast_1d(y - center_y) / beta
+
+        H_x = jnp.zeros((n_order + 1, len(x_)))
+        H_x = H_x.at[0].set(jnp.ones_like(x_, dtype=float))
+        H_x = H_x.at[1].set(2 * x_)
+
+        H_y = jnp.zeros((n_order + 1, len(y_)))
+        H_y = H_y.at[0].set(jnp.ones_like(y_, dtype=float))
+        H_y = H_y.at[1].set(2 * y_)
+
+        prefactor = jnp.zeros(n_order + 1, dtype=float)
+        prefactor = prefactor.at[0].set(1.0 / (jnp.pi)**(1./4.))
+        prefactor = prefactor.at[1].set(prefactor[0] / jnp.sqrt(2))
+
+        exp_x = jnp.exp(-(x_**2) / 2.0)
+        exp_y = jnp.exp(-(y_**2) / 2.0)
+
+        def body_fun(n, val):
+            H_x, H_y, prefactor = val
+
+            new_Hx = 2 * x_ * H_x.at[n-1].get() - 2 * (n-1) * H_x.at[n-2].get()
+            H_x = H_x.at[n].set(new_Hx)
+
+            new_Hy = 2 * y_ * H_y.at[n-1].get() - 2 * (n-1) * H_y.at[n-2].get()
+            H_y = H_y.at[n].set(new_Hy)
+
+            new_prefactor = prefactor.at[n-1].get() / jnp.sqrt(2 * n)
+            prefactor = prefactor.at[n].set(new_prefactor)
+
+            return H_x, H_y, prefactor
+        
+        H_x, H_y, prefactor = lax.fori_loop(2, n_order + 1, body_fun, (H_x, H_y, prefactor))
+
+        if self._stable_cut:
+            cut_threshold = np.sqrt(n_order + 2) * self._cut_scale
+            cut_x, cut_y = jnp.where(x_ < cut_threshold, 1, 0), jnp.where(y_ < cut_threshold, 1, 0)
+        else:
+            cut_x, cut_y = jnp.ones_like(x_), jnp.ones_like(y_)
+            
+        phi_x = ((H_x * cut_x * exp_x).T * prefactor).T
+        phi_y = ((H_y * cut_y * exp_y).T * prefactor).T
+        return phi_x, phi_y
+
+
+class ShapeletSet(object):
+    """Class to operate on entire shapelet set limited by a maximal polynomial order
+    n_max, such that n1 + n2 <= n_max."""
+
+    param_names = ["amp", "n_max", "beta", "center_x", "center_y"]
+    lower_limit_default = {"beta": 0.01, "center_x": -100, "center_y": -100}
+    upper_limit_default = {"beta": 100, "center_x": 100, "center_y": 100}
+
+    def __init__(self):
+        self.shapelets = Shapelets(precalc=True)
+
+    @partial(jit, static_argnums=(0, 4))
+    def function(self, x, y, amp, n_max, beta, center_x=0, center_y=0):
+        """
+
+        :param x: x-coordinates
+        :param y: y-coordinates
+        :param amp: 1d array of amplitudes in pre-defined order of shapelet basis functions
+            amp[0] corresponds to (n1, n2) = (0, 0), amp[1] corresponds to (n1, n2) = (1, 0)
+            amp[2] corresponds to (n1, n2) = (0, 1), amp[3] corresponds to (n1, n2) = (2, 0)
+            amp[4] corresponds to (n1, n2) = (1, 1), amp[5] corresponds to (n1, n2) = (0, 2)
+            amp[6] corresponds to (n1, n2) = (3, 0), etc
+        :param beta: shapelet scale
+        :param n_max: maximum polynomial order in Hermite polynomial
+        :param center_x: shapelet center
+        :param center_y: shapelet center
+        :return: surface brightness of combined shapelet set
+        """
+        x_shape = x.shape
+        x = jnp.atleast_1d(x)
+        f_ = jnp.zeros_like(x)
+
+        num_param = int((n_max + 1) * (n_max + 2) / 2)
+        n1 = 0
+        n2 = 0
+        phi_x, phi_y = self.shapelets.pre_calc(x, y, beta, n_max, center_x, center_y)
+        def body_fun(i, val):
+            f_, n1, n2 = val
+            f_ += amp[i] * phi_x.at[n1].get() * phi_y.at[n2].get()
+            n1, n2 = jnp.where(n1 == 0, n2 + 1, n1 - 1), jnp.where(n1 == 0, 0, n2 + 1)
+            return f_, n1, n2
+
+        f_ = lax.fori_loop(0, num_param, body_fun, (f_, n1, n2))[0]
+        f_ = f_.reshape(x_shape)
+        return jnp.nan_to_num(f_)

--- a/jaxtronomy/LightModel/light_model.py
+++ b/jaxtronomy/LightModel/light_model.py
@@ -48,4 +48,6 @@ class LightModel(LinearBasis):
             sersic_major_axis=sersic_major_axis,
         )
         self.deflection_scaling_list = deflection_scaling_list
+        if source_redshift_list is not None:
+            raise ValueError("multi plane sources not supported in jaxtronomy yet")
         self.redshift_list = source_redshift_list

--- a/jaxtronomy/LightModel/light_model.py
+++ b/jaxtronomy/LightModel/light_model.py
@@ -48,6 +48,6 @@ class LightModel(LinearBasis):
             sersic_major_axis=sersic_major_axis,
         )
         self.deflection_scaling_list = deflection_scaling_list
-        if source_redshift_list is not None or source_redshift_list != []:
+        if source_redshift_list is not None and source_redshift_list != []:
             raise ValueError("multi plane sources not supported in jaxtronomy yet")
         self.redshift_list = source_redshift_list

--- a/jaxtronomy/LightModel/light_model.py
+++ b/jaxtronomy/LightModel/light_model.py
@@ -48,6 +48,6 @@ class LightModel(LinearBasis):
             sersic_major_axis=sersic_major_axis,
         )
         self.deflection_scaling_list = deflection_scaling_list
-        if source_redshift_list is not None:
+        if source_redshift_list is not None or source_redshift_list != []:
             raise ValueError("multi plane sources not supported in jaxtronomy yet")
         self.redshift_list = source_redshift_list

--- a/jaxtronomy/LightModel/light_model_base.py
+++ b/jaxtronomy/LightModel/light_model_base.py
@@ -20,6 +20,7 @@ _JAXXED_MODELS = [
     "SERSIC",
     "SERSIC_ELLIPSE",
     "SERSIC_ELLIPSE_Q_PHI",
+    "SHAPELETS",
     "CORE_SERSIC",
 ]
 
@@ -124,10 +125,10 @@ class LightModelBase(object):
                     CoreSersic(smoothing=smoothing, sersic_major_axis=sersic_major_axis)
                 )
 
-            # elif profile_type == "SHAPELETS":
-            #     from lenstronomy.LightModel.Profiles.shapelets import ShapeletSet
+            elif profile_type == "SHAPELETS":
+                from jaxtronomy.LightModel.Profiles.shapelets import ShapeletSet
 
-            #     self.func_list.append(ShapeletSet())
+                self.func_list.append(ShapeletSet())
             # elif profile_type == "SHAPELETS_ELLIPSE":
             #     from lenstronomy.LightModel.Profiles.shapelets_ellipse import (
             #         ShapeletSetEllipse,

--- a/jaxtronomy/Util/herm_util.py
+++ b/jaxtronomy/Util/herm_util.py
@@ -1,0 +1,52 @@
+import jax.numpy as jnp
+from jax import jit, lax
+
+from functools import partial
+
+@partial(jit, static_argnums=0)
+def eval_hermite(n, x):
+    """Equivalent to scipy.special.eval_hermite(n, x).
+
+    :param n: int, order of hermite polynomial to be evaluated
+    :param x: array-like, coordinates to evaluate hermite polynomial
+    :return: array with same shape as x containing H_n(x)
+    """
+    x = jnp.array(x, dtype=float)
+
+    prev_H = jnp.ones_like(x)
+    H = 2. * x
+    def body_fun(i, val):
+        x, H, prev_H = val
+        H, prev_H = 2 * x * H - 2 * (i-1) * prev_H, H
+        return (x, H, prev_H)
+    
+    result = lax.fori_loop(2, n + 1, body_fun, (x, H, prev_H))[1]
+
+    result = jnp.where(n == 0, 1., result)
+
+    return result
+
+@jit
+def hermval(x, c):
+    """Equivalent to numpy.polynomial.hermite.hermval when the input c is 1 dimensional.
+    
+    :param x: array-like, coordinates to evaluate hermite polynomials
+    :param c: array-like, with dimension equal to 1
+    :return: array with the same shape as x containing hermval(x)
+    """
+    x = jnp.array(x, dtype=float)
+    x_shape = x.shape
+    x = jnp.ravel(x)
+    n_array = jnp.array(c, dtype=float)
+    
+    H = jnp.zeros((len(n_array), len(x)))
+    H = H.at[0].set(jnp.ones_like(x))
+    H = H.at[1].set(2. * x)
+
+    def body_fun(i, H):
+        new_H = 2 * x * H.at[i-1].get() - 2 * (i-1) * H.at[i-2].get()
+        H = H.at[i].set(new_H)
+        return H
+
+    H = lax.fori_loop(2, len(n_array), body_fun, H)
+    return jnp.sum(H.T * n_array, axis=1).reshape(x_shape)

--- a/jaxtronomy/Util/herm_util.py
+++ b/jaxtronomy/Util/herm_util.py
@@ -3,6 +3,7 @@ from jax import jit, lax
 
 from functools import partial
 
+
 @partial(jit, static_argnums=0)
 def eval_hermite(n, x):
     """Equivalent to scipy.special.eval_hermite(n, x).
@@ -14,22 +15,24 @@ def eval_hermite(n, x):
     x = jnp.array(x, dtype=float)
 
     prev_H = jnp.ones_like(x)
-    H = 2. * x
+    H = 2.0 * x
+
     def body_fun(i, val):
         x, H, prev_H = val
-        H, prev_H = 2 * x * H - 2 * (i-1) * prev_H, H
+        H, prev_H = 2 * x * H - 2 * (i - 1) * prev_H, H
         return (x, H, prev_H)
-    
+
     result = lax.fori_loop(2, n + 1, body_fun, (x, H, prev_H))[1]
 
-    result = jnp.where(n == 0, 1., result)
+    result = jnp.where(n == 0, 1.0, result)
 
     return result
+
 
 @jit
 def hermval(x, c):
     """Equivalent to numpy.polynomial.hermite.hermval when the input c is 1 dimensional.
-    
+
     :param x: array-like, coordinates to evaluate hermite polynomials
     :param c: array-like, with dimension equal to 1
     :return: array with the same shape as x containing hermval(x)
@@ -38,13 +41,13 @@ def hermval(x, c):
     x_shape = x.shape
     x = jnp.ravel(x)
     n_array = jnp.array(c, dtype=float)
-    
+
     H = jnp.zeros((len(n_array), len(x)))
     H = H.at[0].set(jnp.ones_like(x))
-    H = H.at[1].set(2. * x)
+    H = H.at[1].set(2.0 * x)
 
     def body_fun(i, H):
-        new_H = 2 * x * H.at[i-1].get() - 2 * (i-1) * H.at[i-2].get()
+        new_H = 2 * x * H.at[i - 1].get() - 2 * (i - 1) * H.at[i - 2].get()
         H = H.at[i].set(new_H)
         return H
 

--- a/test/test_LensModel/test_lens_model.py
+++ b/test/test_LensModel/test_lens_model.py
@@ -5,8 +5,6 @@ import numpy.testing as npt
 import pytest
 from jaxtronomy.LensModel.lens_model import LensModel
 from lenstronomy.LensModel.lens_model import LensModel as LensModel_ref
-from lenstronomy.LensModel.MultiPlane.multi_plane import MultiPlane
-from lenstronomy.LensModel.MultiPlane.decoupled_multi_plane import MultiPlaneDecoupled
 
 from lenstronomy.Util.util import make_grid
 import unittest
@@ -112,10 +110,10 @@ class TestLensModel(object):
 
     def test_flexion(self):
         f_xxx, f_xxy, f_xyy, f_yyy = self.lensModel.flexion(
-            self.x, self.y, kwargs=self.kwargs
+            self.x, self.y, kwargs=self.kwargs, hessian_diff=True
         )
         f_xxx_ref, f_xxy_ref, f_xyy_ref, f_yyy_ref = self.lensModel_ref.flexion(
-            self.x, self.y, kwargs=self.kwargs
+            self.x, self.y, kwargs=self.kwargs, hessian_diff=True
         )
         npt.assert_array_almost_equal(f_xxx, f_xxx_ref, decimal=6)
         npt.assert_array_almost_equal(f_xxy, f_xxy_ref, decimal=6)
@@ -143,84 +141,98 @@ class TestLensModel(object):
         npt.assert_array_almost_equal(delta_x, delta_x_ref, decimal=6)
         npt.assert_array_almost_equal(delta_y, delta_y_ref, decimal=6)
 
-    def test_arrival_time(self):
-        z_lens = 0.5
-        z_source = 1.5
-        x_image, y_image = 1.0, 0.0
-        lensModel_mp = LensModel(
-            lens_model_list=["SIS"],
-            multi_plane=True,
-            lens_redshift_list=[z_lens],
-            z_source=z_source,
-        )
-        lensModel_mp_ref = LensModel_ref(
-            lens_model_list=["SIS"],
-            multi_plane=True,
-            lens_redshift_list=[z_lens],
-            z_source=z_source,
-        )
-        kwargs = [
-            {
-                "theta_E": 1.0,
-                "center_x": 0.0,
-                "center_y": 0.0,
-            }
-        ]
-        arrival_time_mp = lensModel_mp.arrival_time(x_image, y_image, kwargs)
-        arrival_time_mp_ref = lensModel_mp_ref.arrival_time(x_image, y_image, kwargs)
-        lensModel_sp = LensModel(
-            lens_model_list=["SIS"], z_source=z_source, z_lens=z_lens
-        )
-        lensModel_sp_ref = LensModel_ref(
-            lens_model_list=["SIS"], z_source=z_source, z_lens=z_lens
-        )
-        arrival_time_sp = lensModel_sp.arrival_time(x_image, y_image, kwargs)
-        arrival_time_sp_ref = lensModel_sp_ref.arrival_time(x_image, y_image, kwargs)
-        npt.assert_array_almost_equal(arrival_time_sp, arrival_time_mp, decimal=8)
-        npt.assert_array_almost_equal(arrival_time_sp, arrival_time_sp_ref, decimal=6)
-        npt.assert_array_almost_equal(arrival_time_mp, arrival_time_mp_ref, decimal=6)
+    #def test_arrival_time(self):
+    #    z_lens = 0.5
+    #    z_source = 1.5
+    #    x_image, y_image = 1.0, 0.0
+    #    lensModel_mp = LensModel(
+    #        lens_model_list=["SIS"],
+    #        multi_plane=True,
+    #        lens_redshift_list=[z_lens],
+    #        z_source=z_source,
+    #    )
+    #    lensModel_mp_ref = LensModel_ref(
+    #        lens_model_list=["SIS"],
+    #        multi_plane=True,
+    #        lens_redshift_list=[z_lens],
+    #        z_source=z_source,
+    #    )
+    #    kwargs = [
+    #        {
+    #            "theta_E": 1.0,
+    #            "center_x": 0.0,
+    #            "center_y": 0.0,
+    #        }
+    #    ]
+    #    arrival_time_mp = lensModel_mp.arrival_time(x_image, y_image, kwargs)
+    #    arrival_time_mp_ref = lensModel_mp_ref.arrival_time(x_image, y_image, kwargs)
+    #    lensModel_sp = LensModel(
+    #        lens_model_list=["SIS"], z_source=z_source, z_lens=z_lens
+    #    )
+    #    lensModel_sp_ref = LensModel_ref(
+    #        lens_model_list=["SIS"], z_source=z_source, z_lens=z_lens
+    #    )
+    #    arrival_time_sp = lensModel_sp.arrival_time(x_image, y_image, kwargs)
+    #    arrival_time_sp_ref = lensModel_sp_ref.arrival_time(x_image, y_image, kwargs)
+    #    npt.assert_array_almost_equal(arrival_time_sp, arrival_time_mp, decimal=8)
+    #    npt.assert_array_almost_equal(arrival_time_sp, arrival_time_sp_ref, decimal=6)
+    #    npt.assert_array_almost_equal(arrival_time_mp, arrival_time_mp_ref, decimal=6)
 
     def test_fermat_potential(self):
         z_lens = 0.5
         z_source = 1.5
-        x_image, y_image = 1.0, 0.0
+        x_image, y_image = 1.032, -2.0234
         lensModel = LensModel(
             lens_model_list=["SIS"],
-            multi_plane=True,
-            lens_redshift_list=[z_lens],
-            z_lens=z_lens,
-            z_source=z_source,
+            #multi_plane=True,
+            #lens_redshift_list=[z_lens],
+            #z_lens=z_lens,
+            #z_source=z_source,
+        )
+        lensModel_ref = LensModel_ref(
+            lens_model_list=["SIS"],
+            #multi_plane=True,
+            #lens_redshift_list=[z_lens],
+            #z_lens=z_lens,
+            #z_source=z_source,
         )
         kwargs = [{"theta_E": 1.0, "center_x": 0.0, "center_y": 0.0}]
         fermat_pot = lensModel.fermat_potential(x_image, y_image, kwargs)
-        arrival_time = lensModel.arrival_time(x_image, y_image, kwargs)
-        arrival_time_from_fermat_pot = lensModel._lensCosmo.time_delay_units(fermat_pot)
-        npt.assert_almost_equal(arrival_time_from_fermat_pot, arrival_time, decimal=8)
+        fermat_pot_ref = lensModel_ref.fermat_potential(x_image, y_image, kwargs)
+        #arrival_time = lensModel.arrival_time(x_image, y_image, kwargs)
+        #arrival_time_from_fermat_pot = lensModel._lensCosmo.time_delay_units(fermat_pot)
+        npt.assert_allclose(fermat_pot, fermat_pot_ref, rtol=1e-10, atol=1e-10)
 
     def test_curl(self):
-        z_lens_list = [0.2, 0.8]
-        z_source = 1.5
+        #z_lens_list = [0.2, 0.8]
+        #z_source = 1.5
         lensModel = LensModel(
             lens_model_list=["SIS", "SIS"],
-            multi_plane=True,
-            lens_redshift_list=z_lens_list,
-            z_source=z_source,
+            #multi_plane=True,
+            #lens_redshift_list=z_lens_list,
+            #z_source=z_source,
+        )
+        lensModel_ref = LensModel_ref(
+            lens_model_list=["SIS", "SIS"],
+            #multi_plane=True,
+            #lens_redshift_list=z_lens_list,
+            #z_source=z_source,
         )
         kwargs = [
             {"theta_E": 1.0, "center_x": 0.0, "center_y": 0.0},
-            {"theta_E": 0.0, "center_x": 0.0, "center_y": 0.2},
+            {"theta_E": 0.1, "center_x": 0.0, "center_y": 0.2},
         ]
-
-        curl = lensModel.curl(x=1, y=1, kwargs=kwargs)
-        assert curl == 0
+        curl = lensModel.curl(x=1.2438, y=1.37485, kwargs=kwargs)
+        curl_ref = lensModel_ref.curl(x=1.2438, y=1.37485, kwargs=kwargs)
+        npt.assert_allclose(curl, curl_ref, rtol=1e-10, atol=1e-10)
 
         kwargs = [
-            {"theta_E": 1.0, "center_x": 0.0, "center_y": 0.0},
-            {"theta_E": 1.0, "center_x": 0.0, "center_y": 0.2},
+            {"theta_E": 1.35, "center_x": -0.348, "center_y": 0.102},
+            {"theta_E": 1.23, "center_x": 0.329, "center_y": 0.2},
         ]
-
-        curl = lensModel.curl(x=1, y=1, kwargs=kwargs)
-        assert curl != 0
+        curl = lensModel.curl(x=1.2438, y=1.37485, kwargs=kwargs)
+        curl_ref = lensModel_ref.curl(x=1.2438, y=1.37485, kwargs=kwargs)
+        npt.assert_allclose(curl, curl_ref, rtol=1e-10, atol=1e-10)
 
     def test_hessian_differentials(self):
         """Routine to test the private numerical differentials, both cross and square
@@ -246,45 +258,45 @@ class TestLensModel(object):
         npt.assert_array_almost_equal(f_yx_sq, f_yx, decimal=5)
         npt.assert_array_almost_equal(f_yy_sq, f_yy, decimal=5)
 
-    def test_hessian_z1z2(self):
-        z_source = 1.5
-        lens_model_list = ["SIS"]
-        kwargs_lens = [{"theta_E": 1}]
-        redshift_list = [0.5]
-        lensModel = LensModel(
-            lens_model_list=lens_model_list,
-            multi_plane=True,
-            lens_redshift_list=redshift_list,
-            z_source=z_source,
-        )
-        z1, z2 = 0.5, 1.5
-        theta_x, theta_y = jnp.linspace(start=-1, stop=1, num=10), jnp.linspace(
-            start=-1, stop=1, num=10
-        )
+    #def test_hessian_z1z2(self):
+    #    z_source = 1.5
+    #    lens_model_list = ["SIS"]
+    #    kwargs_lens = [{"theta_E": 1}]
+    #    redshift_list = [0.5]
+    #    lensModel = LensModel(
+    #        lens_model_list=lens_model_list,
+    #        multi_plane=True,
+    #        lens_redshift_list=redshift_list,
+    #        z_source=z_source,
+    #    )
+    #    z1, z2 = 0.5, 1.5
+    #    theta_x, theta_y = jnp.linspace(start=-1, stop=1, num=10), jnp.linspace(
+    #        start=-1, stop=1, num=10
+    #    )
 
-        f_xx, f_xy, f_yx, f_yy = lensModel.hessian_z1z2(
-            z1, z2, theta_x, theta_y, kwargs_lens
-        )
-        # Use the method in multi_plane.hessian_z1z2 as a comparison
-        multi_plane = MultiPlane(
-            z_source=1.5,
-            lens_model_list=lens_model_list,
-            lens_redshift_list=redshift_list,
-            z_interp_stop=3,
-            cosmo_interp=False,
-        )
-        (
-            f_xx_expected,
-            f_xy_expected,
-            f_yx_expected,
-            f_yy_expected,
-        ) = multi_plane.hessian_z1z2(
-            z1=z1, z2=z2, theta_x=theta_x, theta_y=theta_y, kwargs_lens=kwargs_lens
-        )
-        npt.assert_array_almost_equal(f_xx, f_xx_expected, decimal=5)
-        npt.assert_array_almost_equal(f_xy, f_xy_expected, decimal=5)
-        npt.assert_array_almost_equal(f_yx, f_yx_expected, decimal=5)
-        npt.assert_array_almost_equal(f_yy, f_yy_expected, decimal=5)
+    #    f_xx, f_xy, f_yx, f_yy = lensModel.hessian_z1z2(
+    #        z1, z2, theta_x, theta_y, kwargs_lens
+    #    )
+    #    # Use the method in multi_plane.hessian_z1z2 as a comparison
+    #    multi_plane = MultiPlane(
+    #        z_source=1.5,
+    #        lens_model_list=lens_model_list,
+    #        lens_redshift_list=redshift_list,
+    #        z_interp_stop=3,
+    #        cosmo_interp=False,
+    #    )
+    #    (
+    #        f_xx_expected,
+    #        f_xy_expected,
+    #        f_yx_expected,
+    #        f_yy_expected,
+    #    ) = multi_plane.hessian_z1z2(
+    #        z1=z1, z2=z2, theta_x=theta_x, theta_y=theta_y, kwargs_lens=kwargs_lens
+    #    )
+    #    npt.assert_array_almost_equal(f_xx, f_xx_expected, decimal=5)
+    #    npt.assert_array_almost_equal(f_xy, f_xy_expected, decimal=5)
+    #    npt.assert_array_almost_equal(f_yx, f_yx_expected, decimal=5)
+    #    npt.assert_array_almost_equal(f_yy, f_yy_expected, decimal=5)
 
 
 class TestRaise(unittest.TestCase):
@@ -297,10 +309,10 @@ class TestRaise(unittest.TestCase):
             f_x, f_y = lensModel.alpha(1, 1, kwargs, diff=0.0001)
         with self.assertRaises(ValueError):
             lensModel = LensModel(["NFW"], multi_plane=True, lens_redshift_list=[1])
-        with self.assertRaises(ValueError):
-            kwargs = [{"alpha_Rs": 1, "Rs": 0.5, "center_x": 0, "center_y": 0}]
-            lensModel = LensModel(["NFW"], multi_plane=False)
-            t_arrival = lensModel.arrival_time(1, 1, kwargs)
+        #with self.assertRaises(ValueError):
+        #    kwargs = [{"alpha_Rs": 1, "Rs": 0.5, "center_x": 0, "center_y": 0}]
+        #    lensModel = LensModel(["NFW"], multi_plane=False)
+        #    t_arrival = lensModel.arrival_time(1, 1, kwargs)
         with self.assertRaises(ValueError):
             z_lens = 0.5
             z_source = 1.5
@@ -345,30 +357,30 @@ class TestRaise(unittest.TestCase):
                 lens_redshift_list=[0.5, 0.5, 0.5],
             )
 
-    def test_hessian_z1z2_raise(self):
-        lensModel = LensModel(
-            lens_model_list=["SIS"],
-            multi_plane=True,
-            lens_redshift_list=[1],
-            z_source=2,
-        )
-        kwargs = [{"theta_E": 1, "center_x": 0, "center_y": 0}]
+    #def test_hessian_z1z2_raise(self):
+    #    lensModel = LensModel(
+    #        lens_model_list=["SIS"],
+    #        multi_plane=True,
+    #        lens_redshift_list=[1],
+    #        z_source=2,
+    #    )
+    #    kwargs = [{"theta_E": 1, "center_x": 0, "center_y": 0}]
 
-        # Test when the model is not in multi-plane mode
-        lensModel_non_multi = LensModel(
-            lens_model_list=["SIS"],
-            multi_plane=False,
-            lens_redshift_list=[1],
-            z_source=2,
-        )
-        with self.assertRaises(ValueError):
-            lensModel_non_multi.hessian_z1z2(0.5, 1.5, 1, 1, kwargs)
+    #    # Test when the model is not in multi-plane mode
+    #    lensModel_non_multi = LensModel(
+    #        lens_model_list=["SIS"],
+    #        multi_plane=False,
+    #        lens_redshift_list=[1],
+    #        z_source=2,
+    #    )
+    #    with self.assertRaises(ValueError):
+    #        lensModel_non_multi.hessian_z1z2(0.5, 1.5, 1, 1, kwargs)
 
-        # Test when z1 >= z2
-        with self.assertRaises(ValueError):
-            lensModel.hessian_z1z2(1.5, 1.5, 1, 1, kwargs)
-        with self.assertRaises(ValueError):
-            lensModel.hessian_z1z2(2.0, 1.5, 1, 1, kwargs)
+    #    # Test when z1 >= z2
+    #    with self.assertRaises(ValueError):
+    #        lensModel.hessian_z1z2(1.5, 1.5, 1, 1, kwargs)
+    #    with self.assertRaises(ValueError):
+    #        lensModel.hessian_z1z2(2.0, 1.5, 1, 1, kwargs)
 
 
 if __name__ == "__main__":

--- a/test/test_LensModel/test_single_plane.py
+++ b/test/test_LensModel/test_single_plane.py
@@ -117,7 +117,7 @@ class TestSinglePlane(object):
         )
 
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.lensModel_ref.hessian(
-            x=1.0, y=1.0, kwargs=self.kwargs, k=(0,1)
+            x=1.0, y=1.0, kwargs=self.kwargs, k=(0, 1)
         )
 
         npt.assert_almost_equal(f_xx, f_xx_ref, decimal=6)

--- a/test/test_LensModel/test_single_plane.py
+++ b/test/test_LensModel/test_single_plane.py
@@ -113,11 +113,24 @@ class TestSinglePlane(object):
 
     def test_hessian(self):
         f_xx, f_xy, f_yx, f_yy = self.lensModel.hessian(
-            x=1.0, y=1.0, kwargs=self.kwargs
+            x=1.0, y=1.0, kwargs=self.kwargs, k=(0, 1)
         )
 
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.lensModel_ref.hessian(
-            x=1.0, y=1.0, kwargs=self.kwargs
+            x=1.0, y=1.0, kwargs=self.kwargs, k=(0,1)
+        )
+
+        npt.assert_almost_equal(f_xx, f_xx_ref, decimal=6)
+        npt.assert_almost_equal(f_xy, f_xy_ref, decimal=6)
+        npt.assert_almost_equal(f_yx, f_yx_ref, decimal=6)
+        npt.assert_almost_equal(f_yy, f_yy_ref, decimal=6)
+
+        f_xx, f_xy, f_yx, f_yy = self.lensModel.hessian(
+            x=1.0, y=1.0, kwargs=self.kwargs, k=0
+        )
+
+        f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.lensModel_ref.hessian(
+            x=1.0, y=1.0, kwargs=self.kwargs, k=0
         )
 
         npt.assert_almost_equal(f_xx, f_xx_ref, decimal=6)

--- a/test/test_LensModel/test_single_plane.py
+++ b/test/test_LensModel/test_single_plane.py
@@ -23,12 +23,12 @@ except:
     bool_test = False
 
 
-class TestLensModel(object):
-    """Tests the source model routines."""
+class TestSinglePlane(object):
+    """Tests the Single Plane lens model routines."""
 
     def setup_method(self):
-        self.lensModel = SinglePlane(["EPL"])
-        self.lensModel_ref = SinglePlane_ref(["EPL"])
+        self.lensModel = SinglePlane(["EPL", "SHEAR"])
+        self.lensModel_ref = SinglePlane_ref(["EPL", "SHEAR"])
 
         self.kwargs = [
             {
@@ -38,12 +38,42 @@ class TestLensModel(object):
                 "center_x": 0.3,
                 "center_y": 0.1,
                 "gamma": 1.73,
+            },
+            {
+                "gamma1": 0.1,
+                "gamma2": 0.3,
             }
         ]
 
+    def test_fermat_potential(self):
+        output = self.lensModel.fermat_potential(x_image=1.0, y_image=1.0, kwargs_lens=self.kwargs, k=0)
+        output_ref = self.lensModel_ref.fermat_potential(x_image=1.0, y_image=1.0, kwargs_lens=self.kwargs, k=0)
+        npt.assert_array_almost_equal(output, output_ref, decimal=8)
+
+        output = self.lensModel.fermat_potential(x_image=1.0, y_image=1.0, kwargs_lens=self.kwargs)
+        output_ref = self.lensModel_ref.fermat_potential(x_image=1.0, y_image=1.0, kwargs_lens=self.kwargs)
+        npt.assert_array_almost_equal(output, output_ref, decimal=8)
+
+        output = self.lensModel.fermat_potential(x_image=1.0, y_image=1.0, kwargs_lens=self.kwargs, k=(0,1))
+        output_ref = self.lensModel_ref.fermat_potential(x_image=1.0, y_image=1.0, kwargs_lens=self.kwargs, k=(0,1))
+        npt.assert_array_almost_equal(output, output_ref, decimal=8)
+
+        output = self.lensModel.fermat_potential(x_image=1.0, y_image=1.0, kwargs_lens=self.kwargs, x_source=3.1, y_source=2.7, k=(0,1))
+        output_ref = self.lensModel_ref.fermat_potential(x_image=1.0, y_image=1.0, kwargs_lens=self.kwargs, x_source=3.1, y_source=2.7, k=(0,1))
+        npt.assert_array_almost_equal(output, output_ref, decimal=8)
+
+
     def test_potential(self):
+        output = self.lensModel.potential(x=1.0, y=1.0, kwargs=self.kwargs, k=0)
+        output_ref = self.lensModel_ref.potential(x=1.0, y=1.0, kwargs=self.kwargs, k=0)
+        npt.assert_array_almost_equal(output, output_ref, decimal=8)
+
         output = self.lensModel.potential(x=1.0, y=1.0, kwargs=self.kwargs)
         output_ref = self.lensModel_ref.potential(x=1.0, y=1.0, kwargs=self.kwargs)
+        npt.assert_array_almost_equal(output, output_ref, decimal=8)
+
+        output = self.lensModel.potential(x=1.0, y=1.0, kwargs=self.kwargs, k=(0,1))
+        output_ref = self.lensModel_ref.potential(x=1.0, y=1.0, kwargs=self.kwargs, k=(0,1))
         npt.assert_array_almost_equal(output, output_ref, decimal=8)
 
     def test_alpha(self):

--- a/test/test_LightModel/test_Profiles/test_shapelets.py
+++ b/test/test_LightModel/test_Profiles/test_shapelets.py
@@ -60,7 +60,6 @@ class TestShapelets_StableCut(object):
         )
         npt.assert_allclose(result, result_ref, atol=1e-10, rtol=1e-15)
 
-
     def test_Hn(self):
         x = np.array([1.3, 3.5, 6.7, 2.5, 13.54, 99])
         n1 = 6

--- a/test/test_LightModel/test_Profiles/test_shapelets.py
+++ b/test/test_LightModel/test_Profiles/test_shapelets.py
@@ -1,0 +1,189 @@
+import numpy as np
+import pytest
+import numpy.testing as npt
+
+import jax
+jax.config.update("jax_enable_x64", True)
+
+from jaxtronomy.LightModel.Profiles.shapelets import Shapelets, ShapeletSet
+from lenstronomy.LightModel.Profiles.shapelets import Shapelets as Shapelets_ref, ShapeletSet as ShapeletSet_ref
+
+class TestShapelets_StableCut(object):
+
+    def setup_method(self):
+        self.shapelet = Shapelets()
+        self.shapelet_ref = Shapelets_ref()
+
+    def test_init(self):
+        npt.assert_raises(ValueError, Shapelets, interpolation=True)
+
+    def test_hermval(self):
+        x = np.array([1.3, 3.5, 6.7, 2.5, 13.54, 99])
+        y = np.array([-0.6, 2.5, 6.1, -2.6, 13.54, 99])
+        n_array = [2, 3.3, 4.6, 6.7, 1.4]
+
+        result = self.shapelet.hermval(x, n_array)
+        result_ref = self.shapelet_ref.hermval(x, n_array)
+        npt.assert_allclose(result, result_ref, atol=1e-10, rtol=1e-15)
+
+        result = self.shapelet.hermval(y, n_array)
+        result_ref = self.shapelet_ref.hermval(y, n_array)
+        npt.assert_allclose(result, result_ref, atol=1e-10, rtol=1e-15)
+
+    def test_function(self):
+        x = np.array([1.3, 3.5, 6.7, 2.5, 13.54, 99])
+        y = np.array([-0.6, 2.5, 6.1, -2.6, 13.54, 99])
+        amp = 31.3584
+        beta = 3.287
+        n1 = 6
+        n2 = 8
+        center_x = np.linspace(-0.3, 0.4, 6)
+        center_y = np.linspace(-0.5, 0.1, 6)
+
+        result = self.shapelet.function(x, y, amp, beta, n1, n2, center_x, center_y)
+        result_ref = self.shapelet_ref.function(x, y, amp, beta, n1, n2, center_x, center_y)
+        npt.assert_allclose(result, result_ref, atol=1e-10, rtol=1e-15)
+
+    def test_Hn(self):
+        x = np.array([1.3, 3.5, 6.7, 2.5, 13.54, 99])
+        n1 = 6
+        n2 = 8
+
+        result = self.shapelet.H_n(n1, x)
+        result_ref = self.shapelet_ref.H_n(n1, x)
+        npt.assert_allclose(result, result_ref, atol=1e-10, rtol=1e-15)
+
+        result = self.shapelet.H_n(n2, x)
+        result_ref = self.shapelet_ref.H_n(n2, x)
+        npt.assert_allclose(result, result_ref, atol=1e-10, rtol=1e-15)
+
+    def test_phin(self):
+        x = np.array([1.3, 3.5, 6.7, 2.5, 13.54, 99])
+        n1 = 6
+        n2 = 8
+
+        result = self.shapelet.phi_n(n1, x)
+        result_ref = self.shapelet_ref.phi_n(n1, x)
+        npt.assert_allclose(result, result_ref, atol=1e-10, rtol=1e-15)
+
+        result = self.shapelet.phi_n(n2, x)
+        result_ref = self.shapelet_ref.phi_n(n2, x)
+        npt.assert_allclose(result, result_ref, atol=1e-10, rtol=1e-15)
+
+    def test_precalc(self):
+        x = np.array([1.3, 3.5, 6.7, 2.5, 13.54, 99])
+        y = np.array([-0.6, 2.5, 6.1, -2.6, 13.54, 99])
+        beta = 3.287
+        n1 = 6
+        center_x = np.linspace(-0.3, 0.4, 6)
+        center_y = np.linspace(-0.5, 0.1, 6)
+        phi_x, phi_y = self.shapelet.pre_calc(x, y, beta, n1, center_x, center_y)
+        phi_x_ref, phi_y_ref = self.shapelet_ref.pre_calc(x, y, beta, n1, center_x, center_y)
+        npt.assert_allclose(phi_x, phi_x_ref, atol=1e-10, rtol=1e-15)
+        npt.assert_allclose(phi_y, phi_y_ref, atol=1e-10, rtol=1e-15)
+        npt.assert_raises(ValueError, self.shapelet.pre_calc, x, y, beta, 171, center_x, center_y)
+
+
+class TestShapelets_NoStableCut(object):
+
+    def setup_method(self):  
+        self.shapelet = Shapelets(stable_cut=False)
+        self.shapelet_ref = Shapelets_ref(stable_cut=False)
+
+    def test_hermval(self):
+        x = np.array([1.3, 3.5, 6.7, 2.5, 13.54, 99])
+        y = np.array([-0.6, 2.5, 6.1, -2.6, 13.54, 99])
+        n_array = [2, 3.3, 4.6, 6.7, 1.4]
+
+        result = self.shapelet.hermval(x, n_array)
+        result_ref = self.shapelet_ref.hermval(x, n_array)
+        npt.assert_allclose(result, result_ref, atol=1e-10, rtol=1e-15)
+
+        result = self.shapelet.hermval(y, n_array)
+        result_ref = self.shapelet_ref.hermval(y, n_array)
+        npt.assert_allclose(result, result_ref, atol=1e-10, rtol=1e-15)
+
+    def test_function(self):
+        x = np.array([1.3, 3.5, 6.7, 2.5, 13.54, 99])
+        y = np.array([-0.6, 2.5, 6.1, -2.6, 13.54, 99])
+        amp = 31.3584
+        beta = 3.287
+        n1 = 6
+        n2 = 8
+        center_x = np.linspace(-0.3, 0.4, 6)
+        center_y = np.linspace(-0.5, 0.1, 6)
+
+        result = self.shapelet.function(x, y, amp, beta, n1, n2, center_x, center_y)
+        result_ref = self.shapelet_ref.function(x, y, amp, beta, n1, n2, center_x, center_y)
+        npt.assert_allclose(result, result_ref, atol=1e-10, rtol=1e-15)
+
+    def test_Hn(self):
+        x = np.array([1.3, 3.5, 6.7, 2.5, 13.54, 99])
+        n1 = 6
+        n2 = 8
+
+        result = self.shapelet.H_n(n1, x)
+        result_ref = self.shapelet_ref.H_n(n1, x)
+        npt.assert_allclose(result, result_ref, atol=1e-10, rtol=1e-15)
+
+        result = self.shapelet.H_n(n2, x)
+        result_ref = self.shapelet_ref.H_n(n2, x)
+        npt.assert_allclose(result, result_ref, atol=1e-10, rtol=1e-15)
+
+    def test_phin(self):
+        x = np.array([1.3, 3.5, 6.7, 2.5, 13.54, 99])
+        n1 = 6
+        n2 = 8
+
+        result = self.shapelet.phi_n(n1, x)
+        result_ref = self.shapelet_ref.phi_n(n1, x)
+        npt.assert_allclose(result, result_ref, atol=1e-10, rtol=1e-15)
+
+        result = self.shapelet.phi_n(n2, x)
+        result_ref = self.shapelet_ref.phi_n(n2, x)
+        npt.assert_allclose(result, result_ref, atol=1e-10, rtol=1e-15)
+
+    def test_precalc(self):
+        x = np.array([1.3, 3.5, 6.7, 2.5, 13.54, 99])
+        y = np.array([-0.6, 2.5, 6.1, -2.6, 13.54, 99])
+        beta = 3.287
+        n1 = 6
+        n2 = 8
+        center_x = np.linspace(-0.3, 0.4, 6)
+        center_y = np.linspace(-0.5, 0.1, 6)
+        phi_x, phi_y = self.shapelet.pre_calc(x, y, beta, n1, center_x, center_y)
+        phi_x_ref, phi_y_ref = self.shapelet_ref.pre_calc(x, y, beta, n1, center_x, center_y)
+        npt.assert_allclose(phi_x, phi_x_ref, atol=1e-10, rtol=1e-15)
+        npt.assert_allclose(phi_y, phi_y_ref, atol=1e-10, rtol=1e-15)
+
+
+class TestShapeletSet(object):
+
+    def setup_method(self):
+        self.shapeletset = ShapeletSet()
+        self.shapeletset_ref = ShapeletSet_ref()
+
+    def test_function(self):
+        x = np.array([1.3, 3.5, 6.7, 2.5, 13.54, 99])
+        y = np.array([-0.6, 2.5, 6.1, -2.6, 13.54, 99])
+        beta = 3.287
+        center_x = np.linspace(-0.3, 0.4, 6)
+        center_y = np.linspace(-0.5, 0.1, 6)
+
+        n_max = 4
+        num_param = int((n_max + 1) * (n_max + 2) / 2)
+        amp = np.linspace(1., 100., num_param)
+        result = self.shapeletset.function(x, y, amp, n_max, beta, center_x, center_y)
+        result_ref = self.shapeletset_ref.function(x, y, amp, n_max, beta, center_x, center_y)
+        npt.assert_allclose(result, result_ref, atol=1e-10, rtol=1e-15)
+
+        n_max = 12
+        num_param = int((n_max + 1) * (n_max + 2) / 2)
+        amp = np.linspace(1., 100., num_param)
+        result = self.shapeletset.function(y, x, amp, n_max, beta, center_x, center_y)
+        result_ref = self.shapeletset_ref.function(y, x, amp, n_max, beta, center_x, center_y)
+        npt.assert_allclose(result, result_ref, atol=1e-10, rtol=1e-15)
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/test/test_LightModel/test_Profiles/test_shapelets.py
+++ b/test/test_LightModel/test_Profiles/test_shapelets.py
@@ -3,10 +3,15 @@ import pytest
 import numpy.testing as npt
 
 import jax
+
 jax.config.update("jax_enable_x64", True)
 
 from jaxtronomy.LightModel.Profiles.shapelets import Shapelets, ShapeletSet
-from lenstronomy.LightModel.Profiles.shapelets import Shapelets as Shapelets_ref, ShapeletSet as ShapeletSet_ref
+from lenstronomy.LightModel.Profiles.shapelets import (
+    Shapelets as Shapelets_ref,
+    ShapeletSet as ShapeletSet_ref,
+)
+
 
 class TestShapelets_StableCut(object):
 
@@ -41,7 +46,9 @@ class TestShapelets_StableCut(object):
         center_y = np.linspace(-0.5, 0.1, 6)
 
         result = self.shapelet.function(x, y, amp, beta, n1, n2, center_x, center_y)
-        result_ref = self.shapelet_ref.function(x, y, amp, beta, n1, n2, center_x, center_y)
+        result_ref = self.shapelet_ref.function(
+            x, y, amp, beta, n1, n2, center_x, center_y
+        )
         npt.assert_allclose(result, result_ref, atol=1e-10, rtol=1e-15)
 
     def test_Hn(self):
@@ -78,15 +85,19 @@ class TestShapelets_StableCut(object):
         center_x = np.linspace(-0.3, 0.4, 6)
         center_y = np.linspace(-0.5, 0.1, 6)
         phi_x, phi_y = self.shapelet.pre_calc(x, y, beta, n1, center_x, center_y)
-        phi_x_ref, phi_y_ref = self.shapelet_ref.pre_calc(x, y, beta, n1, center_x, center_y)
+        phi_x_ref, phi_y_ref = self.shapelet_ref.pre_calc(
+            x, y, beta, n1, center_x, center_y
+        )
         npt.assert_allclose(phi_x, phi_x_ref, atol=1e-10, rtol=1e-15)
         npt.assert_allclose(phi_y, phi_y_ref, atol=1e-10, rtol=1e-15)
-        npt.assert_raises(ValueError, self.shapelet.pre_calc, x, y, beta, 171, center_x, center_y)
+        npt.assert_raises(
+            ValueError, self.shapelet.pre_calc, x, y, beta, 171, center_x, center_y
+        )
 
 
 class TestShapelets_NoStableCut(object):
 
-    def setup_method(self):  
+    def setup_method(self):
         self.shapelet = Shapelets(stable_cut=False)
         self.shapelet_ref = Shapelets_ref(stable_cut=False)
 
@@ -114,7 +125,9 @@ class TestShapelets_NoStableCut(object):
         center_y = np.linspace(-0.5, 0.1, 6)
 
         result = self.shapelet.function(x, y, amp, beta, n1, n2, center_x, center_y)
-        result_ref = self.shapelet_ref.function(x, y, amp, beta, n1, n2, center_x, center_y)
+        result_ref = self.shapelet_ref.function(
+            x, y, amp, beta, n1, n2, center_x, center_y
+        )
         npt.assert_allclose(result, result_ref, atol=1e-10, rtol=1e-15)
 
     def test_Hn(self):
@@ -152,7 +165,9 @@ class TestShapelets_NoStableCut(object):
         center_x = np.linspace(-0.3, 0.4, 6)
         center_y = np.linspace(-0.5, 0.1, 6)
         phi_x, phi_y = self.shapelet.pre_calc(x, y, beta, n1, center_x, center_y)
-        phi_x_ref, phi_y_ref = self.shapelet_ref.pre_calc(x, y, beta, n1, center_x, center_y)
+        phi_x_ref, phi_y_ref = self.shapelet_ref.pre_calc(
+            x, y, beta, n1, center_x, center_y
+        )
         npt.assert_allclose(phi_x, phi_x_ref, atol=1e-10, rtol=1e-15)
         npt.assert_allclose(phi_y, phi_y_ref, atol=1e-10, rtol=1e-15)
 
@@ -172,16 +187,20 @@ class TestShapeletSet(object):
 
         n_max = 4
         num_param = int((n_max + 1) * (n_max + 2) / 2)
-        amp = np.linspace(1., 100., num_param)
+        amp = np.linspace(1.0, 100.0, num_param)
         result = self.shapeletset.function(x, y, amp, n_max, beta, center_x, center_y)
-        result_ref = self.shapeletset_ref.function(x, y, amp, n_max, beta, center_x, center_y)
+        result_ref = self.shapeletset_ref.function(
+            x, y, amp, n_max, beta, center_x, center_y
+        )
         npt.assert_allclose(result, result_ref, atol=1e-10, rtol=1e-15)
 
         n_max = 12
         num_param = int((n_max + 1) * (n_max + 2) / 2)
-        amp = np.linspace(1., 100., num_param)
+        amp = np.linspace(1.0, 100.0, num_param)
         result = self.shapeletset.function(y, x, amp, n_max, beta, center_x, center_y)
-        result_ref = self.shapeletset_ref.function(y, x, amp, n_max, beta, center_x, center_y)
+        result_ref = self.shapeletset_ref.function(
+            y, x, amp, n_max, beta, center_x, center_y
+        )
         npt.assert_allclose(result, result_ref, atol=1e-10, rtol=1e-15)
 
 

--- a/test/test_LightModel/test_Profiles/test_shapelets.py
+++ b/test/test_LightModel/test_Profiles/test_shapelets.py
@@ -51,6 +51,16 @@ class TestShapelets_StableCut(object):
         )
         npt.assert_allclose(result, result_ref, atol=1e-10, rtol=1e-15)
 
+        n1, n2 = 2, 3
+        precalc_shapelet = Shapelets(precalc=True)
+        precalc_shapelet_ref = Shapelets_ref(precalc=True)
+        result = precalc_shapelet.function(x, y, amp, beta, n1, n2, center_x, center_y)
+        result_ref = precalc_shapelet_ref.function(
+            x, y, amp, beta, n1, n2, center_x, center_y
+        )
+        npt.assert_allclose(result, result_ref, atol=1e-10, rtol=1e-15)
+
+
     def test_Hn(self):
         x = np.array([1.3, 3.5, 6.7, 2.5, 13.54, 99])
         n1 = 6

--- a/test/test_LightModel/test_light_model.py
+++ b/test/test_LightModel/test_light_model.py
@@ -171,6 +171,8 @@ class TestRaise(unittest.TestCase):
             lighModel = LightModel(light_model_list=["SERSIC"])
             lighModel.profile_type_list = ["WRONG"]
             lighModel.total_flux(kwargs_list=[{}])
+        with self.assertRaises(ValueError):
+            lightmodel = LightModel(light_model_list=["SERSIC"], source_redshift_list=[1, 3])
 
 
 if __name__ == "__main__":

--- a/test/test_LightModel/test_light_model.py
+++ b/test/test_LightModel/test_light_model.py
@@ -172,7 +172,9 @@ class TestRaise(unittest.TestCase):
             lighModel.profile_type_list = ["WRONG"]
             lighModel.total_flux(kwargs_list=[{}])
         with self.assertRaises(ValueError):
-            lightmodel = LightModel(light_model_list=["SERSIC"], source_redshift_list=[1, 3])
+            lightmodel = LightModel(
+                light_model_list=["SERSIC"], source_redshift_list=[1, 3]
+            )
 
 
 if __name__ == "__main__":

--- a/test/test_Util/test_class_creator.py
+++ b/test/test_Util/test_class_creator.py
@@ -43,6 +43,9 @@ class TestClassCreator(object):
             "index_lens_light_model_list": [[0]],
             "index_point_source_model_list": [[0]],
             "point_source_frame_list": [[0]],
+            "optical_depth_model_list": ["UNIFORM"],
+            "index_optical_depth_model_list": [[0]],
+            "tau0_index_list": [0],
         }
         self.kwargs_model_4 = {
             "lens_model_list": ["SIS", "SIS"],
@@ -213,21 +216,6 @@ class TestRaise(unittest.TestCase):
             class_creator.create_class_instances(
                 source_redshift_list=[1], **kwargs_model
             )
-
-        kwargs_model = {
-            "lens_model_list": ["SIS", "SIS"],
-            "lens_redshift_list": [0.3, 0.4],
-            "multi_plane": True,
-            "observed_convention_index": [0],
-            "index_lens_model_list": [[0]],
-            "z_source": 1,
-            "optical_depth_model_list": ["UNIFORM"],
-            "index_optical_depth_model_list": [[0]],
-            "tau0_index_list": [0],
-            "point_source_frame_list": [[0]],
-        }
-        with self.assertRaises(ValueError):
-            class_creator.create_class_instances(**kwargs_model)
 
 
 if __name__ == "__main__":

--- a/test/test_Util/test_class_creator.py
+++ b/test/test_Util/test_class_creator.py
@@ -210,7 +210,9 @@ class TestRaise(unittest.TestCase):
             "point_source_frame_list": [[0]],
         }
         with self.assertRaises(ValueError):
-            class_creator.create_class_instances(source_redshift_list=[1], **kwargs_model)
+            class_creator.create_class_instances(
+                source_redshift_list=[1], **kwargs_model
+            )
 
         kwargs_model = {
             "lens_model_list": ["SIS", "SIS"],

--- a/test/test_Util/test_class_creator.py
+++ b/test/test_Util/test_class_creator.py
@@ -217,6 +217,18 @@ class TestRaise(unittest.TestCase):
                 source_redshift_list=[1], **kwargs_model
             )
 
+        kwargs_model = {
+            "lens_model_list": ["SIS", "SIS"],
+            "lens_redshift_list": [0.3, 0.4],
+            "multi_plane": True,
+            "observed_convention_index": [0],
+            "index_lens_model_list": [[0]],
+            "z_source": 1,
+            "point_source_frame_list": [[0]],
+        }
+        with self.assertRaises(ValueError):
+            class_creator.create_class_instances(**kwargs_model)
+
 
 if __name__ == "__main__":
     pytest.main()

--- a/test/test_Util/test_class_creator.py
+++ b/test/test_Util/test_class_creator.py
@@ -21,10 +21,10 @@ class TestClassCreator(object):
             "index_point_source_model_list": [[0]],
             "band_index": 0,
             "source_deflection_scaling_list": [1],
-            "source_redshift_list": [1],
+            #"source_redshift_list": [1],
             "fixed_magnification_list": [True],
             "additional_images_list": [False],
-            "lens_redshift_list": [0.5],
+            #"lens_redshift_list": [0.5],
             "point_source_frame_list": [[0]],
         }
         self.kwargs_model_2 = {
@@ -58,11 +58,11 @@ class TestClassCreator(object):
         }
         self.kwargs_model_5 = {
             "lens_model_list": ["SIS", "SIS"],
-            "lens_redshift_list": [0.3, 0.4],
-            "multi_plane": True,
-            "z_source": 1,
+            #"lens_redshift_list": [0.3, 0.4],
+            #"multi_plane": True,
+            #"z_source": 1,
             "kwargs_multiplane_model_point_source": {},
-            "decouple_multi_plane": False,
+            #"decouple_multi_plane": False,
         }
 
         self.kwargs_psf = {"psf_type": "NONE"}
@@ -99,15 +99,16 @@ class TestClassCreator(object):
         ) = class_creator.create_class_instances(**self.kwargs_model_3)
         assert lens_model_class.lens_model_list[0] == "SIS"
 
-        (
-            lens_model_class,
-            source_model_class,
-            lens_light_model_class,
-            point_source_class,
-            extinction_class,
-        ) = class_creator.create_class_instances(**self.kwargs_model_4)
-        assert lens_model_class.lens_model_list[0] == "SIS"
-        assert lens_model_class.lens_model._observed_convention_index[0] == 0
+        # TODO: implement multiplane
+        #(
+        #    lens_model_class,
+        #    source_model_class,
+        #    lens_light_model_class,
+        #    point_source_class,
+        #    extinction_class,
+        #) = class_creator.create_class_instances(**self.kwargs_model_4)
+        #assert lens_model_class.lens_model_list[0] == "SIS"
+        #assert lens_model_class.lens_model._observed_convention_index[0] == 0
 
         (
             lens_model_class,

--- a/test/test_Util/test_class_creator.py
+++ b/test/test_Util/test_class_creator.py
@@ -193,6 +193,39 @@ class TestRaise(unittest.TestCase):
                 image_likelihood_mask_list=None,
                 band_index=0,
             )
+        kwargs_model = {
+            "lens_model_list": ["SIS"],
+            "source_light_model_list": ["SERSIC"],
+            "lens_light_model_list": ["SERSIC"],
+            "point_source_model_list": ["LENSED_POSITION"],
+            "index_lens_model_list": [[0]],
+            "index_source_light_model_list": [[0]],
+            "index_lens_light_model_list": [[0]],
+            "index_point_source_model_list": [[0]],
+            "band_index": 0,
+            "source_deflection_scaling_list": [1],
+            "fixed_magnification_list": [True],
+            "additional_images_list": [False],
+            "lens_redshift_list": [0.5],
+            "point_source_frame_list": [[0]],
+        }
+        with self.assertRaises(ValueError):
+            class_creator.create_class_instances(source_redshift_list=[1], **kwargs_model)
+
+        kwargs_model = {
+            "lens_model_list": ["SIS", "SIS"],
+            "lens_redshift_list": [0.3, 0.4],
+            "multi_plane": True,
+            "observed_convention_index": [0],
+            "index_lens_model_list": [[0]],
+            "z_source": 1,
+            "optical_depth_model_list": ["UNIFORM"],
+            "index_optical_depth_model_list": [[0]],
+            "tau0_index_list": [0],
+            "point_source_frame_list": [[0]],
+        }
+        with self.assertRaises(ValueError):
+            class_creator.create_class_instances(**kwargs_model)
 
 
 if __name__ == "__main__":

--- a/test/test_Util/test_herm_util.py
+++ b/test/test_Util/test_herm_util.py
@@ -1,0 +1,40 @@
+import pytest
+
+import jax
+import numpy as np, numpy.testing as npt
+from numpy.polynomial.hermite import hermval as hermval_ref
+from scipy.special import eval_hermite as eval_hermite_ref
+
+jax.config.update("jax_enable_x64", True)  # 64-bit floats, consistent witsh numpy
+from jaxtronomy.Util.herm_util import eval_hermite, hermval
+
+A_TOL = 1e-10
+R_TOL = 1e-12
+
+def test_eval_hermite():
+    n_test = 3
+    x_array = np.array([[1, 4, 6],[2, 3, 5]])
+    npt.assert_allclose(eval_hermite(n_test, x_array), eval_hermite_ref(n_test, x_array), R_TOL, A_TOL)
+
+    n_test = 7
+    x_array = np.array([[1, 4, 6],[2, 3, 5]])
+    npt.assert_allclose(eval_hermite(n_test, x_array), eval_hermite_ref(n_test, x_array), R_TOL, A_TOL)
+
+    n_test = 38
+    x_array = np.array([[1.3, 4.49, -6],[2.344, -3.194, 5.392]])
+    npt.assert_allclose(eval_hermite(n_test, x_array), eval_hermite_ref(n_test, x_array), R_TOL, A_TOL)
+
+def test_hermval():
+    n_array = np.linspace(0.5, 1.5, 4)
+    x_array = np.array([[1.35, 2.234], [-3.45654, 4.465], [5.236, -6.26]], dtype=float)
+    npt.assert_allclose(hermval(x_array, n_array), hermval_ref(x_array, n_array), R_TOL, A_TOL)
+
+    n_array = np.linspace(0.5, 32, 50)
+    x_array = np.array([[1.35, 2.234], [-3.45654, 4.465], [5.236, -6.26]], dtype=float)
+    npt.assert_allclose(hermval(x_array, n_array), hermval_ref(x_array, n_array), R_TOL, A_TOL)
+    
+
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/test/test_Util/test_herm_util.py
+++ b/test/test_Util/test_herm_util.py
@@ -11,29 +11,39 @@ from jaxtronomy.Util.herm_util import eval_hermite, hermval
 A_TOL = 1e-10
 R_TOL = 1e-12
 
+
 def test_eval_hermite():
     n_test = 3
-    x_array = np.array([[1, 4, 6],[2, 3, 5]])
-    npt.assert_allclose(eval_hermite(n_test, x_array), eval_hermite_ref(n_test, x_array), R_TOL, A_TOL)
+    x_array = np.array([[1, 4, 6], [2, 3, 5]])
+    npt.assert_allclose(
+        eval_hermite(n_test, x_array), eval_hermite_ref(n_test, x_array), R_TOL, A_TOL
+    )
 
     n_test = 7
-    x_array = np.array([[1, 4, 6],[2, 3, 5]])
-    npt.assert_allclose(eval_hermite(n_test, x_array), eval_hermite_ref(n_test, x_array), R_TOL, A_TOL)
+    x_array = np.array([[1, 4, 6], [2, 3, 5]])
+    npt.assert_allclose(
+        eval_hermite(n_test, x_array), eval_hermite_ref(n_test, x_array), R_TOL, A_TOL
+    )
 
     n_test = 38
-    x_array = np.array([[1.3, 4.49, -6],[2.344, -3.194, 5.392]])
-    npt.assert_allclose(eval_hermite(n_test, x_array), eval_hermite_ref(n_test, x_array), R_TOL, A_TOL)
+    x_array = np.array([[1.3, 4.49, -6], [2.344, -3.194, 5.392]])
+    npt.assert_allclose(
+        eval_hermite(n_test, x_array), eval_hermite_ref(n_test, x_array), R_TOL, A_TOL
+    )
+
 
 def test_hermval():
     n_array = np.linspace(0.5, 1.5, 4)
     x_array = np.array([[1.35, 2.234], [-3.45654, 4.465], [5.236, -6.26]], dtype=float)
-    npt.assert_allclose(hermval(x_array, n_array), hermval_ref(x_array, n_array), R_TOL, A_TOL)
+    npt.assert_allclose(
+        hermval(x_array, n_array), hermval_ref(x_array, n_array), R_TOL, A_TOL
+    )
 
     n_array = np.linspace(0.5, 32, 50)
     x_array = np.array([[1.35, 2.234], [-3.45654, 4.465], [5.236, -6.26]], dtype=float)
-    npt.assert_allclose(hermval(x_array, n_array), hermval_ref(x_array, n_array), R_TOL, A_TOL)
-    
-
+    npt.assert_allclose(
+        hermval(x_array, n_array), hermval_ref(x_array, n_array), R_TOL, A_TOL
+    )
 
 
 if __name__ == "__main__":

--- a/test/test_lenstronomy_import.py
+++ b/test/test_lenstronomy_import.py
@@ -2,4 +2,4 @@ def test_lenstronomy_version():
     """Tests the import of lenstronomy."""
     import lenstronomy
 
-    assert lenstronomy.__version__ == "1.12.4"
+    assert lenstronomy.__version__ == "1.12.5"


### PR DESCRIPTION
1. The interpolation feature for the shapelets profile has been removed since it is actually slower than directly computing the hermite polynomials using JAX
2. Commented out multiplane lensing functionality in LensModel for now
3. Restored missing jit decorators in various places
4. Improved testing coverage in various places