### PR TITLE
update jaxtronomy version

### DIFF
--- a/jaxtronomy/Workflow/fitting_sequence.py
+++ b/jaxtronomy/Workflow/fitting_sequence.py
@@ -197,11 +197,25 @@ class FittingSequence(object):
                 nautilus = NautilusSampler(
                     likelihood_module=self.likelihoodModule, mpi=self._mpi, **kwargs
                 )
-                points, log_w, log_l, log_z = nautilus.run(**kwargs)
-                chain_list.append([points, log_w, log_l, log_z])
+                samples, means, log_z, log_z_err, log_l, results_object = nautilus.run(
+                    **kwargs
+                )
+                chain_list.append(
+                    [
+                        fitting_type,
+                        samples,
+                        nautilus.param_names,
+                        log_l,
+                        log_z,
+                        log_z_err,
+                        results_object,
+                    ]
+                )
                 if kwargs.get("verbose", False):
-                    print(len(points), "number of points sampled")
-                kwargs_result = self.best_fit_from_samples(points, log_l)
+                    print(len(samples), "number of points sampled")
+                kwargs_result = self.best_fit_from_samples(
+                    results_object["points"], results_object["log_l"]
+                )
                 self._updateManager.update_param_state(**kwargs_result)
             elif fitting_type == "optax":
                 kwargs_result = self.optax(**kwargs)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 requires = [
-    "lenstronomy>=1.13.5",
+    "lenstronomy==1.13.6",
     "numpy>=2.0.0",
     "jax>=0.7.0",
     "numpyro>=0.19.0",
@@ -19,7 +19,7 @@ readme = open("README.rst").read()
 
 setup(
     name="jaxtronomy",
-    version="0.1.2",
+    version="0.1.3",
     python_requires=">=3.11",
     url="https://github.com/lenstronomy/JAXtronomy",
     author="jaxtronomy developers",


### PR DESCRIPTION
1. Upload new jaxtronomy version 0.1.3 onto PyPI, which should be consistent with lenstronomy 1.13.6
2. Copy paste the changes made in lenstronomy PR #829