### PR TITLE
Allow n = -1 for shapelets, remove deprecated jax argument in args2kwargs

### DIFF
--- a/jaxtronomy/LightModel/Profiles/shapelets.py
+++ b/jaxtronomy/LightModel/Profiles/shapelets.py
@@ -356,6 +356,11 @@ class ShapeletSetStatic(object):
         x_shape = x.shape
         x = jnp.atleast_1d(x)
         f_ = jnp.zeros_like(x)
+
+        # It is possible to initialize the class with n_max = -1, effectively turning off the Shapelets
+        if self.num_param == 0:
+            return f_
+        
         amp = jnp.array(amp)
 
         phi_x, phi_y = self.shapelets.pre_calc(
@@ -397,6 +402,9 @@ class ShapeletSetStatic(object):
                 f"Length of amplitude array {len(amp)} not consistent with n_max {self.n_max} given at initialization. The length of amplitude array should be {self.num_param}"
             )
         f_ = []
+        # It is possible to initialize the class with n_max = -1, effectively turning off the Shapelets
+        if self.num_param == 0:
+            return f_
 
         phi_x, phi_y = self.shapelets.pre_calc(
             x, y, beta, self.n_max, center_x, center_y

--- a/jaxtronomy/LightModel/Profiles/shapelets.py
+++ b/jaxtronomy/LightModel/Profiles/shapelets.py
@@ -360,7 +360,7 @@ class ShapeletSetStatic(object):
         # It is possible to initialize the class with n_max = -1, effectively turning off the Shapelets
         if self.num_param == 0:
             return f_
-        
+
         amp = jnp.array(amp)
 
         phi_x, phi_y = self.shapelets.pre_calc(

--- a/jaxtronomy/Sampling/likelihood.py
+++ b/jaxtronomy/Sampling/likelihood.py
@@ -304,7 +304,7 @@ class LikelihoodModule(object):
         :returns: log likelihood of the data given the model (natural logarithm)
         """
         # extract parameters
-        kwargs_return = self.param.args2kwargs(args, jax=True)
+        kwargs_return = self.param.args2kwargs(args)
 
         if self._check_bounds is True:
             penalty, bound_hit = self.check_bounds(

--- a/jaxtronomy/Sampling/sampler.py
+++ b/jaxtronomy/Sampling/sampler.py
@@ -8,6 +8,7 @@ from lenstronomy.Util import sampling_util
 from functools import partial
 import jax
 from jax import lax
+import warnings
 
 __all__ = ["Sampler"]
 
@@ -60,10 +61,13 @@ class Sampler(Sampler_lenstronomy):
         backend = jax.default_backend()
         if backend == "cpu":
             if n_particles % threadCount != 0:
-                raise ValueError(
+                new_n_particles = int(((n_particles // threadCount) + 1) * threadCount)
+                warnings.warn(
                     f"PSO particle count {n_particles} must be divisible by threadCount for parallelization. "
-                    f"threadCount has been set to {threadCount}."
+                    f"n_particles will automatically be set to {new_n_particles}."
                 )
+                n_particles = new_n_particles
+                
         logL_func = prepare_logL_func(
             backend=backend, logL_func=self.chain.logL, threadCount=threadCount
         )
@@ -165,10 +169,13 @@ class Sampler(Sampler_lenstronomy):
         backend = jax.default_backend()
         if backend == "cpu":
             if n_walkers % (2 * threadCount) != 0:
-                raise ValueError(
+                new_n_walkers = int(((n_walkers // (2 * threadCount)) + 1) * (2 * threadCount))
+                warnings.warn(
                     f"Number of MCMC walkers {n_walkers} must be divisible by two times threadCount for parallelization. "
-                    f"threadCount has been set to {threadCount}."
+                    f"The number of walkers will automatically be set to {new_n_walkers}."
                 )
+                n_walkers = new_n_walkers
+
         logL_func = prepare_logL_func(
             backend=backend, logL_func=self.chain.logL, threadCount=threadCount
         )

--- a/jaxtronomy/Sampling/sampler.py
+++ b/jaxtronomy/Sampling/sampler.py
@@ -67,7 +67,7 @@ class Sampler(Sampler_lenstronomy):
                     f"n_particles will automatically be set to {new_n_particles}."
                 )
                 n_particles = new_n_particles
-                
+
         logL_func = prepare_logL_func(
             backend=backend, logL_func=self.chain.logL, threadCount=threadCount
         )
@@ -169,7 +169,9 @@ class Sampler(Sampler_lenstronomy):
         backend = jax.default_backend()
         if backend == "cpu":
             if n_walkers % (2 * threadCount) != 0:
-                new_n_walkers = int(((n_walkers // (2 * threadCount)) + 1) * (2 * threadCount))
+                new_n_walkers = int(
+                    ((n_walkers // (2 * threadCount)) + 1) * (2 * threadCount)
+                )
                 warnings.warn(
                     f"Number of MCMC walkers {n_walkers} must be divisible by two times threadCount for parallelization. "
                     f"The number of walkers will automatically be set to {new_n_walkers}."

--- a/test/test_LightModel/test_Profiles/test_shapelets.py
+++ b/test/test_LightModel/test_Profiles/test_shapelets.py
@@ -206,7 +206,9 @@ class TestShapeletSet(object):
 
         n_max = -1
         amp = []
-        result = self.shapeletset_static_off.function(x, y, amp, n_max, beta, center_x, center_y)
+        result = self.shapeletset_static_off.function(
+            x, y, amp, n_max, beta, center_x, center_y
+        )
         result_ref = self.shapeletset_ref.function(
             x, y, amp, n_max, beta, center_x, center_y
         )
@@ -267,7 +269,9 @@ class TestShapeletSet(object):
 
         n_max = -1
         amp = []
-        result = self.shapeletset_static_off.function_split(x, y, amp, n_max, beta, center_x, center_y)
+        result = self.shapeletset_static_off.function_split(
+            x, y, amp, n_max, beta, center_x, center_y
+        )
         result_ref = self.shapeletset_ref.function_split(
             x, y, amp, n_max, beta, center_x, center_y
         )

--- a/test/test_LightModel/test_Profiles/test_shapelets.py
+++ b/test/test_LightModel/test_Profiles/test_shapelets.py
@@ -190,6 +190,7 @@ class TestShapeletSet(object):
     def setup_method(self):
         self.shapeletset = ShapeletSet()
         self.shapeletset_ref = ShapeletSet_ref()
+        self.shapeletset_static_off = ShapeletSetStatic(n_max=-1)
         self.shapeletset_static4 = ShapeletSetStatic(n_max=4)
         self.shapeletset_static12 = ShapeletSetStatic(n_max=12)
 
@@ -202,6 +203,14 @@ class TestShapeletSet(object):
         beta = 3.287
         center_x = -0.7
         center_y = 1.7
+
+        n_max = -1
+        amp = []
+        result = self.shapeletset_static_off.function(x, y, amp, n_max, beta, center_x, center_y)
+        result_ref = self.shapeletset_ref.function(
+            x, y, amp, n_max, beta, center_x, center_y
+        )
+        npt.assert_allclose(result, result_ref, atol=1e-12, rtol=1e-12)
 
         n_max = 4
         num_param = int((n_max + 1) * (n_max + 2) / 2)
@@ -255,6 +264,14 @@ class TestShapeletSet(object):
         beta = 3.287
         center_x = -0.7
         center_y = 1.7
+
+        n_max = -1
+        amp = []
+        result = self.shapeletset_static_off.function_split(x, y, amp, n_max, beta, center_x, center_y)
+        result_ref = self.shapeletset_ref.function_split(
+            x, y, amp, n_max, beta, center_x, center_y
+        )
+        npt.assert_allclose(result, result_ref, atol=1e-12, rtol=1e-12)
 
         n_max = 4
         num_param = int((n_max + 1) * (n_max + 2) / 2)

--- a/test/test_Sampling/test_likelihood.py
+++ b/test/test_Sampling/test_likelihood.py
@@ -166,7 +166,7 @@ class TestLikelihoodModule(object):
         }
 
         self.param_class = Param(
-            self.kwargs_model, linear_solver=False, num_point_source_list=[2]
+            self.kwargs_model, linear_solver=False, num_point_source_list=[2], _jax=True
         )
         self.imageModel = ImageModel(
             data_class,

--- a/test/test_Sampling/test_sampler.py
+++ b/test/test_Sampling/test_sampler.py
@@ -120,12 +120,11 @@ class TestSampler(object):
             "source_position_tolerance": None,
             "source_position_sigma": 0.001,
         }
-        self.param_class = Param(kwargs_model, **kwargs_constraints)
+        self.param_class = Param(kwargs_model, _jax=True, **kwargs_constraints)
         self.Likelihood = LikelihoodModule(
             kwargs_data_joint=kwargs_data_joint,
             kwargs_model=kwargs_model,
             param_class=self.param_class,
-            _jax=True,
             **kwargs_likelihood
         )
         self.sampler = Sampler(likelihoodModule=self.Likelihood)

--- a/test/test_Sampling/test_sampler.py
+++ b/test/test_Sampling/test_sampler.py
@@ -151,9 +151,9 @@ class TestSampler(object):
             ValueError, self.sampler.pso, n_particles, n_iterations, threadCount=2
         )
 
-        # check that an error is raised when the number of particles is not divisible by the number of CPU devices
+        # check that a warning is raised when the number of particles is not divisible by the number of CPU devices
         # for parallelization
-        npt.assert_raises(ValueError, self.sampler.pso, 1.5, n_iterations)
+        npt.assert_warns(UserWarning, self.sampler.pso, 1.5, n_iterations)
 
     def test_mcmc_emcee(self):
         n_walkers = 36
@@ -217,12 +217,12 @@ class TestSampler(object):
             backend_filename="sjd",
         )
 
-        # check that an error is raised when the number of MCMC walkers is not divisible by
+        # check that a warning is raised when the number of MCMC walkers is not divisible by
         # two times the number of CPU devices for parallelization
-        npt.assert_raises(
-            ValueError,
+        npt.assert_warns(
+            UserWarning,
             self.sampler.mcmc_emcee,
-            1.5,
+            30.5,
             n_run,
             n_burn,
             mean_start,

--- a/test/test_Sampling/test_sampler.py
+++ b/test/test_Sampling/test_sampler.py
@@ -125,6 +125,7 @@ class TestSampler(object):
             kwargs_data_joint=kwargs_data_joint,
             kwargs_model=kwargs_model,
             param_class=self.param_class,
+            _jax=True,
             **kwargs_likelihood
         )
         self.sampler = Sampler(likelihoodModule=self.Likelihood)


### PR DESCRIPTION
1. To match lenstronomy Shapelets behavior, n_max = -1 is allowed, effectively turning off the Shapelets
2. Remove deprecated jax argument when calling Param.args2kwargs()
3. Instead of raising an error whenever the number of PSO particles or MCMC walkers is not convenient for CPU parallelization, a warning is raised and the number of particles/walkers is automatically adjusted.