### PR TITLE
Changed EPL profile

### DIFF
--- a/jaxtronomy/LensModel/Profiles/epl.py
+++ b/jaxtronomy/LensModel/Profiles/epl.py
@@ -300,7 +300,7 @@ class EPLMajorAxis(LensProfileBase):
         hyp2f1_slow,
         hyp2f1_slower,
         hyp2f1_slowest,
-        lambda a,b,c,z: jnp.ones_like(z)
+        lambda a, b, c, z: jnp.ones_like(z),
     ]
 
     @custom_jvp
@@ -324,7 +324,7 @@ class EPLMajorAxis(LensProfileBase):
         case = jnp.where(f < 0.6, 2, case)  # nmax=35
         case = jnp.where(f < 0.4, 1, case)  # nmax=20
         case = jnp.where(f < 0.12, 0, case)  # nmax=10
-        case = jnp.where(f == 0, 7, case) # simply returns 1
+        case = jnp.where(f == 0, 7, case)  # simply returns 1
 
         return lax.switch(case, EPLMajorAxis.hyp2f1_func_list, 1, B, C, z)
 

--- a/jaxtronomy/LensModel/Profiles/epl.py
+++ b/jaxtronomy/LensModel/Profiles/epl.py
@@ -383,7 +383,7 @@ class EPLMajorAxis(LensProfileBase):
         Z = q * x + y * 1j
         R = jnp.abs(Z)
         R = jnp.maximum(R, 0.000000001)
-        f = (1.0 - q)/ (1.0 + q)
+        f = (1.0 - q) / (1.0 + q)
 
         # If f = 0, hyp2f1 just evaluates to 1
         def f_equals_0(Z, f, t):

--- a/jaxtronomy/LensModel/Profiles/epl.py
+++ b/jaxtronomy/LensModel/Profiles/epl.py
@@ -1,20 +1,15 @@
-# Copy pasted from lenstronomy's epl profile but with all instances of numpy
-# replaced by jnp, and scipy.special.hyp2f1 replaced with a jaxified version
-
-
 __author__ = "ntessore"
 
-import jax
-from jax import jit, tree_util
-import jax.numpy as jnp
+from functools import partial
+from jax import config, custom_jvp, jvp, jit, lax, numpy as jnp, tree_util
+config.update("jax_enable_x64", True)  # 64-bit floats, consistent with numpy
 
-from jaxtronomy.Util.hyp2f1_util import hyp2f1_series as hyp2f1
+from jaxtronomy.Util.hyp2f1_util import hyp2f1_lopez_temme_8 as hyp2f1
 import jaxtronomy.Util.util as util
 import jaxtronomy.Util.param_util as param_util
 from jaxtronomy.LensModel.Profiles.spp import SPP
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
-jax.config.update("jax_enable_x64", True)  # 64-bit floats, consistent with numpy
 
 __all__ = ["EPL", "EPLMajorAxis", "EPLQPhi"]
 
@@ -287,8 +282,68 @@ class EPLMajorAxis(LensProfileBase):
 
     param_names = ["b", "t", "q", "center_x", "center_y"]
 
-    def __init__(self):
-        super(EPLMajorAxis, self).__init__()
+    # Defining multiple hyp2f1 functions like this is required since nmax must be static
+    # for autodifferentiation to be used
+    hyp2f1_fastest = partial(hyp2f1, nmax=10)
+    hyp2f1_faster = partial(hyp2f1, nmax=20)
+    hyp2f1_fast = partial(hyp2f1, nmax=35)
+    hyp2f1_norm = partial(hyp2f1, nmax=50)
+    hyp2f1_slow = partial(hyp2f1, nmax=100)
+    hyp2f1_slower = partial(hyp2f1, nmax=200)
+    hyp2f1_slowest = partial(hyp2f1, nmax=500)
+    hyp2f1_func_list = [
+        hyp2f1_fastest,
+        hyp2f1_faster,
+        hyp2f1_fast,
+        hyp2f1_norm,
+        hyp2f1_slow,
+        hyp2f1_slower,
+        hyp2f1_slowest,
+    ]
+
+    @custom_jvp
+    @staticmethod
+    @jit
+    def _hyp2f1_evaluate(t, z):
+        """
+        The series expansion for hyp2f1 converges faster when |z| is closer
+        to the origin. This function decides how many terms to use.
+        By adjusting the number of terms, the performance for ray-shooting
+        is significantly improved.
+        """
+
+        f = jnp.max(jnp.abs(z))
+
+        case = jnp.where(f < 0.92, 5, 6) # nmax=200, if f > 0.92 then nmax=500
+        case = jnp.where(f < 0.86, 4, case) # nmax=100
+        case = jnp.where(f < 0.73, 3, case) # nmax=50
+        case = jnp.where(f < 0.6, 2, case) # nmax=35
+        case = jnp.where(f < 0.4, 1, case) # nmax=20
+        case = jnp.where(f < 0.12, 0, case) # nmax=10
+
+        return lax.switch(case, EPLMajorAxis.hyp2f1_func_list, 1, t/2, 2-t/2, z)
+    
+    @staticmethod
+    @jit
+    def _hyp2f1_for_autodiff(t, z):
+        """
+        This function is the same as above but always uses nmax=100.
+        When performing autodifferentiation, it is faster to autodifferentiate
+        through this function rather than the above function, since autodifferentiating
+        through lax.switch is very slow.
+        """
+        B = t/2
+        C = 2 - B
+        return EPLMajorAxis.hyp2f1_slow(1, B, C, z)
+    
+    @jit
+    @_hyp2f1_evaluate.defjvp
+    def _hyp2f1_jvp(primals, tangents):
+        """
+        This function defines the derivative of _hyp2f1_evaluate, so that when autodifferentiation is used,
+        it will instead autodifferentiate through _hyp2f1_for_autodiff, resulting in performance boost.
+        """
+        return jvp(EPLMajorAxis._hyp2f1_for_autodiff, primals, tangents)
 
     @staticmethod
     @jit
@@ -329,7 +384,7 @@ class EPLMajorAxis(LensProfileBase):
         f = (1.0 - q) / (1.0 + q)
 
         # angular dependency with extra factor of R, eq. (23)
-        R_omega = Z * hyp2f1(1, t / 2, 2 - t / 2, -f * Z / jnp.conj(Z))
+        R_omega = Z * EPLMajorAxis._hyp2f1_evaluate(t, -f * Z / jnp.conj(Z))
 
         # deflection, eq. (22)
         alpha = 2 / (1 + q) * (b / R) ** t * R_omega
@@ -339,7 +394,7 @@ class EPLMajorAxis(LensProfileBase):
         alpha_imag = jnp.nan_to_num(alpha.imag, posinf=10**10, neginf=-(10**10))
 
         return alpha_real, alpha_imag
-
+    
     @staticmethod
     @jit
     def hessian(x, y, b, t, q):
@@ -352,6 +407,8 @@ class EPLMajorAxis(LensProfileBase):
         :param q: axis ratio
         :return: f_xx, f_yy, f_xy
         """
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
         R = jnp.hypot(q * x, y)
         R = jnp.maximum(R, 0.00000001)
         r = jnp.hypot(x, y)
@@ -378,7 +435,6 @@ class EPLMajorAxis(LensProfileBase):
         f_xy = gamma_2
 
         return f_xx, f_xy, f_xy, f_yy
-
 
 class EPLQPhi(LensProfileBase):
     """Class to model a EPL sampling over q and phi instead of e1 and e2."""

--- a/jaxtronomy/LensModel/Profiles/epl.py
+++ b/jaxtronomy/LensModel/Profiles/epl.py
@@ -314,6 +314,8 @@ class EPLMajorAxis(LensProfileBase):
         """
 
         f = jnp.max(jnp.abs(z))
+        B = t / 2.0
+        C = 2.0 - B
 
         case = jnp.where(f < 0.92, 5, 6)  # nmax=200, if f > 0.92 then nmax=500
         case = jnp.where(f < 0.86, 4, case)  # nmax=100
@@ -322,7 +324,7 @@ class EPLMajorAxis(LensProfileBase):
         case = jnp.where(f < 0.4, 1, case)  # nmax=20
         case = jnp.where(f < 0.12, 0, case)  # nmax=10
 
-        return lax.switch(case, EPLMajorAxis.hyp2f1_func_list, 1, t / 2, 2 - t / 2, z)
+        return lax.switch(case, EPLMajorAxis.hyp2f1_func_list, 1, B, C, z)
 
     @staticmethod
     @jit
@@ -333,8 +335,8 @@ class EPLMajorAxis(LensProfileBase):
         this function rather than the above function, since autodifferentiating through
         lax.switch is very slow.
         """
-        B = t / 2
-        C = 2 - B
+        B = t / 2.0
+        C = 2.0 - B
         return EPLMajorAxis.hyp2f1_slow(1, B, C, z)
 
     @jit

--- a/jaxtronomy/LensModel/Profiles/epl_multipole_m1m3m4.py
+++ b/jaxtronomy/LensModel/Profiles/epl_multipole_m1m3m4.py
@@ -633,7 +633,8 @@ class EPL_MULTIPOLE_M1M3M4(LensProfileBase):
         :param e1: ellipticity of EPL profile (along 1st axis)
         :param e2: ellipticity of EPL profile (along 2nd axis)
         :param a1_a: amplitude of the m=1 mutipole perturbation
-        :param delta_phi_m1: orientation of the m=1 multipole perturbation relative to EPL
+        :param delta_phi_m1: orientation of the m=1 multipole perturbation relative to
+            EPL
         :param a3_a: amplitude of the m=3 multiple deviation from pure elliptical shape
             related to the physical amplitude of the MULTIPOLE profile by a scaling
             theta_E / sqrt(q)

--- a/jaxtronomy/Util/hyp2f1_util.py
+++ b/jaxtronomy/Util/hyp2f1_util.py
@@ -5,12 +5,6 @@ import jax.numpy as jnp
 from jax import jit, lax
 from jax.scipy.special import gamma
 
-# TODO: The analytic continuation formula used in hyp2f1_continuation only works
-#       whenever b - a is not an integer. Additionally, hyp2f1_near_one only works
-#       whenever c - b - a is not an integer. Other implementations are required
-#       for these situations.
-
-
 @partial(jit, static_argnums=4)
 def hyp2f1_series(a, b, c, z, nmax=50):
     """This computation is based off of the standard series expansion of hyp2f1.
@@ -69,7 +63,6 @@ def hyp2f1_continuation(a, b, c, z, nmax=50):
     # sum_1 corresponds to the summation on the top line of equation 4.21
     # sum_2 corresponds to the summation on the bottom line of equation 4.21
     # Gamma function prefactors are multiplied at the end
-    # Allows for the input z to be an array of values
     sum_1 = 1.0 * jnp.ones_like(z)
     sum_2 = 1.0 * jnp.ones_like(z)
 
@@ -153,8 +146,8 @@ def hyp2f1_lopez_temme_8(a, b, c, z, nmax=75):
     # This is the n=1 prefactor
     sum_prefactor = a * (z / (z - 2.))
 
-    # The values of hyp2f1 inside the sum are computed iteratively used one of Gauss's
-    # contiguous relations
+    # The values of hyp2f1 inside the sum are computed iteratively using one of Gauss's
+    # contiguous relations, see Eq 15.5.11 https://dlmf.nist.gov/15.5#E11
     prev_prev_F = 1.
     prev_F = 1. - 2. * b / c
 

--- a/jaxtronomy/Util/hyp2f1_util.py
+++ b/jaxtronomy/Util/hyp2f1_util.py
@@ -1,5 +1,6 @@
 # hyp2f1 functions to use with JAX
 
+from functools import partial
 import jax.numpy as jnp
 from jax import jit, lax
 from jax.scipy.special import gamma
@@ -10,23 +11,20 @@ from jax.scipy.special import gamma
 #       for these situations.
 
 
-@jit
-def hyp2f1_series(a, b, c, z):
-    """This computation uses the well known relation between successive terms in the
-    hypergeometric series hyp2f1(z) = sum_i A_i where.
+@partial(jit, static_argnums=4)
+def hyp2f1_series(a, b, c, z, nmax=50):
+    """This computation is based off of the standard series expansion of hyp2f1.
+    The recurrence relation between successive terms in the sum is well known:
 
     A_0 = 1
     A_i = z * [(i - 1 + a)(i - 1 + b) / i(i - 1 + c)] A_{i-1}
 
-    This iterative implementation is necessary, since the usual hypergeometric
-    function `hyp2f1` provided in `scipy.special` has not yet been implemented
-    in an autodifferentiable or JIT-compilable way in JAX.
-
-    This implementation can only be used whenever |z| < 1. Otherwise the
-    series representation of 2F1 diverges and analytic continuation must
-    be used.
+    The conditions required for this series to converge are:
+    1) |z| < 1
+    2) c is not a non-positive integer (i.e. c != 0, -1, -2, ...)
+    3) If Re(c - a - b) > 0, then the series converges on |z| = 1 as well (but very slowly)
     """
-    z = jnp.asarray(z)
+    z = jnp.array(z, dtype=complex)
 
     # Set the first term of the series, A_0 = 1
     A_i = 1.0 * jnp.ones_like(z)
@@ -44,23 +42,23 @@ def hyp2f1_series(a, b, c, z):
 
         return [partial_sum, A_i]
 
-    result = lax.fori_loop(1, 150, body_fun, [partial_sum, A_i])
+    result = lax.fori_loop(1, nmax, body_fun, [partial_sum, A_i])
     return result[0]
 
 
-# TODO: Implement a version that can handle b - a = integer
-@jit
-def hyp2f1_continuation(a, b, c, z):
+@partial(jit, static_argnums=4)
+def hyp2f1_continuation(a, b, c, z, nmax=50):
     """
-    This implementation is based off of the analytic continuation formulas
-    Equations 4.21 and 4.22 with z0 = 1/2 in John Pearson's MSc thesis
-    https://www.math.ucla.edu/~mason/research/pearson_final.pdf
+    This implementation is based off of Bühring's analytic continuation formula
+    Equation 4, from J.L. Lopez and N.M. Temme, “New series expansions of the
+    Gauss hypergeometric function”, Adv Comput Math 39, 349-365 (2013).
+    https://link.springer.com/content/pdf/10.1007/s10444-012-9283-y.pdf
 
-    This approach works whenever z is outside of the circle |z-1/2| = 1/2.
-    Due to the presence of gamma(b - a) and gamma(a - b), there will always
-    be a pole whenever b - a is an integer.
+    The conditions required for this series to converge are:
+    1) |z-1/2| > 1/2.
+    2) b - a is not an integer
     """
-    z = jnp.asarray(z)
+    z = jnp.array(z, dtype=complex)
 
     # d0 = 1 and d_{-1} = 0
     prev_da = 1.0
@@ -79,74 +77,121 @@ def hyp2f1_continuation(a, b, c, z):
     # If z is on the branch cut, take the value above the branch cut
     z = jnp.where(jnp.imag(z) == 0.0, jnp.where(jnp.real(z) >= 1, z + 0.0000001j, z), z)
 
-    def body_fun(j, val):
-        prev_prev_da, prev_prev_db, prev_da, prev_db, sum_1, sum_2 = val
+    # This is the (z - 0.5) ** (-n) term in the series; we start with n = 1
+    z_factor = 1. / (z - 0.5)
+
+    def body_fun(n, val):
+        z_factor, prev_prev_da, prev_prev_db, prev_da, prev_db, sum_1, sum_2 = val
 
         # ------------------------------------------------------------------------------------------------------
-        # This section of the function handles the summation on the first line of equation 4.21
-        # calculates d_j and the corresponding term in the sum
-        d_ja = (
-            (j + a - 1.0)
-            / (j * (j + a - b))
+        # This section of the function handles the summation on the first line of equation 4
+        # calculates d_n and the corresponding term in the sum
+        d_na = (
+            (n + a - 1.0)
+            / (n * (n + a - b))
             * (
                 ((a + b + 1.0) * 0.5 - c) * prev_da
-                + 0.25 * (j + a - 2.0) * prev_prev_da
+                + 0.25 * (n + a - 2.0) * prev_prev_da
             )
         )
-        sum_1 += d_ja * (z - 0.5) ** (-j)
+        sum_1 += d_na * z_factor
 
-        # updates d_{j-2} and d_{j-1}
+        # updates d_{n-2} and d_{n-1}
         prev_prev_da = prev_da
-        prev_da = d_ja
+        prev_da = d_na
 
         # ------------------------------------------------------------------------------------------------------
-        # This section of the function handles the summation on the second line of equation 4.21
-        # calculates d_j and the corresponding term in the sum
-        d_jb = (
-            (j + b - 1.0)
-            / (j * (j - a + b))
+        # This section of the function handles the summation on the second line of equation 4
+        # calculates d_n and the corresponding term in the sum
+        d_nb = (
+            (n + b - 1.0)
+            / (n * (n - a + b))
             * (
                 ((a + b + 1.0) * 0.5 - c) * prev_db
-                + 0.25 * (j + b - 2.0) * prev_prev_db
+                + 0.25 * (n + b - 2.0) * prev_prev_db
             )
         )
-        sum_2 += d_jb * (z - 0.5) ** (-j)
+        sum_2 += d_nb * z_factor
 
-        # updates d_{j-2} and d_{j-1}
+        # updates d_{n-2} and d_{n-1}
         prev_prev_db = prev_db
-        prev_db = d_jb
+        prev_db = d_nb
+
+        # updates z_factor
+        z_factor = z_factor / (z - 0.5)
 
         # -----------------------------------------------------------------------------------------------------
-        return [prev_prev_da, prev_prev_db, prev_da, prev_db, sum_1, sum_2]
+        return [z_factor, prev_prev_da, prev_prev_db, prev_da, prev_db, sum_1, sum_2]
 
     result = lax.fori_loop(
-        1, 200, body_fun, [prev_prev_da, prev_prev_db, prev_da, prev_db, sum_1, sum_2]
+        1, nmax, body_fun, [z_factor, prev_prev_da, prev_prev_db, prev_da, prev_db, sum_1, sum_2]
     )
 
-    # includes the gamma function prefactors in equation 4.21 to compute the final result of 2F1
+    # includes the gamma function prefactors in equation 4 to compute the final result
     final_result = gamma(c) * (
-        result[4] * gamma(b - a) / gamma(b) / gamma(c - a) * (0.5 - z) ** (-a)
-        + result[5] * gamma(a - b) / gamma(a) / gamma(c - b) * (0.5 - z) ** (-b)
+        result[5] * gamma(b - a) / gamma(b) / gamma(c - a) * (0.5 - z) ** (-a)
+        + result[6] * gamma(a - b) / gamma(a) / gamma(c - b) * (0.5 - z) ** (-b)
     )
     return final_result
+
+@partial(jit, static_argnums=4)
+def hyp2f1_lopez_temme_8(a, b, c, z, nmax=75):
+    """
+    Equation 8 from J.L. Lopez and N.M. Temme, “New series expansions of the
+    Gauss hypergeometric function”, Adv Comput Math 39, 349-365 (2013).
+    https://link.springer.com/content/pdf/10.1007/s10444-012-9283-y.pdf"
+
+    This series expansion converges whenever Re(z) < 1, and does not have any
+    restrictions on a, b, or c. The downside is that this series converges 
+    slowly for |z| -> infty, so nmax needs to be higher for an accurate result.
+    This series expansion coverges a bit faster than the standard series expansion
+    when z is in the unit disk.
+    """
+    z = jnp.array(z, dtype=complex)
+
+    # This prefactor includes the Pochhammer symbol, n factorial and (z/(z-2))**n in the sum.
+    # This is the n=1 prefactor
+    sum_prefactor = a * (z / (z - 2.))
+
+    # The values of hyp2f1 inside the sum are computed iteratively used one of Gauss's
+    # contiguous relations
+    prev_prev_F = 1.
+    prev_F = 1. - 2. * b / c
+
+    # The loop starts at n = 2
+    init_sum = 1 + sum_prefactor * prev_F
+
+    def body_fun(n, val):
+        sum_prefactor, prev_prev_F, prev_F, sum = val
+
+        sum_prefactor *= (a + n - 1.)/n * (z / (z-2.))
+        new_F = ((n - 1.) * prev_prev_F - (2. * b - c) * prev_F) / (c + n - 1.)
+        sum += sum_prefactor * new_F
+
+        prev_prev_F = prev_F
+        prev_F = new_F
+
+        return sum_prefactor, prev_prev_F, prev_F, sum
+
+    return (1. - z/2.)**(-a) * lax.fori_loop(2, nmax, body_fun, (sum_prefactor, prev_prev_F, prev_F, init_sum))[3]
 
 
 # TODO: Implement a version that can handle c - b - a = integer
 #       This can be done using equations 15.3.10 - 15.3.12 in
 #       Abramowitz and Stegun
-@jit
-def hyp2f1_near_one(a, b, c, z):
+@partial(jit, static_argnums=4)
+def hyp2f1_near_one(a, b, c, z, nmax=50):
     """This implementation is based off of equation 15.3.6 in Abramowitz and Stegun.
-    This transformation formula allows for a calculation of hyp2f1 for points near.
-
+    This transformation formula allows for a calculation of hyp2f1 for points near
     z = 1 (where other iterative computation schemes converge slowly) by
     transforming z to 1 - z.
 
-    However, due to the presence of gamma(c - a - b) and gamma(a + b - c),
-    whenever c - a - b is an integer, one of the two terms will have
-    a pole
+    The conditions required for this series to converge are:
+    1) |1-z| < 1
+    2) z is not purely real such that z >= 1
+    3) c - a - b is not an integer
     """
-    z = jnp.asarray(z)
+    z = jnp.array(z, dtype=complex)
 
     # The branch cut for the hypergeometric function is on Re(z) >= 1, Im(z) = 0
     # If z is on the branch cut, take the value above the branch cut
@@ -159,7 +204,7 @@ def hyp2f1_near_one(a, b, c, z):
         * gamma(c - a - b)
         / gamma(c - a)
         / gamma(c - b)
-        * hyp2f1_series(a, b, a + b - c + 1.0, 1.0 - z)
+        * hyp2f1_series(a, b, a + b - c + 1.0, 1.0 - z, nmax)
     )
     term2 = (
         (1.0 - z) ** (c - a - b)
@@ -167,7 +212,7 @@ def hyp2f1_near_one(a, b, c, z):
         * gamma(a + b - c)
         / gamma(a)
         / gamma(b)
-        * hyp2f1_series(c - a, c - b, c - a - b + 1.0, 1.0 - z)
+        * hyp2f1_series(c - a, c - b, c - a - b + 1.0, 1.0 - z, nmax)
     )
     return term1 + term2
 
@@ -183,7 +228,7 @@ def hyp2f1(a, b, c, z):
     array with values in different regions on the complex plane, this function MUST be
     used so that the appropriate hyp2f1 function is used for each value.
     """
-    z = jnp.asarray(z)
+    z = jnp.array(z, dtype=complex)
     z_shape = jnp.shape(z)
     z = jnp.atleast_1d(z)
 

--- a/jaxtronomy/Util/hyp2f1_util.py
+++ b/jaxtronomy/Util/hyp2f1_util.py
@@ -5,6 +5,7 @@ import jax.numpy as jnp
 from jax import jit, lax
 from jax.scipy.special import gamma
 
+
 @partial(jit, static_argnums=4)
 def hyp2f1_series(a, b, c, z, nmax=50):
     """This computation is based off of the standard series expansion of hyp2f1.

--- a/test/test_ImSim/test_MultiBand/test_single_band_multi_model.py
+++ b/test/test_ImSim/test_MultiBand/test_single_band_multi_model.py
@@ -271,7 +271,12 @@ class TestSingleBandMultiModel(object):
             kwargs_special=self.kwargs_special,
         )
         npt.assert_raises(
-            AssertionError, npt.assert_allclose, image1, image1_ref, atol=1e-10, rtol=1e-10
+            AssertionError,
+            npt.assert_allclose,
+            image1,
+            image1_ref,
+            atol=1e-10,
+            rtol=1e-10,
         )
         image1_ref = self.singleband1_ref.image(
             kwargs_lens=self.kwargs_lens2,

--- a/test/test_ImSim/test_MultiBand/test_single_band_multi_model.py
+++ b/test/test_ImSim/test_MultiBand/test_single_band_multi_model.py
@@ -242,7 +242,7 @@ class TestSingleBandMultiModel(object):
             kwargs_ps=self.kwargs_ps,
             kwargs_special=self.kwargs_special,
         )
-        npt.assert_array_almost_equal(image0, image0_ref, decimal=8)
+        npt.assert_allclose(image0, image0_ref, atol=1e-10, rtol=1e-10)
         assert image0.shape == (self.numPix, self.numPix)
 
         image1 = self.singleband1.image(
@@ -259,7 +259,7 @@ class TestSingleBandMultiModel(object):
             kwargs_ps=self.kwargs_ps,
             kwargs_special=self.kwargs_special,
         )
-        npt.assert_array_almost_equal(image1, image1_ref, decimal=8)
+        npt.assert_allclose(image1, image1_ref, atol=1e-10, rtol=1e-10)
         assert image1.shape == (self.numPix2, self.numPix2)
 
         # Use kwargs_lens2 and make sure we get a different result
@@ -271,7 +271,7 @@ class TestSingleBandMultiModel(object):
             kwargs_special=self.kwargs_special,
         )
         npt.assert_raises(
-            AssertionError, npt.assert_array_almost_equal, image1, image1_ref, decimal=8
+            AssertionError, npt.assert_allclose, image1, image1_ref, atol=1e-10, rtol=1e-10
         )
         image1_ref = self.singleband1_ref.image(
             kwargs_lens=self.kwargs_lens2,
@@ -280,7 +280,7 @@ class TestSingleBandMultiModel(object):
             kwargs_ps=self.kwargs_ps,
             kwargs_special=self.kwargs_special,
         )
-        npt.assert_array_almost_equal(image1, image1_ref, decimal=8)
+        npt.assert_allclose(image1, image1_ref, atol=1e-10, rtol=1e-10)
 
     def test_source_surface_brightness(self):
         flux0 = self.singleband0.source_surface_brightness(
@@ -291,7 +291,7 @@ class TestSingleBandMultiModel(object):
             kwargs_lens=self.kwargs_lens,
             kwargs_source=self.kwargs_source,
         )
-        npt.assert_array_almost_equal(flux0, flux0_ref, decimal=8)
+        npt.assert_allclose(flux0, flux0_ref, atol=1e-10, rtol=1e-10)
 
         flux1 = self.singleband1.source_surface_brightness(
             kwargs_lens=self.kwargs_lens,
@@ -301,7 +301,7 @@ class TestSingleBandMultiModel(object):
             kwargs_lens=self.kwargs_lens,
             kwargs_source=self.kwargs_source,
         )
-        npt.assert_array_almost_equal(flux1, flux1_ref, decimal=8)
+        npt.assert_allclose(flux1, flux1_ref, atol=1e-10, rtol=1e-10)
 
     def test_lens_surface_brightness(self):
         flux0 = self.singleband0.lens_surface_brightness(
@@ -310,7 +310,7 @@ class TestSingleBandMultiModel(object):
         flux0_ref = self.singleband0_ref.lens_surface_brightness(
             kwargs_lens_light=self.kwargs_lens_light,
         )
-        npt.assert_array_almost_equal(flux0, flux0_ref, decimal=8)
+        npt.assert_allclose(flux0, flux0_ref, atol=1e-10, rtol=1e-10)
 
         flux1 = self.singleband1.lens_surface_brightness(
             kwargs_lens_light=self.kwargs_lens_light,
@@ -318,7 +318,7 @@ class TestSingleBandMultiModel(object):
         flux1_ref = self.singleband1_ref.lens_surface_brightness(
             kwargs_lens_light=self.kwargs_lens_light,
         )
-        npt.assert_array_almost_equal(flux1, flux1_ref, decimal=8)
+        npt.assert_allclose(flux1, flux1_ref, atol=1e-10, rtol=1e-10)
 
     def test_point_source(self):
         flux = self.singleband0.point_source(
@@ -373,7 +373,7 @@ class TestSingleBandMultiModel(object):
             kwargs_special=self.kwargs_special,
             linear_solver=False,
         )
-        npt.assert_array_almost_equal(likelihood0, likelihood0_ref, decimal=8)
+        npt.assert_allclose(likelihood0, likelihood0_ref, atol=1e-10, rtol=1e-10)
 
         likelihood1, _ = self.singleband1.likelihood_data_given_model(
             kwargs_lens=self.kwargs_lens,
@@ -390,7 +390,7 @@ class TestSingleBandMultiModel(object):
             kwargs_special=self.kwargs_special,
             linear_solver=False,
         )
-        npt.assert_array_almost_equal(likelihood1, likelihood1_ref, decimal=8)
+        npt.assert_allclose(likelihood1, likelihood1_ref, atol=1e-10, rtol=1e-10)
 
     def test_error_response(self):
         c_d, error0 = self.singleband0.error_response(
@@ -399,8 +399,8 @@ class TestSingleBandMultiModel(object):
         c_d_ref, error0_ref = self.singleband0_ref.error_response(
             self.kwargs_lens, self.kwargs_ps, self.kwargs_special
         )
-        npt.assert_array_almost_equal(c_d, c_d_ref, decimal=8)
-        npt.assert_array_almost_equal(error0, error0_ref, decimal=8)
+        npt.assert_allclose(c_d, c_d_ref, atol=1e-10, rtol=1e-10)
+        npt.assert_allclose(error0, error0_ref, atol=1e-10, rtol=1e-10)
 
         c_d, error1 = self.singleband1.error_response(
             self.kwargs_lens, self.kwargs_ps, self.kwargs_special
@@ -408,8 +408,8 @@ class TestSingleBandMultiModel(object):
         c_d_ref, error1_ref = self.singleband1_ref.error_response(
             self.kwargs_lens, self.kwargs_ps, self.kwargs_special
         )
-        npt.assert_array_almost_equal(c_d, c_d_ref, decimal=8)
-        npt.assert_array_almost_equal(error1, error1_ref, decimal=8)
+        npt.assert_allclose(c_d, c_d_ref, atol=1e-10, rtol=1e-10)
+        npt.assert_allclose(error1, error1_ref, atol=1e-10, rtol=1e-10)
 
     def test_select_kwargs(self):
         (

--- a/test/test_LensModel/test_Profiles/test_epl.py
+++ b/test/test_LensModel/test_Profiles/test_epl.py
@@ -36,10 +36,10 @@ class TestEPL(object):
             q_static_ref,
             phi_static_ref,
         ) = self.profile_ref.param_conv(theta_E, gamma, e1, e2)
-        npt.assert_almost_equal(b_static, b_static_ref, decimal=8)
-        npt.assert_almost_equal(t_static, t_static_ref, decimal=8)
-        npt.assert_almost_equal(q_static, q_static_ref, decimal=8)
-        npt.assert_almost_equal(phi_static, phi_static_ref, decimal=8)
+        npt.assert_allclose(b_static, b_static_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(t_static, t_static_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(q_static, q_static_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(phi_static, phi_static_ref, atol=1e-12, rtol=1e-12)
 
         theta_E = 11.3
         gamma, e1, e2 = 1.6, 0.2, -0.3
@@ -49,10 +49,10 @@ class TestEPL(object):
         b_ref, t_ref, q_ref, phi_G_ref = self.profile_ref.param_conv(
             theta_E, gamma, e1, e2
         )
-        npt.assert_almost_equal(b, b_ref, decimal=8)
-        npt.assert_almost_equal(t, t_ref, decimal=8)
-        npt.assert_almost_equal(q, q_ref, decimal=8)
-        npt.assert_almost_equal(phi_G, phi_G_ref, decimal=8)
+        npt.assert_allclose(b, b_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(t, t_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(q, q_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(phi_G, phi_G_ref, atol=1e-12, rtol=1e-12)
 
         # Do the same test as before to make sure that the
         # static variables are correctly updated with new values
@@ -71,10 +71,10 @@ class TestEPL(object):
             q_static_ref,
             phi_static_ref,
         ) = self.profile_ref.param_conv(theta_E, gamma, e1, e2)
-        npt.assert_almost_equal(b_static, b_static_ref, decimal=8)
-        npt.assert_almost_equal(t_static, t_static_ref, decimal=8)
-        npt.assert_almost_equal(q_static, q_static_ref, decimal=8)
-        npt.assert_almost_equal(phi_static, phi_static_ref, decimal=8)
+        npt.assert_allclose(b_static, b_static_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(t_static, t_static_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(q_static, q_static_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(phi_static, phi_static_ref, atol=1e-12, rtol=1e-12)
 
     def test_function(self):
         x = np.array([1])
@@ -83,13 +83,13 @@ class TestEPL(object):
         gamma, e1, e2 = 1.7, 0.3, -0.2
         values = self.profile.function(x, y, theta_E, gamma, e1, e2)
         values_ref = self.profile_ref.function(x, y, theta_E, gamma, e1, e2)
-        npt.assert_almost_equal(values, values_ref, decimal=8)
+        npt.assert_allclose(values, values_ref, atol=1e-12, rtol=1e-12)
 
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])
         values = self.profile.function(x, y, theta_E, gamma, e1, e2)
         values_ref = self.profile_ref.function(x, y, theta_E, gamma, e1, e2)
-        npt.assert_almost_equal(values, values_ref, decimal=8)
+        npt.assert_allclose(values, values_ref, atol=1e-12, rtol=1e-12)
 
     def test_derivatives(self):
         x = np.array([1])
@@ -98,15 +98,15 @@ class TestEPL(object):
         gamma, e1, e2 = 1.7, -0.1, 0.2
         f_x, f_y = self.profile.derivatives(x, y, theta_E, gamma, e1, e2)
         f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, theta_E, gamma, e1, e2)
-        npt.assert_almost_equal(f_x, f_x_ref, decimal=8)
-        npt.assert_almost_equal(f_y, f_y_ref, decimal=8)
+        npt.assert_allclose(f_x, f_x_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(f_y, f_y_ref, atol=1e-12, rtol=1e-12)
 
         x = np.array([1, 3, 4])
         y = np.array([2, 1, 1])
         f_x, f_y = self.profile.derivatives(x, y, theta_E, gamma, e1, e2)
         f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, theta_E, gamma, e1, e2)
-        npt.assert_array_almost_equal(f_x, f_x_ref, decimal=8)
-        npt.assert_array_almost_equal(f_y, f_y_ref, decimal=8)
+        npt.assert_allclose(f_x, f_x_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(f_y, f_y_ref, atol=1e-12, rtol=1e-12)
 
     def test_hessian(self):
         x = np.array([1])
@@ -117,10 +117,10 @@ class TestEPL(object):
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
             x, y, theta_E, gamma, e1, e2
         )
-        npt.assert_almost_equal(f_xx, f_xx_ref, decimal=8)
-        npt.assert_almost_equal(f_xy, f_xy_ref, decimal=8)
-        npt.assert_almost_equal(f_yy, f_yy_ref, decimal=8)
-        npt.assert_almost_equal(f_xy, f_yx, decimal=8)
+        npt.assert_allclose(f_xx, f_xx_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(f_xy, f_xy_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(f_yy, f_yy_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(f_xy, f_yx, atol=1e-12, rtol=1e-12)
 
         x = np.array([1, 3, 4])
         y = np.array([2, 1, 1])
@@ -128,15 +128,15 @@ class TestEPL(object):
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
             x, y, theta_E, gamma, e1, e2
         )
-        npt.assert_array_almost_equal(f_xx, f_xx_ref, decimal=8)
-        npt.assert_array_almost_equal(f_xy, f_xy_ref, decimal=8)
-        npt.assert_array_almost_equal(f_yy, f_yy_ref, decimal=8)
-        npt.assert_array_almost_equal(f_xy, f_yx, decimal=8)
+        npt.assert_allclose(f_xx, f_xx_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(f_xy, f_xy_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(f_yy, f_yy_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(f_xy, f_yx, atol=1e-12, rtol=1e-12)
 
     def test_mass_3d_lens(self):
         mass = self.profile.mass_3d_lens(r=1, theta_E=1, gamma=1.7)
         mass_ref = self.profile_ref.mass_3d_lens(r=1, theta_E=1, gamma=1.7)
-        npt.assert_almost_equal(mass, mass_ref, decimal=8)
+        npt.assert_allclose(mass, mass_ref, atol=1e-12, rtol=1e-12)
 
     def test_density_lens(self):
         x = 1
@@ -146,7 +146,7 @@ class TestEPL(object):
         gamma = 2.1
         density = self.profile.density_lens(r, theta_E, gamma)
         density_ref = self.profile_ref.density_lens(r, theta_E, gamma)
-        npt.assert_almost_equal(density, density_ref, decimal=8)
+        npt.assert_allclose(density, density_ref, atol=1e-12, rtol=1e-12)
 
 
 class TestEPLMajorAxis(object):
@@ -158,55 +158,54 @@ class TestEPLMajorAxis(object):
     def test_function(self):
         x = np.array([1])
         y = np.array([2])
-        theta_E = 12.3
         b, t, q = 1.7, 0.7, 0.7
         values = self.profile.function(x, y, b, t, q)
         values_ref = self.profile_ref.function(x, y, b, t, q)
-        npt.assert_almost_equal(values, values_ref, decimal=8)
+        npt.assert_allclose(values, values_ref, atol=1e-12, rtol=1e-12)
 
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])
         values = self.profile.function(x, y, b, t, q)
         values_ref = self.profile_ref.function(x, y, b, t, q)
-        npt.assert_almost_equal(values, values_ref, decimal=8)
+        npt.assert_allclose(values, values_ref, atol=1e-12, rtol=1e-12)
 
     def test_derivatives(self):
         x = np.array([1])
         y = np.array([2])
-        theta_E = 1.0
         b, t, q = 1.7, 0.9, 0.8
         f_x, f_y = self.profile.derivatives(x, y, b, t, q)
         f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, b, t, q)
-        npt.assert_almost_equal(f_x, f_x_ref, decimal=8)
-        npt.assert_almost_equal(f_y, f_y_ref, decimal=8)
+        npt.assert_allclose(f_x, f_x_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(f_y, f_y_ref, atol=1e-12, rtol=1e-12)
 
-        x = np.array([1, 3, 4])
-        y = np.array([2, 1, 1])
-        f_x, f_y = self.profile.derivatives(x, y, b, t, q)
-        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, b, t, q)
-        npt.assert_array_almost_equal(f_x, f_x_ref, decimal=8)
-        npt.assert_array_almost_equal(f_y, f_y_ref, decimal=8)
+        y = np.linspace(-10, 10, 101)
+        x = np.ones_like(y)
+        list_of_q = np.linspace(0.03, 1, 200)[::-1]
+        for q in list_of_q:
+            f_x, f_y = self.profile.derivatives(x, y, b, t, q)
+            f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, b, t, q)
+            npt.assert_allclose(f_x, f_x_ref, atol=1e-12, rtol=1e-12)
+            npt.assert_allclose(f_y, f_y_ref, atol=1e-12, rtol=1e-12)
 
     def test_hessian(self):
         x = np.array([1])
         y = np.array([2])
-        theta_E = 1.0
         b, t, q = 2.2, 0.6, 0.4
         f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, b, t, q)
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(x, y, b, t, q)
-        npt.assert_almost_equal(f_xx, f_xx_ref, decimal=7)
-        npt.assert_almost_equal(f_xy, f_xy_ref, decimal=7)
-        npt.assert_almost_equal(f_yy, f_yy_ref, decimal=7)
-        npt.assert_almost_equal(f_xy, f_yx, decimal=7)
+        npt.assert_allclose(f_xx, f_xx_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(f_xy, f_xy_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(f_yy, f_yy_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(f_xy, f_yx, atol=1e-12, rtol=1e-12)
 
         x = np.array([1, 3, 4])
         y = np.array([2, 1, 1])
         f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, b, t, q)
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(x, y, b, t, q)
-        npt.assert_array_almost_equal(f_xx, f_xx_ref, decimal=7)
-        npt.assert_array_almost_equal(f_xy, f_xy_ref, decimal=7)
-        npt.assert_array_almost_equal(f_yy, f_yy_ref, decimal=7)
-        npt.assert_array_almost_equal(f_xy, f_yx, decimal=7)
+        npt.assert_allclose(f_xx, f_xx_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(f_xy, f_xy_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(f_yy, f_yy_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(f_xy, f_yx, atol=1e-12, rtol=1e-12)
 
 
 class TestEPLQPhi(object):
@@ -222,13 +221,13 @@ class TestEPLQPhi(object):
         gamma, q, phi = 1.7, 0.3, -2.2
         values = self.profile.function(x, y, theta_E, gamma, q, phi)
         values_ref = self.profile_ref.function(x, y, theta_E, gamma, q, phi)
-        npt.assert_almost_equal(values, values_ref, decimal=8)
+        npt.assert_allclose(values, values_ref, atol=1e-12, rtol=1e-12)
 
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])
         values = self.profile.function(x, y, theta_E, gamma, q, phi)
         values_ref = self.profile_ref.function(x, y, theta_E, gamma, q, phi)
-        npt.assert_almost_equal(values, values_ref, decimal=8)
+        npt.assert_allclose(values, values_ref, atol=1e-12, rtol=1e-12)
 
     def test_derivatives(self):
         x = np.array([1])
@@ -237,15 +236,15 @@ class TestEPLQPhi(object):
         gamma, q, phi = 1.7, 0.7, 2.2
         f_x, f_y = self.profile.derivatives(x, y, theta_E, gamma, q, phi)
         f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, theta_E, gamma, q, phi)
-        npt.assert_almost_equal(f_x, f_x_ref, decimal=8)
-        npt.assert_almost_equal(f_y, f_y_ref, decimal=8)
+        npt.assert_allclose(f_x, f_x_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(f_y, f_y_ref, atol=1e-12, rtol=1e-12)
 
         x = np.array([1, 3, 4])
         y = np.array([2, 1, 1])
         f_x, f_y = self.profile.derivatives(x, y, theta_E, gamma, q, phi)
         f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, theta_E, gamma, q, phi)
-        npt.assert_array_almost_equal(f_x, f_x_ref, decimal=8)
-        npt.assert_array_almost_equal(f_y, f_y_ref, decimal=8)
+        npt.assert_allclose(f_x, f_x_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(f_y, f_y_ref, atol=1e-12, rtol=1e-12)
 
     def test_hessian(self):
         x = np.array([1])
@@ -256,10 +255,10 @@ class TestEPLQPhi(object):
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
             x, y, theta_E, gamma, q, phi
         )
-        npt.assert_almost_equal(f_xx, f_xx_ref, decimal=8)
-        npt.assert_almost_equal(f_xy, f_xy_ref, decimal=8)
-        npt.assert_almost_equal(f_yy, f_yy_ref, decimal=8)
-        npt.assert_almost_equal(f_xy, f_yx, decimal=8)
+        npt.assert_allclose(f_xx, f_xx_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(f_xy, f_xy_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(f_yy, f_yy_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(f_xy, f_yx, atol=1e-12, rtol=1e-12)
 
         x = np.array([1, 3, 4])
         y = np.array([2, 1, 1])
@@ -267,15 +266,15 @@ class TestEPLQPhi(object):
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
             x, y, theta_E, gamma, q, phi
         )
-        npt.assert_array_almost_equal(f_xx, f_xx_ref, decimal=8)
-        npt.assert_array_almost_equal(f_xy, f_xy_ref, decimal=8)
-        npt.assert_array_almost_equal(f_yy, f_yy_ref, decimal=8)
-        npt.assert_array_almost_equal(f_xy, f_yx, decimal=8)
+        npt.assert_allclose(f_xx, f_xx_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(f_xy, f_xy_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(f_yy, f_yy_ref, atol=1e-12, rtol=1e-12)
+        npt.assert_allclose(f_xy, f_yx, atol=1e-12, rtol=1e-12)
 
     def test_mass_3d_lens(self):
         mass = self.profile.mass_3d_lens(r=1, theta_E=1, gamma=1.7)
         mass_ref = self.profile_ref.mass_3d_lens(r=1, theta_E=1, gamma=1.7)
-        npt.assert_almost_equal(mass, mass_ref, decimal=8)
+        npt.assert_allclose(mass, mass_ref, atol=1e-12, rtol=1e-12)
 
     def test_density_lens(self):
         x = 3
@@ -285,7 +284,7 @@ class TestEPLQPhi(object):
         gamma = 2.1
         density = self.profile.density_lens(r, theta_E, gamma)
         density_ref = self.profile_ref.density_lens(r, theta_E, gamma)
-        npt.assert_almost_equal(density, density_ref, decimal=8)
+        npt.assert_allclose(density, density_ref, atol=1e-12, rtol=1e-12)
 
 
 if __name__ == "__main__":

--- a/test/test_Util/test_hyp2f1_util.py
+++ b/test/test_Util/test_hyp2f1_util.py
@@ -1,15 +1,16 @@
 import pytest
 from scipy.special import hyp2f1 as hyp2f1_ref
+import numpy.testing as npt
 
-import jax
+from jax import config, numpy as jnp
+config.update("jax_enable_x64", True)  # 64-bit floats, consistent with numpy
 
-jax.config.update("jax_enable_x64", True)  # 64-bit floats, consistent with numpy
-import jax.numpy as jnp
 from jaxtronomy.Util.hyp2f1_util import (
     hyp2f1,
     hyp2f1_series,
     hyp2f1_near_one,
     hyp2f1_continuation,
+    hyp2f1_lopez_temme_8,
 )
 
 
@@ -19,29 +20,22 @@ def test_hyp2f1_series():
     x = jnp.array([0.3, 0.5, -0.6, 0.2])
     y = jnp.array([0.5, 0.1, 0.1, -0.6])
     z = x + y * 1j
-    result = hyp2f1_series(a, b, c, z)
+    result = hyp2f1_series(a, b, c, z, nmax=75)
     result_ref = hyp2f1_ref(a, b, c, z)
-    assert jnp.allclose(
-        result, result_ref
-    ), "hyp2f1_series result does not match scipy result"
+    npt.assert_allclose(result, result_ref, atol=1e-12, rtol=1e-12)
 
     # Points very close to the boundary of the circle are less accurate
     # Supports list inputs
     z = [0.99 + 0.001j]
-    result = hyp2f1_series(a, b, c, z)
+    result = hyp2f1_series(a, b, c, z, nmax=200)
     result_ref = hyp2f1_ref(a, b, c, z)
-    assert jnp.allclose(
-        result, result_ref, atol=1e-4
-    ), "hyp2f1_series result does not match scipy result"
+    npt.assert_allclose(result, result_ref, atol=1e-4, rtol=1e-4)
 
     # Also supports scalar inputs
     z = -0.99 + 0.001j
-    result = hyp2f1_series(a, b, c, z)
+    result = hyp2f1_series(a, b, c, z, nmax=200)
     result_ref = hyp2f1_ref(a, b, c, z)
-    assert jnp.allclose(
-        result, result_ref, atol=1e-4
-    ), "hyp2f1_series result does not match scipy result"
-    assert result.ndim == 0
+    npt.assert_allclose(result, result_ref, atol=1e-4, rtol=1e-4)
 
 
 def test_hyp2f1_near_one():
@@ -50,29 +44,23 @@ def test_hyp2f1_near_one():
     x = jnp.array([0.8, 1.3, 1.1, 0.6])
     y = jnp.array([0.3, 0.1, 0.4, -0.2])
     z = x + y * 1j
-    result = hyp2f1_near_one(a, b, c, z)
+    result = hyp2f1_near_one(a, b, c, z, nmax=75)
     result_ref = hyp2f1_ref(a, b, c, z)
-    assert jnp.allclose(
-        result, result_ref
-    ), "hyp2f1_near_one result does not match scipy result"
+    npt.assert_allclose(result, result_ref, atol=1e-8, rtol=1e-8)
 
     # Points very close to the boundary of the circle are less accurate
     # Also supports list inputs
     z = [0.05 + 0.001j]
-    result = hyp2f1_near_one(a, b, c, z)
+    result = hyp2f1_near_one(a, b, c, z, nmax=200)
     result_ref = hyp2f1_ref(a, b, c, z)
-    assert jnp.allclose(
-        result, result_ref, atol=1e-2
-    ), "hyp2f1_near_one result does not match scipy result"
+    npt.assert_allclose(result, result_ref, atol=1e-3, rtol=1e-3)
 
     # Tests to see if the value of z above the branch cut is taken
     # Also supports scalar inputs
     z = 1.1 + 0.0j
     result = hyp2f1_near_one(a, b, c, z)
     result_ref = hyp2f1_ref(a, b, c, z)
-    assert jnp.allclose(
-        result, result_ref
-    ), "hyp2f1_near_one result does not match scipy result"
+    npt.assert_allclose(result, result_ref, atol=1e-7, rtol=1e-7)
 
 
 def test_hyp2f1_continuation():
@@ -81,29 +69,46 @@ def test_hyp2f1_continuation():
     x = jnp.array([-0.8, 1.3, 1.1, -1.6])
     y = jnp.array([0.3, 0.1, -0.4, -2.2])
     z = x + y * 1j
-    result = hyp2f1_continuation(a, b, c, z)
+    result = hyp2f1_continuation(a, b, c, z, nmax=100)
     result_ref = hyp2f1_ref(a, b, c, z)
-    assert jnp.allclose(
-        result, result_ref
-    ), "hyp2f1_continuation result does not match scipy result"
+    npt.assert_allclose(result, result_ref, atol=1e-8, rtol=1e-8)
 
     # Points very close to the boundary of the circle are less accurate
     # Also supports list inputs
     z = [1.03 + 0.001j]
-    result = hyp2f1_continuation(a, b, c, z)
+    result = hyp2f1_continuation(a, b, c, z, nmax=200)
     result_ref = hyp2f1_ref(a, b, c, z)
-    assert jnp.allclose(
-        result, result_ref, atol=1e-4
-    ), "hyp2f1_continuation result does not match scipy result"
+    npt.assert_allclose(result, result_ref, atol=1e-4, rtol=1e-4)
 
     # Tests to see if the value above the branch cut is taken
     # Also supports scalar inputs
     z = 3.0 + 0.0j
     result = hyp2f1_continuation(a, b, c, z)
     result_ref = hyp2f1_ref(a, b, c, z)
-    assert jnp.allclose(
-        result, result_ref
-    ), "hyp2f1_continuation result does not match scipy result"
+    npt.assert_allclose(result, result_ref, atol=1e-8, rtol=1e-8)
+
+def test_hyp2f1_lopez_temme():
+    a, b, c = 0.3, 0.7, 2.2
+    # Only tests points such that Re(z) < 1
+    x = jnp.array([0.3, 0.5, -0.6, 0.2, -3.2])
+    y = jnp.array([0.5, 2.1, 0.1, -1.6, 1.1])
+    z = x + y * 1j
+    result = hyp2f1_lopez_temme_8(a, b, c, z, nmax=75)
+    result_ref = hyp2f1_ref(a, b, c, z)
+    npt.assert_allclose(result, result_ref, atol=1e-8, rtol=1e-8)
+
+    # Points very close to Re(z) are less accurate
+    # Supports list inputs
+    z = [0.99 + 0.001j]
+    result = hyp2f1_lopez_temme_8(a, b, c, z, nmax=200)
+    result_ref = hyp2f1_ref(a, b, c, z)
+    npt.assert_allclose(result, result_ref, atol=1e-5, rtol=1e-5)
+
+    # Also supports scalar inputs
+    z = -10.99 + 0.001j
+    result = hyp2f1_lopez_temme_8(a, b, c, z, nmax=75)
+    result_ref = hyp2f1_ref(a, b, c, z)
+    npt.assert_allclose(result, result_ref, atol=1e-8, rtol=1e-8)
 
 
 def test_hyp2f1():

--- a/test/test_lenstronomy_import.py
+++ b/test/test_lenstronomy_import.py
@@ -2,4 +2,4 @@ def test_lenstronomy_version():
     """Tests the import of lenstronomy."""
     import lenstronomy
 
-    assert lenstronomy.__version__ == "1.12.6"
+    assert lenstronomy.__version__ == "1.13.0"


### PR DESCRIPTION
Previously, the deflection angle calculation for the EPL profile required a fixed number of terms in the hyp2f1 series expansion in order for autodifferentiation to be used. This resulted in a massive slowdown compared to lenstronomy in situations where only a small number of terms are needed.

If we have two different implementations of the same function, `f1` and `f2`, where `f1` is used for straightforward function evaluations and `f2` is used for autodifferentiation, then we can overwrite the derivative of `f1` using jax.custom_jvp so that it always autodifferentiates through `f2` instead.

In this PR, this is done for the hyp2f1 calculation. For straightforward function evaluations, the number of terms included in the series is adjusted depending on how quickly the series converges, and for autodifferentiation, a fixed number of terms is included. This results in a significant performance boost whenever autodifferentiation is not needed.

Additionally, a faster calculation of hyp2f1 based off of J.L. Lopez and N.M. Temme (2013) has been implemented.

I will update the benchmarking table in the next PR.