### PR TITLE
bug fixes

### DIFF
--- a/jaxtronomy/LensModel/lens_model.py
+++ b/jaxtronomy/LensModel/lens_model.py
@@ -6,6 +6,8 @@ from jaxtronomy.LensModel.MultiPlane.multi_plane import MultiPlane
 
 from lenstronomy.Cosmo.lens_cosmo import LensCosmo
 from lenstronomy.Util import constants as const
+from lenstronomy.Util.cosmo_util import get_astropy_cosmology
+from astropy.cosmology import default_cosmology
 
 from functools import partial
 from jax import jit
@@ -38,6 +40,7 @@ class LensModel(object):
         kwargs_multiplane_model=None,
         distance_ratio_sampling=False,
         cosmology_sampling=False,
+        cosmology_model="FlatLambdaCDM",
     ):
         """
 
@@ -68,6 +71,7 @@ class LensModel(object):
             distance ratios to update T_ij value in multi-lens plane computation. Not supported in JAXtronomy.
         :param cosmology_sampling: bool, if True, will use sampled cosmology
             to update T_ij value in multi-lens plane computation. Not supported in JAXtronomy.
+        :param cosmology_model: str, name of the cosmology model to be used. Default is 'FlatLambdaCDM'.
         """
         if cosmology_sampling:
             raise ValueError("Cosmology sampling not supported in JAXtronomy")
@@ -88,11 +92,13 @@ class LensModel(object):
             profile_kwargs_list = [{} for _ in range(len(lens_model_list))]
         self.profile_kwargs_list = profile_kwargs_list
 
-        if cosmo is None:
-            from astropy.cosmology import default_cosmology
-
+        if cosmo is None and cosmology_model == "FlatLambdaCDM":
             cosmo = default_cosmology.get()
+        elif cosmo is None and cosmology_model != "FlatLambdaCDM":
+            cosmo = get_astropy_cosmology(cosmology_model=cosmology_model)
+
         self.cosmo = cosmo
+        self.cosmology_model = cosmology_model
 
         # Are there line-of-sight corrections?
         permitted_los_models = ["LOS", "LOS_MINIMAL"]

--- a/jaxtronomy/LightModel/light_model.py
+++ b/jaxtronomy/LightModel/light_model.py
@@ -45,5 +45,7 @@ class LightModel(LinearBasis):
         )
         self.deflection_scaling_list = deflection_scaling_list
         if source_redshift_list is not None and source_redshift_list != []:
-            raise ValueError("multi plane sources not supported in jaxtronomy yet, source_redshift_list must be None")
+            raise ValueError(
+                "multi plane sources not supported in jaxtronomy yet, source_redshift_list must be None"
+            )
         self.redshift_list = source_redshift_list

--- a/jaxtronomy/LightModel/light_model.py
+++ b/jaxtronomy/LightModel/light_model.py
@@ -45,5 +45,5 @@ class LightModel(LinearBasis):
         )
         self.deflection_scaling_list = deflection_scaling_list
         if source_redshift_list is not None and source_redshift_list != []:
-            raise ValueError("multi plane sources not supported in jaxtronomy yet")
+            raise ValueError("multi plane sources not supported in jaxtronomy yet, source_redshift_list must be None")
         self.redshift_list = source_redshift_list

--- a/jaxtronomy/PointSource/Types/base_ps.py
+++ b/jaxtronomy/PointSource/Types/base_ps.py
@@ -43,7 +43,11 @@ class PSBase(object):
         # Only need to create a new LensModel class if the point source has a redshift
         # that is different than in the initial LensModel class
         # The behavior should be the same as in lenstronomy's LensModel.change_source_redshift()
-        if lens_model is not None and redshift != lens_model.z_source and redshift is not None:
+        if (
+            lens_model is not None
+            and redshift != lens_model.z_source
+            and redshift is not None
+        ):
             new_init_kwargs = deepcopy(lens_model.init_kwargs)
             new_init_kwargs["z_source"] = redshift
             self._lens_model = LensModel(**new_init_kwargs)

--- a/jaxtronomy/PointSource/Types/base_ps.py
+++ b/jaxtronomy/PointSource/Types/base_ps.py
@@ -40,7 +40,10 @@ class PSBase(object):
         self._redshift = redshift
 
         self._lens_model = lens_model
-        if lens_model is not None and redshift != lens_model.z_source:
+        # Only need to create a new LensModel class if the point source has a redshift
+        # that is different than in the initial LensModel class
+        # The behavior should be the same as in lenstronomy's LensModel.change_source_redshift()
+        if lens_model is not None and redshift != lens_model.z_source and redshift is not None:
             new_init_kwargs = deepcopy(lens_model.init_kwargs)
             new_init_kwargs["z_source"] = redshift
             self._lens_model = LensModel(**new_init_kwargs)

--- a/jaxtronomy/Util/class_creator.py
+++ b/jaxtronomy/Util/class_creator.py
@@ -30,6 +30,8 @@ def create_class_instances(
     lens_profile_kwargs_list=None,
     multi_plane=False,
     distance_ratio_sampling=False,
+    cosmology_sampling=False,
+    cosmology_model="FlatLambdaCDM",
     observed_convention_index=None,
     source_light_model_list=None,
     source_light_profile_kwargs_list=None,
@@ -76,6 +78,8 @@ def create_class_instances(
         profile will be initialized using default settings.
     :param multi_plane: bool, if True, computes the lensing quantities in multi-plane mode
     :param distance_ratio_sampling: bool, if True, samples the distance ratios in multi-lens-plane
+    :param cosmology_sampling: bool, if True, samples the cosmology in multi-lens-plane
+    :param cosmology_model: string, name of the cosmology model to be used in the multi-lens-plane mode
     :param observed_convention_index:
     :param source_light_model_list: list of strings indicating the type of source light models
     :param source_light_profile_kwargs_list: list of dicts, keyword arguments used to initialize source light
@@ -173,6 +177,8 @@ def create_class_instances(
         multi_plane=multi_plane,
         cosmo=cosmo,
         distance_ratio_sampling=distance_ratio_sampling,
+        cosmology_sampling=cosmology_sampling,
+        cosmology_model=cosmology_model,
         observed_convention_index=observed_convention_index_i,
         profile_kwargs_list=lens_profile_kwargs_list,
         decouple_multi_plane=decouple_multi_plane,

--- a/jaxtronomy/Workflow/fitting_sequence.py
+++ b/jaxtronomy/Workflow/fitting_sequence.py
@@ -63,9 +63,9 @@ class FittingSequence(object):
         :param verbose: bool, if True prints temporary results and indicators of the fitting process
         """
         solver_type = kwargs_constraints.get("solver_type", None)
-        if solver_type is not None:
+        if solver_type is not None and solver_type != "NONE":
             raise NotImplementedError(
-                "JAXtronomy has not implemented any solvers, so solver_type must be set to None."
+                "JAXtronomy has not implemented any solvers, so solver_type must be set to None or 'NONE'."
             )
 
         self.kwargs_data_joint = kwargs_data_joint

--- a/jaxtronomy/Workflow/fitting_sequence.py
+++ b/jaxtronomy/Workflow/fitting_sequence.py
@@ -73,6 +73,8 @@ class FittingSequence(object):
         self.multi_band_type = kwargs_data_joint.get("multi_band_type", "single-band")
         self._verbose = verbose
         self._mpi = mpi
+
+        kwargs_constraints["_jax"] = True
         self._updateManager = MultiBandUpdateManager(
             kwargs_model,
             kwargs_constraints,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 lenstronomy @ https://github.com/lenstronomy/lenstronomy/archive/refs/heads/main.zip
 numpy>=2.0.0
-jax<0.10.0
+jax>=0.7.0, <0.10.0
 numpyro>=0.19.0
 optax>=0.2.5
 scipy

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 requires = [
     "lenstronomy>=1.13.6",
     "numpy>=2.0.0",
-    "jax>=0.7.0",
+    "jax>=0.7.0,<0.10.0",
     "numpyro>=0.19.0",
     "optax>=0.2.5",
     "tqdm",

--- a/test/test_LensModel/test_MultiPlane/test_multi_plane.py
+++ b/test/test_LensModel/test_MultiPlane/test_multi_plane.py
@@ -19,7 +19,7 @@ class TestMultiPlane(object):
         z_source = 3.5
         lens_model_list = ["NFW", "NIE", "NFW", "NFW", "NFW"]
         redshift_list = [0.5, 1.1, 1.1, 1.5, 1.3]
-        cosmo = FlatwCDM(H0=70, Om0=0.3, w0=-0.8)
+        cosmo = FlatwCDM(H0=70, Om0=0.3, w0=-1)
         self.multiplane = MultiPlane(
             z_source=z_source,
             lens_model_list=lens_model_list,
@@ -28,8 +28,9 @@ class TestMultiPlane(object):
             cosmo_interp=True,
             distance_ratio_sampling=False,
             z_lens_convention=0.5,
-            cosmo=cosmo,
+            cosmo=None,
             cosmology_sampling=False,
+            cosmology_model="FlatwCDM",
         )
 
         self.multiplane_ref = MultiPlane_ref(

--- a/test/test_LensModel/test_lens_model.py
+++ b/test/test_LensModel/test_lens_model.py
@@ -177,6 +177,8 @@ class TestLensModel(object):
             lens_redshift_list=[z_lens, 0.7, 0.9],
             z_lens=z_lens,
             z_source=z_source,
+            cosmo=None,
+            cosmology_model="FlatLambdaCDM",
         )
         lensModel_ref = LensModel_ref(
             lens_model_list=["SIS", "SIS", "SIS"],
@@ -184,6 +186,8 @@ class TestLensModel(object):
             lens_redshift_list=[z_lens, 0.7, 0.9],
             z_lens=z_lens,
             z_source=z_source,
+            cosmo=None,
+            cosmology_model="FlatLambdaCDM",
         )
         kwargs = [
             {"theta_E": 1.1, "center_x": 0.0, "center_y": 0.0},
@@ -233,6 +237,8 @@ class TestLensModel(object):
             lens_redshift_list=[z_lens],
             z_lens=z_lens,
             z_source=z_source,
+            cosmo=None,
+            cosmology_model="FlatwCDM",
         )
         lensModel_ref = LensModel_ref(
             lens_model_list=["SIS"],
@@ -240,6 +246,8 @@ class TestLensModel(object):
             lens_redshift_list=[z_lens],
             z_lens=z_lens,
             z_source=z_source,
+            cosmo=None,
+            cosmology_model="FlatwCDM",
         )
         kwargs = [{"theta_E": 1.0, "center_x": 0.0, "center_y": 0.0}]
         fermat_pot = lensModel.fermat_potential(x_image, y_image, kwargs)

--- a/test/test_PointSource/test_point_source.py
+++ b/test/test_PointSource/test_point_source.py
@@ -400,6 +400,7 @@ class TestPointSource3(TestPointSource):
 
         self.kwargs_lens = [kwargs_epl, kwargs_sis]
 
+
 # Same tests as before but this time with set index_lens_model_list and point_source_frame_list
 # Different setup method but inherits all the tests from above
 class TestPointSourcewithFrames(TestPointSource):

--- a/test/test_PointSource/test_point_source.py
+++ b/test/test_PointSource/test_point_source.py
@@ -331,6 +331,75 @@ class TestPointSource2(TestPointSource):
         self.kwargs_lens = [kwargs_epl, kwargs_sis]
 
 
+# Same tests as before but this time with MultiPlane lens model and
+# the redshift_list is set to None when initializing the PointSource class
+# So the ray shooting should be done using z_source
+# Different setup method but inherits all the tests from above
+class TestPointSource3(TestPointSource):
+    def setup_method(self):
+
+        lens_model_list = ["EPL", "SIS"]
+        point_source_type_list = ["LENSED_POSITION", "UNLENSED", "LENSED_POSITION"]
+
+        lensmodel = LensModel(
+            lens_model_list=lens_model_list,
+            lens_redshift_list=[0.6, 0.8],
+            multi_plane=True,
+            z_source=1.1,
+            z_source_convention=1.1,
+        )
+        self.ps = PointSource(
+            point_source_type_list=point_source_type_list,
+            lens_model=lensmodel,
+            fixed_magnification_list=[False, False, True],
+        )
+
+        lensmodel_ref = LensModel_ref(
+            lens_model_list=lens_model_list,
+            lens_redshift_list=[0.6, 0.8],
+            multi_plane=True,
+            z_source=1.1,
+            z_source_convention=1.1,
+        )
+        self.ps_ref = PointSource_ref(
+            point_source_type_list=point_source_type_list,
+            lens_model=lensmodel_ref,
+            fixed_magnification_list=[False, False, True],
+        )
+
+        kwargs_ps1 = {
+            "ra_image": [0.1, 0.3, -0.298],
+            "dec_image": [-0.3, 0.2, 0.1293],
+            "point_amp": [1.3, 1.4, 0.2387],
+        }
+
+        kwargs_ps2 = {
+            "ra_image": [0.5, 0.1, 0.2198, 1.38234],
+            "dec_image": [-0.31, 0.232, -0.23487, 0.2347],
+            "point_amp": [1.3534, 1.4345, 0.434, 2.3429],
+        }
+
+        kwargs_ps3 = {
+            "ra_image": [0.4321, 0.233, 0.345],
+            "dec_image": [-0.123, 0.243, 0.389],
+            "source_amp": 1.5,
+        }
+        self.kwargs_ps = [kwargs_ps1, kwargs_ps2, kwargs_ps3]
+
+        kwargs_epl = {
+            "theta_E": 1.3,
+            "gamma": 1.7,
+            "e1": 0.13,
+            "e2": 0.01,
+        }
+        kwargs_sis = {
+            "theta_E": 1.5,
+            "center_x": -0.11,
+            "center_y": -0.03,
+        }
+
+        self.kwargs_lens = [kwargs_epl, kwargs_sis]
+
 # Same tests as before but this time with set index_lens_model_list and point_source_frame_list
 # Different setup method but inherits all the tests from above
 class TestPointSourcewithFrames(TestPointSource):


### PR DESCRIPTION
1. Previously, the PointSource class created a new LensModel class even if the supplied redshift was None. Now, a new LensModel class is only created if the supplied redshift is not None. This is consistent with lenstronomy's LensModel.change_source_redshift() behavior.
2. A _jax=True flag is sent to lenstronomy's Param class, allowing for JAX instances of classes to be created when dealing with certain parameter settings (e.g. joint source with point source)
3. Some arguments in lenstronomy's create_class_instances() and LensModel() were not present in the jaxtronomy version. Those arguments have been restored.
4. Fixed JAX requirements to be >=0.7.0 and <0.10.0 in both the requirements.txt and setup.py (until NumPyro fixes their issue)