### PR TITLE
convert all coordinates to jax arrays for consistent behavior

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -41,6 +41,7 @@ jobs:
       #    flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with pytest
         run: |
+          export JAX_ENABLE_X64=True
           pytest --cov=./ --cov-report=xml
           codecov
 

--- a/jaxtronomy/LensModel/MultiPlane/decoupled_multi_plane.py
+++ b/jaxtronomy/LensModel/MultiPlane/decoupled_multi_plane.py
@@ -223,7 +223,7 @@ class MultiPlaneDecoupled(MultiPlane):
         """
         theta_x = jnp.asarray(theta_x, dtype=float)
         theta_y = jnp.asarray(theta_y, dtype=float)
-        
+
         alpha_ra, alpha_dec = self.alpha(
             theta_x,
             theta_y,

--- a/jaxtronomy/LensModel/MultiPlane/decoupled_multi_plane.py
+++ b/jaxtronomy/LensModel/MultiPlane/decoupled_multi_plane.py
@@ -1,7 +1,7 @@
 __author__ = "dangilman"
 
 from functools import partial
-from jax import config, jit
+from jax import config, jit, numpy as jnp
 
 config.update("jax_enable_x64", True)
 
@@ -141,6 +141,9 @@ class MultiPlaneDecoupled(MultiPlane):
         :param kwargs_lens: keyword arguments for the main deflector
         :return: coordinates on the source plane
         """
+        theta_x = jnp.asarray(theta_x, dtype=float)
+        theta_y = jnp.asarray(theta_y, dtype=float)
+
         coordinates = (theta_x, theta_y)
         # here we use an interpolation function to compute the comoving coordinates of the light rays
         # where they hit the main lens plane at redshift z = z_main
@@ -190,6 +193,9 @@ class MultiPlaneDecoupled(MultiPlane):
         :param kwargs_lens: lens model kwargs
         :return: deflection angles in x and y directions
         """
+        theta_x = jnp.asarray(theta_x, dtype=float)
+        theta_y = jnp.asarray(theta_y, dtype=float)
+
         beta_x, beta_y = self.ray_shooting(
             theta_x,
             theta_y,
@@ -215,6 +221,9 @@ class MultiPlaneDecoupled(MultiPlane):
         :param diff: numerical differential step (float)
         :return: f_xx, f_xy, f_yx, f_yy
         """
+        theta_x = jnp.asarray(theta_x, dtype=float)
+        theta_y = jnp.asarray(theta_y, dtype=float)
+        
         alpha_ra, alpha_dec = self.alpha(
             theta_x,
             theta_y,

--- a/jaxtronomy/LensModel/MultiPlane/multi_plane.py
+++ b/jaxtronomy/LensModel/MultiPlane/multi_plane.py
@@ -564,7 +564,7 @@ class MultiPlane(object):
 
         theta_x = jnp.asarray(theta_x, dtype=float)
         theta_y = jnp.asarray(theta_y, dtype=float)
-        
+
         alpha_ra, alpha_dec = self.alpha(
             theta_x, theta_y, kwargs_lens, check_convention=False
         )

--- a/jaxtronomy/LensModel/MultiPlane/multi_plane.py
+++ b/jaxtronomy/LensModel/MultiPlane/multi_plane.py
@@ -250,10 +250,12 @@ class MultiPlane(object):
         self._check_raise(k=k)
         if check_convention and not self.ignore_observed_positions:
             kwargs_lens = self._convention(kwargs_lens)
-        x = jnp.zeros_like(theta_x, dtype=float)
-        y = jnp.zeros_like(theta_y, dtype=float)
-        alpha_x = jnp.array(theta_x)
-        alpha_y = jnp.array(theta_y)
+
+        alpha_x = jnp.asarray(theta_x, dtype=float)
+        alpha_y = jnp.asarray(theta_y, dtype=float)
+        x = jnp.zeros_like(alpha_x)
+        y = jnp.zeros_like(alpha_y)
+
         x, y, _, _ = self._multi_plane_base.ray_shooting_partial_comoving(
             x,
             y,
@@ -470,6 +472,9 @@ class MultiPlane(object):
             checks whether the positional conventions are satisfied.
         :return: travel time in unit of days
         """
+        theta_x = jnp.asarray(theta_x, dtype=float)
+        theta_y = jnp.asarray(theta_y, dtype=float)
+
         dt_geo, dt_grav = self.geo_shapiro_delay(
             theta_x, theta_y, kwargs_lens, check_convention=check_convention
         )
@@ -490,6 +495,10 @@ class MultiPlane(object):
         """
         if check_convention and not self.ignore_observed_positions:
             kwargs_lens = self._convention(kwargs_lens)
+
+        theta_x = jnp.asarray(theta_x, dtype=float)
+        theta_y = jnp.asarray(theta_y, dtype=float)
+
         return self._multi_plane_base.geo_shapiro_delay(
             theta_x,
             theta_y,
@@ -511,6 +520,10 @@ class MultiPlane(object):
         :return: deflection angles in x and y directions
         """
         self._check_raise(k=k)
+
+        theta_x = jnp.asarray(theta_x, dtype=float)
+        theta_y = jnp.asarray(theta_y, dtype=float)
+
         beta_x, beta_y = self.ray_shooting(
             theta_x, theta_y, kwargs_lens, check_convention=check_convention
         )
@@ -549,6 +562,9 @@ class MultiPlane(object):
         if check_convention and not self.ignore_observed_positions:
             kwargs_lens = self._convention(kwargs_lens)
 
+        theta_x = jnp.asarray(theta_x, dtype=float)
+        theta_y = jnp.asarray(theta_y, dtype=float)
+        
         alpha_ra, alpha_dec = self.alpha(
             theta_x, theta_y, kwargs_lens, check_convention=False
         )

--- a/jaxtronomy/LensModel/MultiPlane/multi_plane_base.py
+++ b/jaxtronomy/LensModel/MultiPlane/multi_plane_base.py
@@ -361,7 +361,7 @@ class MultiPlaneBase(ProfileListBase):
                 "You can do T_z_stop = MultiPlaneBase.compute_source_distance(z_stop) and "
                 "_, T_ij_end = MultiPlaneBase.transverse_distance_start_stop(0, z_stop)."
             )
-        
+
         alpha_x = jnp.asarray(theta_x, dtype=float)
         alpha_y = jnp.asarray(theta_y, dtype=float)
         dt_grav = jnp.zeros_like(alpha_x)

--- a/jaxtronomy/LensModel/MultiPlane/multi_plane_base.py
+++ b/jaxtronomy/LensModel/MultiPlane/multi_plane_base.py
@@ -202,11 +202,11 @@ class MultiPlaneBase(ProfileListBase):
                 "T_ij_end must be provided in jaxtronomy. You can use the class function \n"
                 "MultiPlaneBase.transverse_distance_start_stop(z_start, z_stop) to compute T_ij_end."
             )
-        x = jnp.array(x, dtype=float)
-        y = jnp.array(y, dtype=float)
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
 
-        alpha_x = jnp.array(alpha_x)
-        alpha_y = jnp.array(alpha_y)
+        alpha_x = jnp.asarray(alpha_x, dtype=float)
+        alpha_y = jnp.asarray(alpha_y, dtype=float)
 
         # z_lens_last = z_start
         for i, idex in enumerate(self._sorted_redshift_index):
@@ -361,13 +361,13 @@ class MultiPlaneBase(ProfileListBase):
                 "You can do T_z_stop = MultiPlaneBase.compute_source_distance(z_stop) and "
                 "_, T_ij_end = MultiPlaneBase.transverse_distance_start_stop(0, z_stop)."
             )
-
-        dt_grav = jnp.zeros_like(theta_x, dtype=float)
-        dt_geo = jnp.zeros_like(theta_x, dtype=float)
-        x = jnp.zeros_like(theta_x, dtype=float)
-        y = jnp.zeros_like(theta_y, dtype=float)
-        alpha_x = jnp.array(theta_x, dtype=float)
-        alpha_y = jnp.array(theta_y, dtype=float)
+        
+        alpha_x = jnp.asarray(theta_x, dtype=float)
+        alpha_y = jnp.asarray(theta_y, dtype=float)
+        dt_grav = jnp.zeros_like(alpha_x)
+        dt_geo = jnp.zeros_like(alpha_x)
+        x = jnp.zeros_like(alpha_x)
+        y = jnp.zeros_like(alpha_y)
 
         for i, index in enumerate(self._sorted_redshift_index):
             z_lens = self._lens_redshift_list[index]
@@ -440,6 +440,9 @@ class MultiPlaneBase(ProfileListBase):
         :param index: index of the lens model in sorted redshfit convention
         :return: gravitational delay in units of days as seen at z=0
         """
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
+
         theta_x, theta_y = self._co_moving2angle(x, y, index)
         k = self._sorted_redshift_index[index]
         potential = self.func_list[k].function(theta_x, theta_y, **kwargs_lens[k])

--- a/jaxtronomy/LensModel/MultiPlane/multi_plane_bulk.py
+++ b/jaxtronomy/LensModel/MultiPlane/multi_plane_bulk.py
@@ -175,8 +175,8 @@ class MultiPlaneBulk(ProfileListBase):
             deflection angles to physical deflection angles
         :return: angles at the source plane
         """
-        alpha_x = jnp.array(alpha_x, dtype=float)
-        alpha_y = jnp.array(alpha_y, dtype=float)
+        alpha_x = jnp.asarray(alpha_x, dtype=float)
+        alpha_y = jnp.asarray(alpha_y, dtype=float)
         x = jnp.zeros_like(alpha_x)
         y = jnp.zeros_like(alpha_y)
 

--- a/jaxtronomy/LensModel/Profiles/convergence.py
+++ b/jaxtronomy/LensModel/Profiles/convergence.py
@@ -26,8 +26,7 @@ class Convergence(LensProfileBase):
         :param kappa: (external) convergence
         :return: lensing potential
         """
-        x, y = shift_center(x, y, ra_0, dec_0)
-        theta, phi = param_util.cart2polar(x, y)
+        theta, phi = param_util.cart2polar(x, y, ra_0, dec_0)
         f_ = 1.0 / 2 * kappa * theta**2
         return f_
 

--- a/jaxtronomy/LensModel/Profiles/convergence.py
+++ b/jaxtronomy/LensModel/Profiles/convergence.py
@@ -1,6 +1,7 @@
 __author__ = "sibirrer"
 
 import jaxtronomy.Util.param_util as param_util
+from jaxtronomy.Util.util import shift_center
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 from jax import jit
 
@@ -25,7 +26,8 @@ class Convergence(LensProfileBase):
         :param kappa: (external) convergence
         :return: lensing potential
         """
-        theta, phi = param_util.cart2polar(x - ra_0, y - dec_0)
+        x, y = shift_center(x, y, ra_0, dec_0)
+        theta, phi = param_util.cart2polar(x, y)
         f_ = 1.0 / 2 * kappa * theta**2
         return f_
 
@@ -39,10 +41,9 @@ class Convergence(LensProfileBase):
         :param kappa: (external) convergence
         :return: deflection angles (first order derivatives)
         """
-        x_ = x - ra_0
-        y_ = y - dec_0
-        f_x = kappa * x_
-        f_y = kappa * y_
+        x, y = shift_center(x, y, ra_0, dec_0)
+        f_x = kappa * x
+        f_y = kappa * y
         return f_x, f_y
 
     @staticmethod
@@ -59,7 +60,6 @@ class Convergence(LensProfileBase):
         """
         gamma1 = 0
         gamma2 = 0
-        kappa = kappa
         f_xx = kappa + gamma1
         f_yy = kappa - gamma1
         f_xy = gamma2

--- a/jaxtronomy/LensModel/Profiles/convergence.py
+++ b/jaxtronomy/LensModel/Profiles/convergence.py
@@ -40,9 +40,9 @@ class Convergence(LensProfileBase):
         :param kappa: (external) convergence
         :return: deflection angles (first order derivatives)
         """
-        x, y = shift_center(x, y, ra_0, dec_0)
-        f_x = kappa * x
-        f_y = kappa * y
+        x_, y_ = shift_center(x, y, ra_0, dec_0)
+        f_x = kappa * x_
+        f_y = kappa * y_
         return f_x, f_y
 
     @staticmethod

--- a/jaxtronomy/LensModel/Profiles/cored_steep_ellipsoid.py
+++ b/jaxtronomy/LensModel/Profiles/cored_steep_ellipsoid.py
@@ -4,7 +4,7 @@ from jax import config, jit, lax, tree_util
 import jax.numpy as jnp
 
 from jaxtronomy.Util import param_util
-from jaxtronomy.Util import util
+from jaxtronomy.Util.util import rotate, shift_center
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
 config.update("jax_enable_x64", True)
@@ -94,16 +94,15 @@ class CSE(LensProfileBase):
         """
         phi_q, q = param_util.ellipticity2phi_q(e1, e2)
         # shift
-        x_ = x - center_x
-        y_ = y - center_y
+        x, y = shift_center(x, y, center_x, center_y)
         # rotate
-        x__, y__ = util.rotate(x_, y_, phi_q)
+        x, y = rotate(x, y, phi_q)
 
         # potential calculation
         case = jnp.where(self.axis == "major", 0, 1)
         func = [CSEMajorAxis.function, CSEProductAvg.function]
 
-        f_ = lax.switch(case, func, x__, y__, a, s, q)
+        f_ = lax.switch(case, func, x, y, a, s, q)
 
         return f_
 
@@ -123,18 +122,17 @@ class CSE(LensProfileBase):
         """
         phi_q, q = param_util.ellipticity2phi_q(e1, e2)
         # shift
-        x_ = x - center_x
-        y_ = y - center_y
+        x, y = shift_center(x, y, center_x, center_y)
         # rotate
-        x__, y__ = util.rotate(x_, y_, phi_q)
+        x, y = rotate(x, y, phi_q)
 
         case = jnp.where(self.axis == "major", 0, 1)
         func = [CSEMajorAxis.derivatives, CSEProductAvg.derivatives]
 
-        f__x, f__y = lax.switch(case, func, x__, y__, a, s, q)
+        f_x, f_y = lax.switch(case, func, x, y, a, s, q)
 
         # rotate deflections back
-        f_x, f_y = util.rotate(f__x, f__y, -phi_q)
+        f_x, f_y = rotate(f_x, f_y, -phi_q)
         return f_x, f_y
 
     @jit
@@ -153,15 +151,14 @@ class CSE(LensProfileBase):
         """
         phi_q, q = param_util.ellipticity2phi_q(e1, e2)
         # shift
-        x_ = x - center_x
-        y_ = y - center_y
+        x, y = shift_center(x, y, center_x, center_y)
         # rotate
-        x__, y__ = util.rotate(x_, y_, phi_q)
+        x, y = rotate(x, y, phi_q)
 
         case = jnp.where(self.axis == "major", 0, 1)
         func = [CSEMajorAxis.hessian, CSEProductAvg.hessian]
 
-        f__xx, f__xy, _, f__yy = lax.switch(case, func, x__, y__, a, s, q)
+        f__xx, f__xy, _, f__yy = lax.switch(case, func, x, y, a, s, q)
 
         # rotate back
         kappa = 1.0 / 2 * (f__xx + f__yy)
@@ -221,6 +218,8 @@ class CSEMajorAxis(LensProfileBase):
         :param q: axis ratio
         :return: lensing potential
         """
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
 
         # potential calculation
         psi = jnp.sqrt(q**2 * (s**2 + x**2) + y**2)
@@ -240,6 +239,8 @@ class CSEMajorAxis(LensProfileBase):
         :param q: axis ratio
         :return: deflection in x- and y-direction
         """
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
 
         psi = jnp.sqrt(q**2 * (s**2 + x**2) + y**2)
         Phi = (psi + s) ** 2 + (1 - q**2) * x**2
@@ -260,6 +261,8 @@ class CSEMajorAxis(LensProfileBase):
         :param q: axis ratio
         :return: hessian elements f_xx, f_xy, f_yx, f_yy
         """
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
 
         # equations 21-23 in Oguri 2021
         psi = jnp.sqrt(q**2 * (s**2 + x**2) + y**2)
@@ -311,10 +314,10 @@ class CSEMajorAxisSet(LensProfileBase):
         :param q: axis ratio
         :return: lensing potential
         """
-        x = x.astype(float)
-        y = y.astype(float)
-        a_list = jnp.asarray(a_list)
-        s_list = jnp.asarray(s_list)
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
+        a_list = jnp.asarray(a_list, dtype=float)
+        s_list = jnp.asarray(s_list, dtype=float)
         f_ = jnp.zeros_like(x)
 
         def body_fun(i, val):
@@ -339,10 +342,10 @@ class CSEMajorAxisSet(LensProfileBase):
         :param q: axis ratio
         :return: deflection in x- and y-direction
         """
-        x = x.astype(float)
-        y = y.astype(float)
-        a_list = jnp.asarray(a_list)
-        s_list = jnp.asarray(s_list)
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
+        a_list = jnp.asarray(a_list, dtype=float)
+        s_list = jnp.asarray(s_list, dtype=float)
         f_x, f_y = jnp.zeros_like(x), jnp.zeros_like(y)
 
         def body_fun(i, val):
@@ -372,10 +375,10 @@ class CSEMajorAxisSet(LensProfileBase):
         :param q: axis ratio
         :return: hessian elements f_xx, f_xy, f_yx, f_yy
         """
-        x = x.astype(float)
-        y = y.astype(float)
-        a_list = jnp.asarray(a_list)
-        s_list = jnp.asarray(s_list)
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
+        a_list = jnp.asarray(a_list, dtype=float)
+        s_list = jnp.asarray(s_list, dtype=float)
         f_xx, f_xy, f_yy = jnp.zeros_like(x), jnp.zeros_like(x), jnp.zeros_like(x)
 
         def body_fun(i, val):
@@ -455,6 +458,8 @@ class CSEProductAvg(LensProfileBase):
         :param q: axis ratio
         :return: lensing potential
         """
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
         x, y, a, s, q = CSEProductAvg._convert2prodavg(x, y, a, s, q)
         return CSEMajorAxis.function(x, y, a, s, q)
 
@@ -469,6 +474,8 @@ class CSEProductAvg(LensProfileBase):
         :param q: axis ratio
         :return: deflection in x- and y-direction
         """
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
         x, y, a, s, q = CSEProductAvg._convert2prodavg(x, y, a, s, q)
         af_x, af_y = CSEMajorAxis.derivatives(x, y, a, s, q)
         # extra sqrt(q) factor from taking derivative of transformed coordinate
@@ -485,6 +492,8 @@ class CSEProductAvg(LensProfileBase):
         :param q: axis ratio
         :return: hessian elements f_xx, f_xy, f_yx, f_yy
         """
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
         x, y, a, s, q = CSEProductAvg._convert2prodavg(x, y, a, s, q)
         af_xx, af_xy, af_xy, af_yy = CSEMajorAxis.hessian(x, y, a, s, q)
         # two sqrt(q) factors from taking derivatives of transformed coordinate
@@ -509,10 +518,10 @@ class CSEProductAvgSet(LensProfileBase):
         :param q: axis ratio
         :return: lensing potential
         """
-        x = x.astype(float)
-        y = y.astype(float)
-        a_list = jnp.asarray(a_list)
-        s_list = jnp.asarray(s_list)
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
+        a_list = jnp.asarray(a_list, dtype=float)
+        s_list = jnp.asarray(s_list, dtype=float)
         f_ = jnp.zeros_like(x)
 
         def body_fun(i, val):
@@ -539,10 +548,10 @@ class CSEProductAvgSet(LensProfileBase):
         :param q: axis ratio
         :return: deflection in x- and y-direction
         """
-        x = x.astype(float)
-        y = y.astype(float)
-        a_list = jnp.asarray(a_list)
-        s_list = jnp.asarray(s_list)
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
+        a_list = jnp.asarray(a_list, dtype=float)
+        s_list = jnp.asarray(s_list, dtype=float)
         f_x, f_y = jnp.zeros_like(x), jnp.zeros_like(y)
 
         def body_fun(i, val):
@@ -571,10 +580,10 @@ class CSEProductAvgSet(LensProfileBase):
         :param q: axis ratio
         :return: hessian elements f_xx, f_xy, f_yx, f_yy
         """
-        x = x.astype(float)
-        y = y.astype(float)
-        a_list = jnp.asarray(a_list)
-        s_list = jnp.asarray(s_list)
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
+        a_list = jnp.asarray(a_list, dtype=float)
+        s_list = jnp.asarray(s_list, dtype=float)
         f_xx, f_xy, f_yy = jnp.zeros_like(x), jnp.zeros_like(x), jnp.zeros_like(x)
 
         def body_fun(i, val):

--- a/jaxtronomy/LensModel/Profiles/cored_steep_ellipsoid.py
+++ b/jaxtronomy/LensModel/Profiles/cored_steep_ellipsoid.py
@@ -1,13 +1,11 @@
 __author__ = "sibirrer"
 
-from jax import config, jit, lax, tree_util
+from jax import jit, lax, tree_util
 import jax.numpy as jnp
 
 from jaxtronomy.Util import param_util
 from jaxtronomy.Util.util import rotate, shift_center
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
-
-config.update("jax_enable_x64", True)
 
 __all__ = [
     "CSE",
@@ -93,16 +91,15 @@ class CSE(LensProfileBase):
         :return: lensing potential
         """
         phi_q, q = param_util.ellipticity2phi_q(e1, e2)
-        # shift
-        x, y = shift_center(x, y, center_x, center_y)
-        # rotate
-        x, y = rotate(x, y, phi_q)
+        # shift and rotate coordinates
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        x_, y_ = rotate(x_, y_, phi_q)
 
         # potential calculation
         case = jnp.where(self.axis == "major", 0, 1)
         func = [CSEMajorAxis.function, CSEProductAvg.function]
 
-        f_ = lax.switch(case, func, x, y, a, s, q)
+        f_ = lax.switch(case, func, x_, y_, a, s, q)
 
         return f_
 
@@ -121,15 +118,14 @@ class CSE(LensProfileBase):
         :return: deflection in x- and y-direction
         """
         phi_q, q = param_util.ellipticity2phi_q(e1, e2)
-        # shift
-        x, y = shift_center(x, y, center_x, center_y)
-        # rotate
-        x, y = rotate(x, y, phi_q)
+        # shift and rotate coordinates
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        x_, y_ = rotate(x_, y_, phi_q)
 
         case = jnp.where(self.axis == "major", 0, 1)
         func = [CSEMajorAxis.derivatives, CSEProductAvg.derivatives]
 
-        f_x, f_y = lax.switch(case, func, x, y, a, s, q)
+        f_x, f_y = lax.switch(case, func, x_, y_, a, s, q)
 
         # rotate deflections back
         f_x, f_y = rotate(f_x, f_y, -phi_q)
@@ -150,15 +146,14 @@ class CSE(LensProfileBase):
         :return: hessian elements f_xx, f_xy, f_yx, f_yy
         """
         phi_q, q = param_util.ellipticity2phi_q(e1, e2)
-        # shift
-        x, y = shift_center(x, y, center_x, center_y)
-        # rotate
-        x, y = rotate(x, y, phi_q)
+        # shift and rotate coordinates
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        x_, y_ = rotate(x_, y_, phi_q)
 
         case = jnp.where(self.axis == "major", 0, 1)
         func = [CSEMajorAxis.hessian, CSEProductAvg.hessian]
 
-        f__xx, f__xy, _, f__yy = lax.switch(case, func, x, y, a, s, q)
+        f__xx, f__xy, _, f__yy = lax.switch(case, func, x_, y_, a, s, q)
 
         # rotate back
         kappa = 1.0 / 2 * (f__xx + f__yy)

--- a/jaxtronomy/LensModel/Profiles/epl.py
+++ b/jaxtronomy/LensModel/Profiles/epl.py
@@ -6,7 +6,7 @@ from jax import config, custom_jvp, jvp, jit, lax, numpy as jnp, tree_util
 config.update("jax_enable_x64", True)  # 64-bit floats, consistent with numpy
 
 from jaxtronomy.Util.hyp2f1_util import hyp2f1_lopez_temme_8 as hyp2f1
-import jaxtronomy.Util.util as util
+from jaxtronomy.Util.util import rotate, shift_center
 import jaxtronomy.Util.param_util as param_util
 from jaxtronomy.LensModel.Profiles.spp import SPP
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
@@ -170,12 +170,11 @@ class EPL(LensProfileBase):
         """
         b, t, q, phi_G = self.param_conv(theta_E, gamma, e1, e2)
         # shift
-        x_ = x - center_x
-        y_ = y - center_y
+        x, y = shift_center(x, y, center_x, center_y)
         # rotate
-        x__, y__ = util.rotate(x_, y_, phi_G)
+        x, y = rotate(x, y, phi_G)
         # evaluate
-        f_ = EPLMajorAxis.function(x__, y__, b, t, q)
+        f_ = EPLMajorAxis.function(x, y, b, t, q)
         # rotate back
         return f_
 
@@ -195,14 +194,13 @@ class EPL(LensProfileBase):
         """
         b, t, q, phi_G = self.param_conv(theta_E, gamma, e1, e2)
         # shift
-        x_ = x - center_x
-        y_ = y - center_y
+        x, y = shift_center(x, y, center_x, center_y)
         # rotate
-        x__, y__ = util.rotate(x_, y_, phi_G)
+        x, y = rotate(x, y, phi_G)
         # evaluate
-        f__x, f__y = EPLMajorAxis.derivatives(x__, y__, b, t, q)
+        f__x, f__y = EPLMajorAxis.derivatives(x, y, b, t, q)
         # rotate back
-        f_x, f_y = util.rotate(f__x, f__y, -phi_G)
+        f_x, f_y = rotate(f__x, f__y, -phi_G)
         return f_x, f_y
 
     @jit
@@ -222,12 +220,11 @@ class EPL(LensProfileBase):
 
         b, t, q, phi_G = self.param_conv(theta_E, gamma, e1, e2)
         # shift
-        x_ = x - center_x
-        y_ = y - center_y
+        x, y = shift_center(x, y, center_x, center_y)
         # rotate
-        x__, y__ = util.rotate(x_, y_, phi_G)
+        x, y = rotate(x, y, phi_G)
         # evaluate
-        f__xx, f__xy, f__yx, f__yy = EPLMajorAxis.hessian(x__, y__, b, t, q)
+        f__xx, f__xy, f__yx, f__yy = EPLMajorAxis.hessian(x, y, b, t, q)
         # rotate back
         kappa = 1.0 / 2 * (f__xx + f__yy)
         gamma1__ = 1.0 / 2 * (f__xx - f__yy)
@@ -359,6 +356,8 @@ class EPLMajorAxis(LensProfileBase):
         :param q: axis ratio
         :return: lensing potential
         """
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
         # deflection from method
         alpha_x, alpha_y = EPLMajorAxis.derivatives(x, y, b, t, q)
 
@@ -379,6 +378,8 @@ class EPLMajorAxis(LensProfileBase):
         :param q: axis ratio
         :return: f_x, f_y
         """
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
         # elliptical radius, eq. (5)
         Z = q * x + y * 1j
         R = jnp.abs(Z)

--- a/jaxtronomy/LensModel/Profiles/epl.py
+++ b/jaxtronomy/LensModel/Profiles/epl.py
@@ -169,12 +169,11 @@ class EPL(LensProfileBase):
         :return: lensing potential
         """
         b, t, q, phi_G = self.param_conv(theta_E, gamma, e1, e2)
-        # shift
-        x, y = shift_center(x, y, center_x, center_y)
-        # rotate
-        x, y = rotate(x, y, phi_G)
+        # shift and rotate coordinates
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        x_, y_ = rotate(x_, y_, phi_G)
         # evaluate
-        f_ = EPLMajorAxis.function(x, y, b, t, q)
+        f_ = EPLMajorAxis.function(x_, y_, b, t, q)
         # rotate back
         return f_
 
@@ -193,12 +192,11 @@ class EPL(LensProfileBase):
         :return: alpha_x, alpha_y
         """
         b, t, q, phi_G = self.param_conv(theta_E, gamma, e1, e2)
-        # shift
-        x, y = shift_center(x, y, center_x, center_y)
-        # rotate
-        x, y = rotate(x, y, phi_G)
+        # shift and rotate coordinates
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        x_, y_ = rotate(x_, y_, phi_G)
         # evaluate
-        f__x, f__y = EPLMajorAxis.derivatives(x, y, b, t, q)
+        f__x, f__y = EPLMajorAxis.derivatives(x_, y_, b, t, q)
         # rotate back
         f_x, f_y = rotate(f__x, f__y, -phi_G)
         return f_x, f_y
@@ -219,12 +217,11 @@ class EPL(LensProfileBase):
         """
 
         b, t, q, phi_G = self.param_conv(theta_E, gamma, e1, e2)
-        # shift
-        x, y = shift_center(x, y, center_x, center_y)
-        # rotate
-        x, y = rotate(x, y, phi_G)
+        # shift and rotate coordinates
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        x_, y_ = rotate(x_, y_, phi_G)
         # evaluate
-        f__xx, f__xy, f__yx, f__yy = EPLMajorAxis.hessian(x, y, b, t, q)
+        f__xx, f__xy, f__yx, f__yy = EPLMajorAxis.hessian(x_, y_, b, t, q)
         # rotate back
         kappa = 1.0 / 2 * (f__xx + f__yy)
         gamma1__ = 1.0 / 2 * (f__xx - f__yy)

--- a/jaxtronomy/LensModel/Profiles/flexion.py
+++ b/jaxtronomy/LensModel/Profiles/flexion.py
@@ -29,23 +29,23 @@ class Flexion(LensProfileBase):
     @staticmethod
     @jit
     def function(x, y, g1, g2, g3, g4, ra_0=0, dec_0=0):
-        x, y = shift_center(x, y, ra_0, dec_0)
-        f_ = 1.0 / 6 * (g1 * x**3 + 3 * g2 * x**2 * y + 3 * g3 * x * y**2 + g4 * y**3)
+        x_, y_ = shift_center(x, y, ra_0, dec_0)
+        f_ = 1.0 / 6 * (g1 * x_**3 + 3 * g2 * x_**2 * y_ + 3 * g3 * x_ * y_**2 + g4 * y_**3)
         return f_
 
     @staticmethod
     @jit
     def derivatives(x, y, g1, g2, g3, g4, ra_0=0, dec_0=0):
-        x, y = shift_center(x, y, ra_0, dec_0)
-        f_x = 1.0 / 2.0 * g1 * x**2 + g2 * x * y + 1.0 / 2.0 * g3 * y**2
-        f_y = 1.0 / 2.0 * g2 * x**2 + g3 * x * y + 1.0 / 2.0 * g4 * y**2
+        x_, y_ = shift_center(x, y, ra_0, dec_0)
+        f_x = 1.0 / 2.0 * g1 * x_**2 + g2 * x_ * y_ + 1.0 / 2.0 * g3 * y_**2
+        f_y = 1.0 / 2.0 * g2 * x_**2 + g3 * x_ * y_ + 1.0 / 2.0 * g4 * y_**2
         return f_x, f_y
 
     @staticmethod
     @jit
     def hessian(x, y, g1, g2, g3, g4, ra_0=0, dec_0=0):
-        x, y = shift_center(x, y, ra_0, dec_0)
-        f_xx = g1 * x + g2 * y
-        f_yy = g3 * x + g4 * y
-        f_xy = g2 * x + g3 * y
+        x_, y_ = shift_center(x, y, ra_0, dec_0)
+        f_xx = g1 * x_ + g2 * y_
+        f_yy = g3 * x_ + g4 * y_
+        f_xy = g2 * x_ + g3 * y_
         return f_xx, f_xy, f_xy, f_yy

--- a/jaxtronomy/LensModel/Profiles/flexion.py
+++ b/jaxtronomy/LensModel/Profiles/flexion.py
@@ -30,11 +30,7 @@ class Flexion(LensProfileBase):
     @jit
     def function(x, y, g1, g2, g3, g4, ra_0=0, dec_0=0):
         x, y = shift_center(x, y, ra_0, dec_0)
-        f_ = (
-            1.0
-            / 6
-            * (g1 * x**3 + 3 * g2 * x**2 * y + 3 * g3 * x * y**2 + g4 * y**3)
-        )
+        f_ = 1.0 / 6 * (g1 * x**3 + 3 * g2 * x**2 * y + 3 * g3 * x * y**2 + g4 * y**3)
         return f_
 
     @staticmethod

--- a/jaxtronomy/LensModel/Profiles/flexion.py
+++ b/jaxtronomy/LensModel/Profiles/flexion.py
@@ -1,6 +1,5 @@
-from functools import partial
-from jax import jit, numpy as jnp
-
+from jax import jit
+from jaxtronomy.Util.util import shift_center
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
 __all__ = ["Flexion"]
@@ -30,30 +29,27 @@ class Flexion(LensProfileBase):
     @staticmethod
     @jit
     def function(x, y, g1, g2, g3, g4, ra_0=0, dec_0=0):
-        x_ = x - ra_0
-        y_ = y - dec_0
+        x, y = shift_center(x, y, ra_0, dec_0)
         f_ = (
             1.0
             / 6
-            * (g1 * x_**3 + 3 * g2 * x_**2 * y_ + 3 * g3 * x_ * y_**2 + g4 * y_**3)
+            * (g1 * x**3 + 3 * g2 * x**2 * y + 3 * g3 * x * y**2 + g4 * y**3)
         )
         return f_
 
     @staticmethod
     @jit
     def derivatives(x, y, g1, g2, g3, g4, ra_0=0, dec_0=0):
-        x_ = x - ra_0
-        y_ = y - dec_0
-        f_x = 1.0 / 2.0 * g1 * x_**2 + g2 * x_ * y_ + 1.0 / 2.0 * g3 * y_**2
-        f_y = 1.0 / 2.0 * g2 * x_**2 + g3 * x_ * y_ + 1.0 / 2.0 * g4 * y_**2
+        x, y = shift_center(x, y, ra_0, dec_0)
+        f_x = 1.0 / 2.0 * g1 * x**2 + g2 * x * y + 1.0 / 2.0 * g3 * y**2
+        f_y = 1.0 / 2.0 * g2 * x**2 + g3 * x * y + 1.0 / 2.0 * g4 * y**2
         return f_x, f_y
 
     @staticmethod
     @jit
     def hessian(x, y, g1, g2, g3, g4, ra_0=0, dec_0=0):
-        x_ = x - ra_0
-        y_ = y - dec_0
-        f_xx = g1 * x_ + g2 * y_
-        f_yy = g3 * x_ + g4 * y_
-        f_xy = g2 * x_ + g3 * y_
+        x, y = shift_center(x, y, ra_0, dec_0)
+        f_xx = g1 * x + g2 * y
+        f_yy = g3 * x + g4 * y
+        f_xy = g2 * x + g3 * y
         return f_xx, f_xy, f_xy, f_yy

--- a/jaxtronomy/LensModel/Profiles/flexion.py
+++ b/jaxtronomy/LensModel/Profiles/flexion.py
@@ -30,7 +30,11 @@ class Flexion(LensProfileBase):
     @jit
     def function(x, y, g1, g2, g3, g4, ra_0=0, dec_0=0):
         x_, y_ = shift_center(x, y, ra_0, dec_0)
-        f_ = 1.0 / 6 * (g1 * x_**3 + 3 * g2 * x_**2 * y_ + 3 * g3 * x_ * y_**2 + g4 * y_**3)
+        f_ = (
+            1.0
+            / 6
+            * (g1 * x_**3 + 3 * g2 * x_**2 * y_ + 3 * g3 * x_ * y_**2 + g4 * y_**3)
+        )
         return f_
 
     @staticmethod

--- a/jaxtronomy/LensModel/Profiles/gaussian.py
+++ b/jaxtronomy/LensModel/Profiles/gaussian.py
@@ -39,8 +39,8 @@ class Gaussian(LensProfileBase):
         :param center_x: x position of the center of the lens
         :param center_y: y position of the center of the lens
         """
-        x, y = shift_center(x, y, center_x, center_y)
-        r = jnp.sqrt(x**2 + y**2)
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x_**2 + y_**2)
         sigma_x, sigma_y = sigma, sigma
         c = 1.0 / (2 * sigma_x * sigma_y)
         num_int = Gaussian._num_integral(r, c)
@@ -101,11 +101,11 @@ class Gaussian(LensProfileBase):
         :param center_x: x position of the center of the lens
         :param center_y: y position of the center of the lens
         """
-        x, y = shift_center(x, y, center_x, center_y)
-        R = jnp.sqrt(x**2 + y**2)
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        R = jnp.sqrt(x_**2 + y_**2)
         R = jnp.where(R <= Gaussian.ds, Gaussian.ds, R)
         alpha = Gaussian.alpha_abs(R, amp, sigma)
-        return alpha / R * x, alpha / R * y
+        return alpha / R * x_, alpha / R * y_
 
     @staticmethod
     @jit
@@ -119,8 +119,8 @@ class Gaussian(LensProfileBase):
         :param center_x: x position of the center of the lens
         :param center_y: y position of the center of the lens
         """
-        x, y = shift_center(x, y, center_x, center_y)
-        r = jnp.sqrt(x**2 + y**2)
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x_**2 + y_**2)
         sigma_x, sigma_y = sigma, sigma
         r = jnp.where(r < Gaussian.ds, Gaussian.ds, r)
         d_alpha_dr = -Gaussian.d_alpha_dr(r, amp, sigma_x, sigma_y)

--- a/jaxtronomy/LensModel/Profiles/gaussian.py
+++ b/jaxtronomy/LensModel/Profiles/gaussian.py
@@ -126,9 +126,9 @@ class Gaussian(LensProfileBase):
         d_alpha_dr = -Gaussian.d_alpha_dr(r, amp, sigma_x, sigma_y)
         alpha = Gaussian.alpha_abs(r, amp, sigma)
 
-        f_xx = -(d_alpha_dr / r + alpha / r**2) * x**2 / r + alpha / r
-        f_yy = -(d_alpha_dr / r + alpha / r**2) * y**2 / r + alpha / r
-        f_xy = -(d_alpha_dr / r + alpha / r**2) * x * y / r
+        f_xx = -(d_alpha_dr / r + alpha / r**2) * x_**2 / r + alpha / r
+        f_yy = -(d_alpha_dr / r + alpha / r**2) * y_**2 / r + alpha / r
+        f_xy = -(d_alpha_dr / r + alpha / r**2) * x_ * y_ / r
         return f_xx, f_xy, f_xy, f_yy
 
     @staticmethod

--- a/jaxtronomy/LensModel/Profiles/gaussian.py
+++ b/jaxtronomy/LensModel/Profiles/gaussian.py
@@ -2,10 +2,11 @@ __author__ = "sibirrer"
 # this file contains a class to make a gaussian
 
 import jax
-from jax import jit, lax, numpy as jnp, tree_util
+from jax import jit, lax, numpy as jnp
 import jax.scipy.special
 import numpy as np
 
+from jaxtronomy.Util.util import shift_center
 from jaxtronomy.LensModel.Profiles.gaussian_potential import GaussianPotential
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
@@ -38,9 +39,8 @@ class Gaussian(LensProfileBase):
         :param center_x: x position of the center of the lens
         :param center_y: y position of the center of the lens
         """
-        x_ = jnp.array(x - center_x, dtype=float)
-        y_ = jnp.array(y - center_y, dtype=float)
-        r = jnp.sqrt(x_**2 + y_**2)
+        x, y = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x**2 + y**2)
         sigma_x, sigma_y = sigma, sigma
         c = 1.0 / (2 * sigma_x * sigma_y)
         num_int = Gaussian._num_integral(r, c)
@@ -63,7 +63,7 @@ class Gaussian(LensProfileBase):
         :param c: float, 1/2sigma^2
         :return: Array with the same shape as r containing the result for each integral
         """
-        r = jnp.array(r)
+        r = jnp.asarray(r, dtype=float)
         r_shape = r.shape
         r = jnp.ravel(r)
 
@@ -101,12 +101,11 @@ class Gaussian(LensProfileBase):
         :param center_x: x position of the center of the lens
         :param center_y: y position of the center of the lens
         """
-        x_ = jnp.array(x - center_x, dtype=float)
-        y_ = jnp.array(y - center_y, dtype=float)
-        R = jnp.sqrt(x_**2 + y_**2)
+        x, y = shift_center(x, y, center_x, center_y)
+        R = jnp.sqrt(x**2 + y**2)
         R = jnp.where(R <= Gaussian.ds, Gaussian.ds, R)
         alpha = Gaussian.alpha_abs(R, amp, sigma)
-        return alpha / R * x_, alpha / R * y_
+        return alpha / R * x, alpha / R * y
 
     @staticmethod
     @jit
@@ -120,17 +119,16 @@ class Gaussian(LensProfileBase):
         :param center_x: x position of the center of the lens
         :param center_y: y position of the center of the lens
         """
-        x_ = jnp.array(x - center_x, dtype=float)
-        y_ = jnp.array(y - center_y, dtype=float)
-        r = jnp.sqrt(x_**2 + y_**2)
+        x, y = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x**2 + y**2)
         sigma_x, sigma_y = sigma, sigma
         r = jnp.where(r < Gaussian.ds, Gaussian.ds, r)
         d_alpha_dr = -Gaussian.d_alpha_dr(r, amp, sigma_x, sigma_y)
         alpha = Gaussian.alpha_abs(r, amp, sigma)
 
-        f_xx = -(d_alpha_dr / r + alpha / r**2) * x_**2 / r + alpha / r
-        f_yy = -(d_alpha_dr / r + alpha / r**2) * y_**2 / r + alpha / r
-        f_xy = -(d_alpha_dr / r + alpha / r**2) * x_ * y_ / r
+        f_xx = -(d_alpha_dr / r + alpha / r**2) * x**2 / r + alpha / r
+        f_yy = -(d_alpha_dr / r + alpha / r**2) * y**2 / r + alpha / r
+        f_xy = -(d_alpha_dr / r + alpha / r**2) * x * y / r
         return f_xx, f_xy, f_xy, f_yy
 
     @staticmethod

--- a/jaxtronomy/LensModel/Profiles/gaussian_potential.py
+++ b/jaxtronomy/LensModel/Profiles/gaussian_potential.py
@@ -41,9 +41,9 @@ class GaussianPotential(LensProfileBase):
         :param center_x: x position of the center of the lens
         :param center_y: y position of the center of the lens
         """
-        x, y = shift_center(x, y, center_x, center_y)
+        x_, y_ = shift_center(x, y, center_x, center_y)
         c = amp / (2 * jnp.pi * sigma_x * sigma_y)
-        exponent = -((x / sigma_x) ** 2 + (y / sigma_y) ** 2) / 2.0
+        exponent = -((x_ / sigma_x) ** 2 + (y_ / sigma_y) ** 2) / 2.0
         return c * jnp.exp(exponent)
 
     @staticmethod

--- a/jaxtronomy/LensModel/Profiles/gaussian_potential.py
+++ b/jaxtronomy/LensModel/Profiles/gaussian_potential.py
@@ -2,6 +2,7 @@ __author__ = "sibirrer"
 # this file contains a class to make a gaussian
 
 from jax import jit, numpy as jnp
+from jaxtronomy.Util.util import shift_center
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
 __all__ = ["GaussianPotential"]
@@ -40,10 +41,9 @@ class GaussianPotential(LensProfileBase):
         :param center_x: x position of the center of the lens
         :param center_y: y position of the center of the lens
         """
+        x, y = shift_center(x, y, center_x, center_y)
         c = amp / (2 * jnp.pi * sigma_x * sigma_y)
-        delta_x = x - center_x
-        delta_y = y - center_y
-        exponent = -((delta_x / sigma_x) ** 2 + (delta_y / sigma_y) ** 2) / 2.0
+        exponent = -((x / sigma_x) ** 2 + (y / sigma_y) ** 2) / 2.0
         return c * jnp.exp(exponent)
 
     @staticmethod
@@ -59,6 +59,8 @@ class GaussianPotential(LensProfileBase):
         :param center_x: x position of the center of the lens
         :param center_y: y position of the center of the lens
         """
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
         f_ = GaussianPotential.function(x, y, amp, sigma_x, sigma_y, center_x, center_y)
         return f_ * (center_x - x) / sigma_x**2, f_ * (center_y - y) / sigma_y**2
 
@@ -75,6 +77,8 @@ class GaussianPotential(LensProfileBase):
         :param center_x: x position of the center of the lens
         :param center_y: y position of the center of the lens
         """
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
         f_ = GaussianPotential.function(x, y, amp, sigma_x, sigma_y, center_x, center_y)
         f_xx = f_ * ((-1.0 / sigma_x**2) + (center_x - x) ** 2 / sigma_x**4)
         f_yy = f_ * ((-1.0 / sigma_y**2) + (center_y - y) ** 2 / sigma_y**4)

--- a/jaxtronomy/LensModel/Profiles/hernquist.py
+++ b/jaxtronomy/LensModel/Profiles/hernquist.py
@@ -83,8 +83,8 @@ class Hernquist(LensProfileBase):
         :param center_y: y-center of the profile
         :return: projected density
         """
-        x, y = shift_center(x, y, center_x, center_y)
-        r = jnp.sqrt(x**2 + y**2)
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x_**2 + y_**2)
         X = r / Rs
         sigma0 = Hernquist.rho2sigma(rho0, Rs)
         X = jnp.where(X == 1, 1.000001, X)
@@ -175,8 +175,8 @@ class Hernquist(LensProfileBase):
         :param center_y: y-center of the profile (units of angle)
         :return: lensing potential at (x,y)
         """
-        x, y = shift_center(x, y, center_x, center_y)
-        r = jnp.sqrt(x**2 + y**2)
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x_**2 + y_**2)
         r = jnp.where(r < Hernquist._s, Hernquist._s, r)
         X = r / Rs
         f_ = 2 * sigma0 * Rs**2 * (jnp.log(X / 2.0) + Hernquist._F(X))
@@ -196,8 +196,8 @@ class Hernquist(LensProfileBase):
         :param center_y: y-center of the profile (units of angle)
         :return: derivative of function (deflection angles in x- and y-direction)
         """
-        x, y = shift_center(x, y, center_x, center_y)
-        r = jnp.sqrt(x**2 + y**2)
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x_**2 + y_**2)
         r = jnp.maximum(r, Hernquist._s)
         X = r / Rs
         f = jnp.where(X == 1, 1.0 / 3, (1 - Hernquist._F(X)) / (X**2 - 1))
@@ -306,8 +306,8 @@ class Hernquist(LensProfileBase):
         :param center_y: y-center of the profile (units of angle)
         :return: gravitational potential at projected radius
         """
-        x, y = shift_center(x, y, center_x, center_y)
-        r = jnp.sqrt(x**2 + y**2)
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x_**2 + y_**2)
         M = Hernquist.mass_tot(rho0, Rs)
         pot = M / (r + Rs)
         return pot

--- a/jaxtronomy/LensModel/Profiles/hernquist.py
+++ b/jaxtronomy/LensModel/Profiles/hernquist.py
@@ -202,8 +202,8 @@ class Hernquist(LensProfileBase):
         X = r / Rs
         f = jnp.where(X == 1, 1.0 / 3, (1 - Hernquist._F(X)) / (X**2 - 1))
         alpha_r = 2 * sigma0 * Rs * f * X
-        f_x = alpha_r * x / r
-        f_y = alpha_r * y / r
+        f_x = alpha_r * x_ / r
+        f_y = alpha_r * y_ / r
         return f_x, f_y
 
     @staticmethod

--- a/jaxtronomy/LensModel/Profiles/hernquist.py
+++ b/jaxtronomy/LensModel/Profiles/hernquist.py
@@ -1,7 +1,6 @@
-import jax
-from jax import jit
-import jax.numpy as jnp
+from jax import jit, numpy as jnp
 
+from jaxtronomy.Util.util import shift_center
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
 __all__ = ["Hernquist"]
@@ -84,9 +83,8 @@ class Hernquist(LensProfileBase):
         :param center_y: y-center of the profile
         :return: projected density
         """
-        x_ = jnp.array(x - center_x, dtype=float)
-        y_ = jnp.array(y - center_y, dtype=float)
-        r = jnp.sqrt(x_**2 + y_**2)
+        x, y = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x**2 + y**2)
         X = r / Rs
         sigma0 = Hernquist.rho2sigma(rho0, Rs)
         X = jnp.where(X == 1, 1.000001, X)
@@ -177,9 +175,8 @@ class Hernquist(LensProfileBase):
         :param center_y: y-center of the profile (units of angle)
         :return: lensing potential at (x,y)
         """
-        x_ = jnp.array(x - center_x, dtype=float)
-        y_ = jnp.array(y - center_y, dtype=float)
-        r = jnp.sqrt(x_**2 + y_**2)
+        x, y = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x**2 + y**2)
         r = jnp.where(r < Hernquist._s, Hernquist._s, r)
         X = r / Rs
         f_ = 2 * sigma0 * Rs**2 * (jnp.log(X / 2.0) + Hernquist._F(X))
@@ -199,15 +196,14 @@ class Hernquist(LensProfileBase):
         :param center_y: y-center of the profile (units of angle)
         :return: derivative of function (deflection angles in x- and y-direction)
         """
-        x_ = jnp.array(x - center_x, dtype=float)
-        y_ = jnp.array(y - center_y, dtype=float)
-        r = jnp.sqrt(x_**2 + y_**2)
+        x, y = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x**2 + y**2)
         r = jnp.maximum(r, Hernquist._s)
         X = r / Rs
         f = jnp.where(X == 1, 1.0 / 3, (1 - Hernquist._F(X)) / (X**2 - 1))
         alpha_r = 2 * sigma0 * Rs * f * X
-        f_x = alpha_r * x_ / r
-        f_y = alpha_r * y_ / r
+        f_x = alpha_r * x / r
+        f_y = alpha_r * y / r
         return f_x, f_y
 
     @staticmethod
@@ -224,6 +220,9 @@ class Hernquist(LensProfileBase):
         :param center_y: y-center of the profile (units of angle)
         :return: df/dxdx, df/dxdy, df/dydx, df/dydy
         """
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
+
         diff = Hernquist._diff
         alpha_ra_dx, alpha_dec_dx = Hernquist.derivatives(
             x + diff / 2, y, sigma0, Rs, center_x, center_y
@@ -307,9 +306,8 @@ class Hernquist(LensProfileBase):
         :param center_y: y-center of the profile (units of angle)
         :return: gravitational potential at projected radius
         """
-        x_ = x - center_x
-        y_ = y - center_y
-        r = jnp.sqrt(x_**2 + y_**2)
+        x, y = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x**2 + y**2)
         M = Hernquist.mass_tot(rho0, Rs)
         pot = M / (r + Rs)
         return pot

--- a/jaxtronomy/LensModel/Profiles/hernquist_ellipse_cse.py
+++ b/jaxtronomy/LensModel/Profiles/hernquist_ellipse_cse.py
@@ -137,13 +137,12 @@ class HernquistEllipseCSE(LensProfileBase):
     def function(x, y, sigma0, Rs, e1, e2, center_x=0, center_y=0):
         """Returns double integral of NFW profile."""
         phi_q, q = param_util.ellipticity2phi_q(e1, e2)
-        # shift
-        x, y = shift_center(x, y, center_x, center_y)
-        # rotate
-        x, y = rotate(x, y, phi_q)
+        # shift and rotate coordinates
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        x_, y_ = rotate(x_, y_, phi_q)
 
         # potential calculation
-        f_ = CSEMajorAxisSet.function(x / Rs, y / Rs, A_LIST, S_LIST, q)
+        f_ = CSEMajorAxisSet.function(x_ / Rs, y_ / Rs, A_LIST, S_LIST, q)
         const = HernquistEllipseCSE._normalization(sigma0, Rs, q)
         return const * f_
 
@@ -152,11 +151,10 @@ class HernquistEllipseCSE(LensProfileBase):
     def derivatives(x, y, sigma0, Rs, e1, e2, center_x=0, center_y=0):
         """Returns df/dx and df/dy of the function (integral of NFW)"""
         phi_q, q = param_util.ellipticity2phi_q(e1, e2)
-        # shift
-        x, y = shift_center(x, y, center_x, center_y)
-        # rotate
-        x, y = rotate(x, y, phi_q)
-        f__x, f__y = CSEMajorAxisSet.derivatives(x / Rs, y / Rs, A_LIST, S_LIST, q)
+        # shift and rotate coordinates
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        x_, y_ = rotate(x_, y_, phi_q)
+        f__x, f__y = CSEMajorAxisSet.derivatives(x_ / Rs, y_ / Rs, A_LIST, S_LIST, q)
 
         # rotate deflections back
         f_x, f_y = rotate(f__x, f__y, -phi_q)
@@ -169,12 +167,11 @@ class HernquistEllipseCSE(LensProfileBase):
         """Returns Hessian matrix of function d^2f/dx^2, d^2/dxdy, d^2/dydx,
         d^f/dy^2."""
         phi_q, q = param_util.ellipticity2phi_q(e1, e2)
-        # shift
-        x, y = shift_center(x, y, center_x, center_y)
-        # rotate
-        x, y = rotate(x, y, phi_q)
+        # shift and rotate coordinates
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        x_, y_ = rotate(x_, y_, phi_q)
         f__xx, f__xy, __, f__yy = CSEMajorAxisSet.hessian(
-            x / Rs, y / Rs, A_LIST, S_LIST, q
+            x_ / Rs, y_ / Rs, A_LIST, S_LIST, q
         )
 
         # rotate back

--- a/jaxtronomy/LensModel/Profiles/hernquist_ellipse_cse.py
+++ b/jaxtronomy/LensModel/Profiles/hernquist_ellipse_cse.py
@@ -154,10 +154,10 @@ class HernquistEllipseCSE(LensProfileBase):
         # shift and rotate coordinates
         x_, y_ = shift_center(x, y, center_x, center_y)
         x_, y_ = rotate(x_, y_, phi_q)
-        f__x, f__y = CSEMajorAxisSet.derivatives(x_ / Rs, y_ / Rs, A_LIST, S_LIST, q)
+        f_x, f_y = CSEMajorAxisSet.derivatives(x_ / Rs, y_ / Rs, A_LIST, S_LIST, q)
 
         # rotate deflections back
-        f_x, f_y = rotate(f__x, f__y, -phi_q)
+        f_x, f_y = rotate(f_x, f_y, -phi_q)
         const = HernquistEllipseCSE._normalization(sigma0, Rs, q) / Rs
         return const * f_x, const * f_y
 

--- a/jaxtronomy/LensModel/Profiles/hernquist_ellipse_cse.py
+++ b/jaxtronomy/LensModel/Profiles/hernquist_ellipse_cse.py
@@ -2,7 +2,7 @@ from jax import jit
 import jax.numpy as jnp
 
 import jaxtronomy.Util.param_util as param_util
-from jaxtronomy.Util import util
+from jaxtronomy.Util.util import rotate, shift_center
 from jaxtronomy.LensModel.Profiles.cored_steep_ellipsoid import CSEMajorAxisSet
 from jaxtronomy.LensModel.Profiles.hernquist import Hernquist
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
@@ -10,7 +10,7 @@ from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 __all__ = ["HernquistEllipseCSE"]
 
 # Table 2 in Oguri 2021
-A_LIST = jnp.asarray(
+A_LIST = jnp.array(
     [
         9.200445e-18,
         2.184724e-16,
@@ -53,9 +53,10 @@ A_LIST = jnp.asarray(
         1.652553e-02,
         2.314934e-02,
         3.992313e-01,
-    ]
+    ],
+    dtype=float
 )
-S_LIST = jnp.asarray(
+S_LIST = jnp.array(
     [
         1.199110e-06,
         3.751762e-06,
@@ -98,7 +99,8 @@ S_LIST = jnp.asarray(
         2.944679e04,
         2.834717e03,
         5.931328e04,
-    ]
+    ],
+    dtype=float
 )
 
 
@@ -136,13 +138,12 @@ class HernquistEllipseCSE(LensProfileBase):
         """Returns double integral of NFW profile."""
         phi_q, q = param_util.ellipticity2phi_q(e1, e2)
         # shift
-        x_ = x - center_x
-        y_ = y - center_y
+        x, y = shift_center(x, y, center_x, center_y)
         # rotate
-        x__, y__ = util.rotate(x_, y_, phi_q)
+        x, y = rotate(x, y, phi_q)
 
         # potential calculation
-        f_ = CSEMajorAxisSet.function(x__ / Rs, y__ / Rs, A_LIST, S_LIST, q)
+        f_ = CSEMajorAxisSet.function(x / Rs, y / Rs, A_LIST, S_LIST, q)
         const = HernquistEllipseCSE._normalization(sigma0, Rs, q)
         return const * f_
 
@@ -152,14 +153,13 @@ class HernquistEllipseCSE(LensProfileBase):
         """Returns df/dx and df/dy of the function (integral of NFW)"""
         phi_q, q = param_util.ellipticity2phi_q(e1, e2)
         # shift
-        x_ = x - center_x
-        y_ = y - center_y
+        x, y = shift_center(x, y, center_x, center_y)
         # rotate
-        x__, y__ = util.rotate(x_, y_, phi_q)
-        f__x, f__y = CSEMajorAxisSet.derivatives(x__ / Rs, y__ / Rs, A_LIST, S_LIST, q)
+        x, y = rotate(x, y, phi_q)
+        f__x, f__y = CSEMajorAxisSet.derivatives(x / Rs, y / Rs, A_LIST, S_LIST, q)
 
         # rotate deflections back
-        f_x, f_y = util.rotate(f__x, f__y, -phi_q)
+        f_x, f_y = rotate(f__x, f__y, -phi_q)
         const = HernquistEllipseCSE._normalization(sigma0, Rs, q) / Rs
         return const * f_x, const * f_y
 
@@ -170,12 +170,11 @@ class HernquistEllipseCSE(LensProfileBase):
         d^f/dy^2."""
         phi_q, q = param_util.ellipticity2phi_q(e1, e2)
         # shift
-        x_ = x - center_x
-        y_ = y - center_y
+        x, y = shift_center(x, y, center_x, center_y)
         # rotate
-        x__, y__ = util.rotate(x_, y_, phi_q)
+        x, y = rotate(x, y, phi_q)
         f__xx, f__xy, __, f__yy = CSEMajorAxisSet.hessian(
-            x__ / Rs, y__ / Rs, A_LIST, S_LIST, q
+            x / Rs, y / Rs, A_LIST, S_LIST, q
         )
 
         # rotate back

--- a/jaxtronomy/LensModel/Profiles/hernquist_ellipse_cse.py
+++ b/jaxtronomy/LensModel/Profiles/hernquist_ellipse_cse.py
@@ -54,7 +54,7 @@ A_LIST = jnp.array(
         2.314934e-02,
         3.992313e-01,
     ],
-    dtype=float
+    dtype=float,
 )
 S_LIST = jnp.array(
     [
@@ -100,7 +100,7 @@ S_LIST = jnp.array(
         2.834717e03,
         5.931328e04,
     ],
-    dtype=float
+    dtype=float,
 )
 
 

--- a/jaxtronomy/LensModel/Profiles/nfw.py
+++ b/jaxtronomy/LensModel/Profiles/nfw.py
@@ -80,8 +80,8 @@ class NFW(LensProfileBase):
         """
         rho0_input = NFW.alpha2rho0(alpha_Rs=alpha_Rs, Rs=Rs)
         Rs = jnp.where(Rs < 0.0000001, 0.0000001, Rs)
-        x, y = shift_center(x, y, center_x, center_y)
-        R = jnp.sqrt(x**2 + y**2)
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        R = jnp.sqrt(x_**2 + y_**2)
         f_ = NFW.nfw_potential(R, Rs, rho0_input)
         return f_
 
@@ -101,8 +101,8 @@ class NFW(LensProfileBase):
         """
         rho0_ijnput = NFW.alpha2rho0(alpha_Rs=alpha_Rs, Rs=Rs)
         Rs = jnp.where(Rs < 0.0000001, 0.0000001, Rs)
-        x, y = shift_center(x, y, center_x, center_y)
-        R = jnp.sqrt(x**2 + y**2)
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        R = jnp.sqrt(x_**2 + y_**2)
         f_x, f_y = NFW.nfw_alpha(R, Rs, rho0_ijnput, x, y)
         return f_x, f_y
 
@@ -121,8 +121,8 @@ class NFW(LensProfileBase):
         """
         rho0_ijnput = NFW.alpha2rho0(alpha_Rs=alpha_Rs, Rs=Rs)
         Rs = jnp.where(Rs < 0.0000001, 0.0000001, Rs)
-        x, y = shift_center(x, y, center_x, center_y)
-        R = jnp.sqrt(x**2 + y**2)
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        R = jnp.sqrt(x_**2 + y_**2)
         kappa = NFW.density_2d(R, 0, Rs, rho0_ijnput)
         gamma1, gamma2 = NFW.nfw_gamma(R, Rs, rho0_ijnput, x, y)
         f_xx = kappa + gamma1
@@ -175,8 +175,8 @@ class NFW(LensProfileBase):
         :param center_y: y-centroid position
         :return: Epsilon(R) projected density at radius R
         """
-        x, y = shift_center(x, y, center_x, center_y)
-        R = jnp.sqrt(x**2 + y**2)
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        R = jnp.sqrt(x_**2 + y_**2)
         x = R / Rs
         Fx = NFW.F(x)
         return 2 * rho0 * Rs * Fx

--- a/jaxtronomy/LensModel/Profiles/nfw.py
+++ b/jaxtronomy/LensModel/Profiles/nfw.py
@@ -5,6 +5,7 @@ __author__ = "sibirrer"
 from jax import config, jit
 import jax.numpy as jnp
 
+from jaxtronomy.Util.util import shift_center
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
 config.update("jax_enable_x64", True)
@@ -79,9 +80,8 @@ class NFW(LensProfileBase):
         """
         rho0_input = NFW.alpha2rho0(alpha_Rs=alpha_Rs, Rs=Rs)
         Rs = jnp.where(Rs < 0.0000001, 0.0000001, Rs)
-        x_ = jnp.array(x - center_x, dtype=float)
-        y_ = jnp.array(y - center_y, dtype=float)
-        R = jnp.sqrt(x_**2 + y_**2)
+        x, y = shift_center(x, y, center_x, center_y)
+        R = jnp.sqrt(x**2 + y**2)
         f_ = NFW.nfw_potential(R, Rs, rho0_input)
         return f_
 
@@ -101,10 +101,9 @@ class NFW(LensProfileBase):
         """
         rho0_ijnput = NFW.alpha2rho0(alpha_Rs=alpha_Rs, Rs=Rs)
         Rs = jnp.where(Rs < 0.0000001, 0.0000001, Rs)
-        x_ = jnp.array(x - center_x, dtype=float)
-        y_ = jnp.array(y - center_y, dtype=float)
-        R = jnp.sqrt(x_**2 + y_**2)
-        f_x, f_y = NFW.nfw_alpha(R, Rs, rho0_ijnput, x_, y_)
+        x, y = shift_center(x, y, center_x, center_y)
+        R = jnp.sqrt(x**2 + y**2)
+        f_x, f_y = NFW.nfw_alpha(R, Rs, rho0_ijnput, x, y)
         return f_x, f_y
 
     @staticmethod
@@ -122,11 +121,10 @@ class NFW(LensProfileBase):
         """
         rho0_ijnput = NFW.alpha2rho0(alpha_Rs=alpha_Rs, Rs=Rs)
         Rs = jnp.where(Rs < 0.0000001, 0.0000001, Rs)
-        x_ = jnp.array(x - center_x, dtype=float)
-        y_ = jnp.array(y - center_y, dtype=float)
-        R = jnp.sqrt(x_**2 + y_**2)
+        x, y = shift_center(x, y, center_x, center_y)
+        R = jnp.sqrt(x**2 + y**2)
         kappa = NFW.density_2d(R, 0, Rs, rho0_ijnput)
-        gamma1, gamma2 = NFW.nfw_gamma(R, Rs, rho0_ijnput, x_, y_)
+        gamma1, gamma2 = NFW.nfw_gamma(R, Rs, rho0_ijnput, x, y)
         f_xx = kappa + gamma1
         f_yy = kappa - gamma1
         f_xy = gamma2
@@ -177,9 +175,8 @@ class NFW(LensProfileBase):
         :param center_y: y-centroid position
         :return: Epsilon(R) projected density at radius R
         """
-        x_ = jnp.array(x - center_x, dtype=float)
-        y_ = jnp.array(y - center_y, dtype=float)
-        R = jnp.sqrt(x_**2 + y_**2)
+        x, y = shift_center(x, y, center_x, center_y)
+        R = jnp.sqrt(x**2 + y**2)
         x = R / Rs
         Fx = NFW.F(x)
         return 2 * rho0 * Rs * Fx

--- a/jaxtronomy/LensModel/Profiles/nfw.py
+++ b/jaxtronomy/LensModel/Profiles/nfw.py
@@ -103,7 +103,7 @@ class NFW(LensProfileBase):
         Rs = jnp.where(Rs < 0.0000001, 0.0000001, Rs)
         x_, y_ = shift_center(x, y, center_x, center_y)
         R = jnp.sqrt(x_**2 + y_**2)
-        f_x, f_y = NFW.nfw_alpha(R, Rs, rho0_ijnput, x, y)
+        f_x, f_y = NFW.nfw_alpha(R, Rs, rho0_ijnput, x_, y_)
         return f_x, f_y
 
     @staticmethod
@@ -124,7 +124,7 @@ class NFW(LensProfileBase):
         x_, y_ = shift_center(x, y, center_x, center_y)
         R = jnp.sqrt(x_**2 + y_**2)
         kappa = NFW.density_2d(R, 0, Rs, rho0_ijnput)
-        gamma1, gamma2 = NFW.nfw_gamma(R, Rs, rho0_ijnput, x, y)
+        gamma1, gamma2 = NFW.nfw_gamma(R, Rs, rho0_ijnput, x_, y_)
         f_xx = kappa + gamma1
         f_yy = kappa - gamma1
         f_xy = gamma2

--- a/jaxtronomy/LensModel/Profiles/nfw_ellipse_cse.py
+++ b/jaxtronomy/LensModel/Profiles/nfw_ellipse_cse.py
@@ -59,7 +59,7 @@ HIGH_ACCURACY_S = jnp.array(
         2.143057e03,
         1.935749e03,
     ],
-    dtype=float
+    dtype=float,
 )
 HIGH_ACCURACY_A = jnp.array(
     [
@@ -108,7 +108,7 @@ HIGH_ACCURACY_A = jnp.array(
         9.743682e02,
         1.775124e03,
     ],
-    dtype=float
+    dtype=float,
 )
 
 # Table 3 in Oguri 2021
@@ -131,7 +131,7 @@ LOW_ACCURACY_A = jnp.array(
         2.576763e02,
         1.422619e03,
     ],
-    dtype=float
+    dtype=float,
 )
 LOW_ACCURACY_S = jnp.array(
     [
@@ -152,7 +152,7 @@ LOW_ACCURACY_S = jnp.array(
         1.842613e02,
         8.206569e02,
     ],
-    dtype=float
+    dtype=float,
 )
 
 

--- a/jaxtronomy/LensModel/Profiles/nfw_ellipse_cse.py
+++ b/jaxtronomy/LensModel/Profiles/nfw_ellipse_cse.py
@@ -229,19 +229,18 @@ class NFW_ELLIPSE_CSE(LensProfileBase):
         :return: lensing potential
         """
         phi_q, q = param_util.ellipticity2phi_q(e1, e2)
-        # shift
-        x, y = shift_center(x, y, center_x, center_y)
-        # rotate
-        x, y = rotate(x, y, phi_q)
+        # shift and rotate coordinates
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        x_, y_ = rotate(x_, y_, phi_q)
 
         # potential calculation
         if self.high_accuracy:
             f_ = CSEProductAvgSet.function(
-                x / Rs, y / Rs, HIGH_ACCURACY_A, HIGH_ACCURACY_S, q
+                x_ / Rs, y_ / Rs, HIGH_ACCURACY_A, HIGH_ACCURACY_S, q
             )
         else:
             f_ = CSEProductAvgSet.function(
-                x / Rs, y / Rs, LOW_ACCURACY_A, LOW_ACCURACY_S, q
+                x_ / Rs, y_ / Rs, LOW_ACCURACY_A, LOW_ACCURACY_S, q
             )
 
         const = self._normalization(alpha_Rs, Rs, q)
@@ -263,17 +262,16 @@ class NFW_ELLIPSE_CSE(LensProfileBase):
         :return: deflection in x-direction, deflection in y-direction
         """
         phi_q, q = param_util.ellipticity2phi_q(e1, e2)
-        # shift
-        x, y = shift_center(x, y, center_x, center_y)
-        # rotate
-        x, y = rotate(x, y, phi_q)
+        # shift and rotate coordinates
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        x_, y_ = rotate(x_, y_, phi_q)
         if self.high_accuracy:
             f__x, f__y = CSEProductAvgSet.derivatives(
-                x / Rs, y / Rs, HIGH_ACCURACY_A, HIGH_ACCURACY_S, q
+                x_ / Rs, y_ / Rs, HIGH_ACCURACY_A, HIGH_ACCURACY_S, q
             )
         else:
             f__x, f__y = CSEProductAvgSet.derivatives(
-                x / Rs, y / Rs, LOW_ACCURACY_A, LOW_ACCURACY_S, q
+                x_ / Rs, y_ / Rs, LOW_ACCURACY_A, LOW_ACCURACY_S, q
             )
 
         # rotate deflections back
@@ -298,17 +296,16 @@ class NFW_ELLIPSE_CSE(LensProfileBase):
         :return: d^2f/dx^2, d^2/dxdy, d^2/dydx, d^f/dy^2
         """
         phi_q, q = param_util.ellipticity2phi_q(e1, e2)
-        # shift
-        x, y = shift_center(x, y, center_x, center_y)
-        # rotate
-        x, y = rotate(x, y, phi_q)
+        # shift and rotate coordinates
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        x_, y_ = rotate(x_, y_, phi_q)
         if self.high_accuracy:
             f__xx, f__xy, f__yx, f__yy = CSEProductAvgSet.hessian(
-                x / Rs, y / Rs, HIGH_ACCURACY_A, HIGH_ACCURACY_S, q
+                x_ / Rs, y_ / Rs, HIGH_ACCURACY_A, HIGH_ACCURACY_S, q
             )
         else:
             f__xx, f__xy, f__yx, f__yy = CSEProductAvgSet.hessian(
-                x / Rs, y / Rs, LOW_ACCURACY_A, LOW_ACCURACY_S, q
+                x_ / Rs, y_ / Rs, LOW_ACCURACY_A, LOW_ACCURACY_S, q
             )
 
         # rotate back

--- a/jaxtronomy/LensModel/Profiles/nfw_ellipse_cse.py
+++ b/jaxtronomy/LensModel/Profiles/nfw_ellipse_cse.py
@@ -3,7 +3,7 @@ __author__ = "sibirrer"
 from jax import jit, tree_util
 import jax.numpy as jnp
 
-from jaxtronomy.Util import util
+from jaxtronomy.Util.util import shift_center, rotate
 from jaxtronomy.LensModel.Profiles.nfw import NFW
 from jaxtronomy.LensModel.Profiles.cored_steep_ellipsoid import CSEProductAvgSet
 import jaxtronomy.Util.param_util as param_util
@@ -12,7 +12,7 @@ from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 __all__ = ["NFW_ELLIPSE_CSE"]
 
 # Table 1 in Oguri 2021
-HIGH_ACCURACY_S = jnp.asarray(
+HIGH_ACCURACY_S = jnp.array(
     [
         1.082411e-06,
         8.786566e-06,
@@ -58,9 +58,10 @@ HIGH_ACCURACY_S = jnp.asarray(
         7.760206e02,
         2.143057e03,
         1.935749e03,
-    ]
+    ],
+    dtype=float
 )
-HIGH_ACCURACY_A = jnp.asarray(
+HIGH_ACCURACY_A = jnp.array(
     [
         1.648988e-18,
         6.274458e-16,
@@ -106,11 +107,12 @@ HIGH_ACCURACY_A = jnp.asarray(
         5.401335e02,
         9.743682e02,
         1.775124e03,
-    ]
+    ],
+    dtype=float
 )
 
 # Table 3 in Oguri 2021
-LOW_ACCURACY_A = jnp.asarray(
+LOW_ACCURACY_A = jnp.array(
     [
         1.434960e-16,
         5.232413e-14,
@@ -128,9 +130,10 @@ LOW_ACCURACY_A = jnp.asarray(
         6.340984e01,
         2.576763e02,
         1.422619e03,
-    ]
+    ],
+    dtype=float
 )
-LOW_ACCURACY_S = jnp.asarray(
+LOW_ACCURACY_S = jnp.array(
     [
         4.041628e-06,
         3.086267e-05,
@@ -148,7 +151,8 @@ LOW_ACCURACY_S = jnp.asarray(
         4.627701e01,
         1.842613e02,
         8.206569e02,
-    ]
+    ],
+    dtype=float
 )
 
 
@@ -226,19 +230,18 @@ class NFW_ELLIPSE_CSE(LensProfileBase):
         """
         phi_q, q = param_util.ellipticity2phi_q(e1, e2)
         # shift
-        x_ = x - center_x
-        y_ = y - center_y
+        x, y = shift_center(x, y, center_x, center_y)
         # rotate
-        x__, y__ = util.rotate(x_, y_, phi_q)
+        x, y = rotate(x, y, phi_q)
 
         # potential calculation
         if self.high_accuracy:
             f_ = CSEProductAvgSet.function(
-                x__ / Rs, y__ / Rs, HIGH_ACCURACY_A, HIGH_ACCURACY_S, q
+                x / Rs, y / Rs, HIGH_ACCURACY_A, HIGH_ACCURACY_S, q
             )
         else:
             f_ = CSEProductAvgSet.function(
-                x__ / Rs, y__ / Rs, LOW_ACCURACY_A, LOW_ACCURACY_S, q
+                x / Rs, y / Rs, LOW_ACCURACY_A, LOW_ACCURACY_S, q
             )
 
         const = self._normalization(alpha_Rs, Rs, q)
@@ -261,21 +264,20 @@ class NFW_ELLIPSE_CSE(LensProfileBase):
         """
         phi_q, q = param_util.ellipticity2phi_q(e1, e2)
         # shift
-        x_ = x - center_x
-        y_ = y - center_y
+        x, y = shift_center(x, y, center_x, center_y)
         # rotate
-        x__, y__ = util.rotate(x_, y_, phi_q)
+        x, y = rotate(x, y, phi_q)
         if self.high_accuracy:
             f__x, f__y = CSEProductAvgSet.derivatives(
-                x__ / Rs, y__ / Rs, HIGH_ACCURACY_A, HIGH_ACCURACY_S, q
+                x / Rs, y / Rs, HIGH_ACCURACY_A, HIGH_ACCURACY_S, q
             )
         else:
             f__x, f__y = CSEProductAvgSet.derivatives(
-                x__ / Rs, y__ / Rs, LOW_ACCURACY_A, LOW_ACCURACY_S, q
+                x / Rs, y / Rs, LOW_ACCURACY_A, LOW_ACCURACY_S, q
             )
 
         # rotate deflections back
-        f_x, f_y = util.rotate(f__x, f__y, -phi_q)
+        f_x, f_y = rotate(f__x, f__y, -phi_q)
         const = self._normalization(alpha_Rs, Rs, q) / Rs
         return const * f_x, const * f_y
 
@@ -297,17 +299,16 @@ class NFW_ELLIPSE_CSE(LensProfileBase):
         """
         phi_q, q = param_util.ellipticity2phi_q(e1, e2)
         # shift
-        x_ = x - center_x
-        y_ = y - center_y
+        x, y = shift_center(x, y, center_x, center_y)
         # rotate
-        x__, y__ = util.rotate(x_, y_, phi_q)
+        x, y = rotate(x, y, phi_q)
         if self.high_accuracy:
             f__xx, f__xy, f__yx, f__yy = CSEProductAvgSet.hessian(
-                x__ / Rs, y__ / Rs, HIGH_ACCURACY_A, HIGH_ACCURACY_S, q
+                x / Rs, y / Rs, HIGH_ACCURACY_A, HIGH_ACCURACY_S, q
             )
         else:
             f__xx, f__xy, f__yx, f__yy = CSEProductAvgSet.hessian(
-                x__ / Rs, y__ / Rs, LOW_ACCURACY_A, LOW_ACCURACY_S, q
+                x / Rs, y / Rs, LOW_ACCURACY_A, LOW_ACCURACY_S, q
             )
 
         # rotate back

--- a/jaxtronomy/LensModel/Profiles/nie.py
+++ b/jaxtronomy/LensModel/Profiles/nie.py
@@ -74,12 +74,11 @@ class NIE(LensProfileBase):
         :return: lensing potential
         """
         b, s, q, phi_G = self.param_conv(theta_E, e1, e2, s_scale)
-        # shift
-        x, y = shift_center(x, y, center_x, center_y)
-        # rotate
-        x, y = rotate(x, y, phi_G)
+        # shift and rotate coordinates
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        x_, y_ = rotate(x_, y_, phi_G)
         # evaluate
-        f_ = NIEMajorAxis.function(x, y, b, s, q)
+        f_ = NIEMajorAxis.function(x_, y_, b, s, q)
         # rotate back
         return f_
 
@@ -98,12 +97,11 @@ class NIE(LensProfileBase):
         :return: alpha_x, alpha_y
         """
         b, s, q, phi_G = self.param_conv(theta_E, e1, e2, s_scale)
-        # shift
-        x, y = shift_center(x, y, center_x, center_y)
-        # rotate
-        x, y = rotate(x, y, phi_G)
+        # shift and rotate coordinates
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        x_, y_ = rotate(x_, y_, phi_G)
         # evaluate
-        f__x, f__y = NIEMajorAxis.derivatives(x, y, b, s, q)
+        f__x, f__y = NIEMajorAxis.derivatives(x_, y_, b, s, q)
         # rotate back
         f_x, f_y = rotate(f__x, f__y, -phi_G)
         return f_x, f_y
@@ -123,12 +121,11 @@ class NIE(LensProfileBase):
         :return: f_xx, f_xy, f_yx, f_yy
         """
         b, s, q, phi_G = self.param_conv(theta_E, e1, e2, s_scale)
-        # shift
-        x, y = shift_center(x, y, center_x, center_y)
-        # rotate
-        x, y = rotate(x, y, phi_G)
+        # shift and rotate coordinates
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        x_, y_ = rotate(x_, y_, phi_G)
         # evaluate
-        f__xx, f__xy, _, f__yy = NIEMajorAxis.hessian(x, y, b, s, q)
+        f__xx, f__xy, _, f__yy = NIEMajorAxis.hessian(x_, y_, b, s, q)
         # rotate back
         kappa = 1.0 / 2 * (f__xx + f__yy)
         gamma1__ = 1.0 / 2 * (f__xx - f__yy)

--- a/jaxtronomy/LensModel/Profiles/nie.py
+++ b/jaxtronomy/LensModel/Profiles/nie.py
@@ -2,7 +2,7 @@ __author__ = "sibirrer"
 
 from jax import jit, tree_util
 import jax.numpy as jnp
-import jaxtronomy.Util.util as util
+from jaxtronomy.Util.util import shift_center, rotate
 import jaxtronomy.Util.param_util as param_util
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
@@ -75,12 +75,11 @@ class NIE(LensProfileBase):
         """
         b, s, q, phi_G = self.param_conv(theta_E, e1, e2, s_scale)
         # shift
-        x_ = x - center_x
-        y_ = y - center_y
+        x, y = shift_center(x, y, center_x, center_y)
         # rotate
-        x__, y__ = util.rotate(x_, y_, phi_G)
+        x, y = rotate(x, y, phi_G)
         # evaluate
-        f_ = NIEMajorAxis.function(x__, y__, b, s, q)
+        f_ = NIEMajorAxis.function(x, y, b, s, q)
         # rotate back
         return f_
 
@@ -100,14 +99,13 @@ class NIE(LensProfileBase):
         """
         b, s, q, phi_G = self.param_conv(theta_E, e1, e2, s_scale)
         # shift
-        x_ = x - center_x
-        y_ = y - center_y
+        x, y = shift_center(x, y, center_x, center_y)
         # rotate
-        x__, y__ = util.rotate(x_, y_, phi_G)
+        x, y = rotate(x, y, phi_G)
         # evaluate
-        f__x, f__y = NIEMajorAxis.derivatives(x__, y__, b, s, q)
+        f__x, f__y = NIEMajorAxis.derivatives(x, y, b, s, q)
         # rotate back
-        f_x, f_y = util.rotate(f__x, f__y, -phi_G)
+        f_x, f_y = rotate(f__x, f__y, -phi_G)
         return f_x, f_y
 
     @jit
@@ -126,12 +124,11 @@ class NIE(LensProfileBase):
         """
         b, s, q, phi_G = self.param_conv(theta_E, e1, e2, s_scale)
         # shift
-        x_ = x - center_x
-        y_ = y - center_y
+        x, y = shift_center(x, y, center_x, center_y)
         # rotate
-        x__, y__ = util.rotate(x_, y_, phi_G)
+        x, y = rotate(x, y, phi_G)
         # evaluate
-        f__xx, f__xy, _, f__yy = NIEMajorAxis.hessian(x__, y__, b, s, q)
+        f__xx, f__xy, _, f__yy = NIEMajorAxis.hessian(x, y, b, s, q)
         # rotate back
         kappa = 1.0 / 2 * (f__xx + f__yy)
         gamma1__ = 1.0 / 2 * (f__xx - f__yy)
@@ -270,6 +267,8 @@ class NIEMajorAxis(LensProfileBase):
     @staticmethod
     @jit
     def function(x, y, b, s, q):
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
         psi = NIEMajorAxis._psi(x, y, q, s)
         alpha_x, alpha_y = NIEMajorAxis.derivatives(x, y, b, s, q)
         f_ = (
@@ -283,6 +282,8 @@ class NIEMajorAxis(LensProfileBase):
     @jit
     def derivatives(x, y, b, s, q):
         """Returns df/dx and df/dy of the function."""
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
         q = jnp.where(q >= 1, 0.99999999, q)
         psi = NIEMajorAxis._psi(x, y, q, s)
         f_x = (
@@ -300,6 +301,8 @@ class NIEMajorAxis(LensProfileBase):
     def hessian(x, y, b, s, q):
         """Returns Hessian matrix of function d^2f/dx^2, d^2/dxdy, d^2/dydx,
         d^f/dy^2."""
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
         alpha_ra, alpha_dec = NIEMajorAxis.derivatives(x, y, b, s, q)
         diff = 0.0000000001
         alpha_ra_dx, alpha_dec_dx = NIEMajorAxis.derivatives(x + diff, y, b, s, q)
@@ -323,6 +326,8 @@ class NIEMajorAxis(LensProfileBase):
         :param q: axis ratio
         :return: convergence
         """
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
         kappa = b / 2.0 * (q**2 * (s**2 + x**2) + y**2) ** (-1.0 / 2)
         return kappa
 

--- a/jaxtronomy/LensModel/Profiles/pseudo_jaffe.py
+++ b/jaxtronomy/LensModel/Profiles/pseudo_jaffe.py
@@ -93,8 +93,8 @@ class PseudoJaffe(LensProfileBase):
         :return: projected density
         """
         Ra, Rs = PseudoJaffe._sort_ra_rs(Ra, Rs)
-        x, y = shift_center(x, y, center_x, center_y)
-        r = jnp.sqrt(x**2 + y**2)
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x_**2 + y_**2)
         sigma0 = PseudoJaffe.rho2sigma(rho0, Ra, Rs)
         sigma = (
             sigma0
@@ -224,8 +224,8 @@ class PseudoJaffe(LensProfileBase):
         :return: lensing potential
         """
         Ra, Rs = PseudoJaffe._sort_ra_rs(Ra, Rs)
-        x, y = shift_center(x, y, center_x, center_y)
-        r = jnp.sqrt(x**2 + y**2)
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x_**2 + y_**2)
         f_ = (
             -2
             * sigma0
@@ -257,8 +257,8 @@ class PseudoJaffe(LensProfileBase):
         :return: f_x, f_y
         """
         Ra, Rs = PseudoJaffe._sort_ra_rs(Ra, Rs)
-        x, y = shift_center(x, y, center_x, center_y)
-        r = jnp.sqrt(x**2 + y**2)
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x_**2 + y_**2)
         r = jnp.where(r < PseudoJaffe._s, PseudoJaffe._s, r)
 
         # There is a 0/0 here if Ra = Rs which can be avoided by taking the limit as Ra -> Rs
@@ -269,8 +269,8 @@ class PseudoJaffe(LensProfileBase):
         factor = jnp.where(Ra == Rs, factor2, factor1)
 
         alpha_r = 2 * sigma0 * Ra * Rs * factor
-        f_x = alpha_r * x / r
-        f_y = alpha_r * y / r
+        f_x = alpha_r * x_ / r
+        f_y = alpha_r * y_ / r
         return f_x, f_y
 
     @staticmethod
@@ -289,8 +289,8 @@ class PseudoJaffe(LensProfileBase):
         :return: f_xx, f_xy, f_yx, f_yy
         """
         Ra, Rs = PseudoJaffe._sort_ra_rs(Ra, Rs)
-        x, y = shift_center(x, y, center_x, center_y)
-        r = jnp.sqrt(x**2 + y**2)
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x_**2 + y_**2)
         r = jnp.where(r < PseudoJaffe._s, PseudoJaffe._s, r)
         gamma = (
             sigma0
@@ -313,8 +313,8 @@ class PseudoJaffe(LensProfileBase):
             / (Rs - Ra)
             * (1 / jnp.sqrt(Ra**2 + r**2) - 1 / jnp.sqrt(Rs**2 + r**2))
         )
-        sin_2phi = -2 * x * y / r**2
-        cos_2phi = (y**2 - x**2) / r**2
+        sin_2phi = -2 * x_ * y_ / r**2
+        cos_2phi = (y_**2 - x_**2) / r**2
         gamma1 = cos_2phi * gamma
         gamma2 = sin_2phi * gamma
 

--- a/jaxtronomy/LensModel/Profiles/pseudo_jaffe.py
+++ b/jaxtronomy/LensModel/Profiles/pseudo_jaffe.py
@@ -1,5 +1,6 @@
 import numpy as np
 from jax import jit, numpy as jnp
+from jaxtronomy.Util.util import shift_center
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
 __all__ = ["PseudoJaffe"]
@@ -92,9 +93,8 @@ class PseudoJaffe(LensProfileBase):
         :return: projected density
         """
         Ra, Rs = PseudoJaffe._sort_ra_rs(Ra, Rs)
-        x_ = jnp.array(x - center_x, dtype=float)
-        y_ = jnp.array(y - center_y, dtype=float)
-        r = jnp.sqrt(x_**2 + y_**2)
+        x, y = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x**2 + y**2)
         sigma0 = PseudoJaffe.rho2sigma(rho0, Ra, Rs)
         sigma = (
             sigma0
@@ -224,9 +224,8 @@ class PseudoJaffe(LensProfileBase):
         :return: lensing potential
         """
         Ra, Rs = PseudoJaffe._sort_ra_rs(Ra, Rs)
-        x_ = jnp.array(x - center_x, dtype=float)
-        y_ = jnp.array(y - center_y, dtype=float)
-        r = jnp.sqrt(x_**2 + y_**2)
+        x, y = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x**2 + y**2)
         f_ = (
             -2
             * sigma0
@@ -258,9 +257,8 @@ class PseudoJaffe(LensProfileBase):
         :return: f_x, f_y
         """
         Ra, Rs = PseudoJaffe._sort_ra_rs(Ra, Rs)
-        x_ = jnp.array(x - center_x, dtype=float)
-        y_ = jnp.array(y - center_y, dtype=float)
-        r = jnp.sqrt(x_**2 + y_**2)
+        x, y = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x**2 + y**2)
         r = jnp.where(r < PseudoJaffe._s, PseudoJaffe._s, r)
 
         # There is a 0/0 here if Ra = Rs which can be avoided by taking the limit as Ra -> Rs
@@ -271,8 +269,8 @@ class PseudoJaffe(LensProfileBase):
         factor = jnp.where(Ra == Rs, factor2, factor1)
 
         alpha_r = 2 * sigma0 * Ra * Rs * factor
-        f_x = alpha_r * x_ / r
-        f_y = alpha_r * y_ / r
+        f_x = alpha_r * x / r
+        f_y = alpha_r * y / r
         return f_x, f_y
 
     @staticmethod
@@ -291,9 +289,8 @@ class PseudoJaffe(LensProfileBase):
         :return: f_xx, f_xy, f_yx, f_yy
         """
         Ra, Rs = PseudoJaffe._sort_ra_rs(Ra, Rs)
-        x_ = jnp.array(x - center_x, dtype=float)
-        y_ = jnp.array(y - center_y, dtype=float)
-        r = jnp.sqrt(x_**2 + y_**2)
+        x, y = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x**2 + y**2)
         r = jnp.where(r < PseudoJaffe._s, PseudoJaffe._s, r)
         gamma = (
             sigma0
@@ -316,8 +313,8 @@ class PseudoJaffe(LensProfileBase):
             / (Rs - Ra)
             * (1 / jnp.sqrt(Ra**2 + r**2) - 1 / jnp.sqrt(Rs**2 + r**2))
         )
-        sin_2phi = -2 * x_ * y_ / r**2
-        cos_2phi = (y_**2 - x_**2) / r**2
+        sin_2phi = -2 * x * y / r**2
+        cos_2phi = (y**2 - x**2) / r**2
         gamma1 = cos_2phi * gamma
         gamma2 = sin_2phi * gamma
 

--- a/jaxtronomy/LensModel/Profiles/pseudo_jaffe_ellipse_potential.py
+++ b/jaxtronomy/LensModel/Profiles/pseudo_jaffe_ellipse_potential.py
@@ -2,7 +2,6 @@ from jaxtronomy.LensModel.Profiles.pseudo_jaffe import PseudoJaffe
 import jaxtronomy.Util.param_util as param_util
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 from jax import jit, numpy as jnp
-import numpy as np
 
 __all__ = ["PseudoJaffeEllipsePotential"]
 
@@ -70,10 +69,10 @@ class PseudoJaffeEllipsePotential(LensProfileBase):
     @jit
     def function(x, y, sigma0, Ra, Rs, e1, e2, center_x=0, center_y=0):
         """Returns double integral of NFW profile."""
-        x_, y_ = param_util.transform_e1e2_square_average(
+        x, y = param_util.transform_e1e2_square_average(
             x, y, e1, e2, center_x, center_y
         )
-        f_ = PseudoJaffeEllipsePotential.spherical.function(x_, y_, sigma0, Ra, Rs)
+        f_ = PseudoJaffeEllipsePotential.spherical.function(x, y, sigma0, Ra, Rs)
         return f_
 
     @staticmethod
@@ -81,14 +80,14 @@ class PseudoJaffeEllipsePotential(LensProfileBase):
     def derivatives(x, y, sigma0, Ra, Rs, e1, e2, center_x=0, center_y=0):
         """Returns df/dx and df/dy of the function (integral of NFW)"""
         phi_G, q = param_util.ellipticity2phi_q(e1, e2)
-        x_, y_ = param_util.transform_e1e2_square_average(
+        x, y = param_util.transform_e1e2_square_average(
             x, y, e1, e2, center_x, center_y
         )
         e = param_util.q2e(q)
         cos_phi = jnp.cos(phi_G)
         sin_phi = jnp.sin(phi_G)
         f_x_prim, f_y_prim = PseudoJaffeEllipsePotential.spherical.derivatives(
-            x_, y_, sigma0, Ra, Rs, center_x=0, center_y=0
+            x, y, sigma0, Ra, Rs, center_x=0, center_y=0
         )
         f_x_prim *= jnp.sqrt(1 - e)
         f_y_prim *= jnp.sqrt(1 + e)

--- a/jaxtronomy/LensModel/Profiles/pseudo_jaffe_ellipse_potential.py
+++ b/jaxtronomy/LensModel/Profiles/pseudo_jaffe_ellipse_potential.py
@@ -69,10 +69,10 @@ class PseudoJaffeEllipsePotential(LensProfileBase):
     @jit
     def function(x, y, sigma0, Ra, Rs, e1, e2, center_x=0, center_y=0):
         """Returns double integral of NFW profile."""
-        x, y = param_util.transform_e1e2_square_average(
+        x_, y_ = param_util.transform_e1e2_square_average(
             x, y, e1, e2, center_x, center_y
         )
-        f_ = PseudoJaffeEllipsePotential.spherical.function(x, y, sigma0, Ra, Rs)
+        f_ = PseudoJaffeEllipsePotential.spherical.function(x_, y_, sigma0, Ra, Rs)
         return f_
 
     @staticmethod
@@ -80,14 +80,14 @@ class PseudoJaffeEllipsePotential(LensProfileBase):
     def derivatives(x, y, sigma0, Ra, Rs, e1, e2, center_x=0, center_y=0):
         """Returns df/dx and df/dy of the function (integral of NFW)"""
         phi_G, q = param_util.ellipticity2phi_q(e1, e2)
-        x, y = param_util.transform_e1e2_square_average(
+        x_, y_ = param_util.transform_e1e2_square_average(
             x, y, e1, e2, center_x, center_y
         )
         e = param_util.q2e(q)
         cos_phi = jnp.cos(phi_G)
         sin_phi = jnp.sin(phi_G)
         f_x_prim, f_y_prim = PseudoJaffeEllipsePotential.spherical.derivatives(
-            x, y, sigma0, Ra, Rs, center_x=0, center_y=0
+            x_, y_, sigma0, Ra, Rs, center_x=0, center_y=0
         )
         f_x_prim *= jnp.sqrt(1 - e)
         f_y_prim *= jnp.sqrt(1 + e)

--- a/jaxtronomy/LensModel/Profiles/sersic_utils.py
+++ b/jaxtronomy/LensModel/Profiles/sersic_utils.py
@@ -95,18 +95,18 @@ class SersicUtil(object):
 
         if self._sersic_major_axis:
             phi_G, q = param_util.ellipticity2phi_q(e1, e2)
-            x, y = shift_center(x, y, center_x, center_y)
+            x_, y_ = shift_center(x, y, center_x, center_y)
             cos_phi = jnp.cos(phi_G)
             sin_phi = jnp.sin(phi_G)
-            xt1 = cos_phi * x + sin_phi * y
-            xt2 = -sin_phi * x + cos_phi * y
+            xt1 = cos_phi * x_ + sin_phi * y_
+            xt2 = -sin_phi * x_ + cos_phi * y_
             xt2difq2 = xt2 / (q * q)
             r = jnp.sqrt(xt1 * xt1 + xt2 * xt2difq2)
         else:
-            x, y = param_util.transform_e1e2_product_average(
+            x_, y_ = param_util.transform_e1e2_product_average(
                 x, y, e1, e2, center_x, center_y
             )
-            r = jnp.sqrt(x**2 + y**2)
+            r = jnp.sqrt(x_**2 + y_**2)
         return r
 
     @jit
@@ -119,8 +119,8 @@ class SersicUtil(object):
         :param center_y: position of the center of the source
         :return: transformed normalized radius coordinate
         """
-        x, y = shift_center(x, y, center_x, center_y)
-        r = jnp.sqrt(x**2 + y**2)
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x_**2 + y_**2)
         r = jnp.where(r < self._smoothing, self._smoothing, r)
         x_reduced = (r / r_eff) ** (1.0 / n_sersic)
         return x_reduced
@@ -179,8 +179,8 @@ class SersicUtil(object):
         :return: derivative of deflection angle w.r.t radius
         """
         _dr = 0.00001
-        x, y = shift_center(x, y, center_x, center_y)
-        r = jnp.sqrt(x**2 + y**2)
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x_**2 + y_**2)
         alpha = self.alpha_abs(r, 0, n_sersic, r_eff, k_eff)
         alpha_dr = self.alpha_abs(r + _dr, 0, n_sersic, r_eff, k_eff)
         d_alpha_dr = (alpha_dr - alpha) / _dr

--- a/jaxtronomy/LensModel/Profiles/sersic_utils.py
+++ b/jaxtronomy/LensModel/Profiles/sersic_utils.py
@@ -3,6 +3,7 @@ import jax.numpy as jnp
 import jax.scipy.special as special
 
 from jaxtronomy.Util import param_util
+from jaxtronomy.Util.util import shift_center
 
 __all__ = ["SersicUtil"]
 
@@ -94,19 +95,18 @@ class SersicUtil(object):
 
         if self._sersic_major_axis:
             phi_G, q = param_util.ellipticity2phi_q(e1, e2)
-            x_shift = x - center_x
-            y_shift = y - center_y
+            x, y = shift_center(x, y, center_x, center_y)
             cos_phi = jnp.cos(phi_G)
             sin_phi = jnp.sin(phi_G)
-            xt1 = cos_phi * x_shift + sin_phi * y_shift
-            xt2 = -sin_phi * x_shift + cos_phi * y_shift
+            xt1 = cos_phi * x + sin_phi * y
+            xt2 = -sin_phi * x + cos_phi * y
             xt2difq2 = xt2 / (q * q)
             r = jnp.sqrt(xt1 * xt1 + xt2 * xt2difq2)
         else:
-            x_, y_ = param_util.transform_e1e2_product_average(
+            x, y = param_util.transform_e1e2_product_average(
                 x, y, e1, e2, center_x, center_y
             )
-            r = jnp.sqrt(x_**2 + y_**2)
+            r = jnp.sqrt(x**2 + y**2)
         return r
 
     @jit
@@ -119,9 +119,8 @@ class SersicUtil(object):
         :param center_y: position of the center of the source
         :return: transformed normalized radius coordinate
         """
-        x_ = x - center_x
-        y_ = y - center_y
-        r = jnp.sqrt(x_**2 + y_**2)
+        x, y = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x**2 + y**2)
         r = jnp.where(r < self._smoothing, self._smoothing, r)
         x_reduced = (r / r_eff) ** (1.0 / n_sersic)
         return x_reduced
@@ -180,9 +179,8 @@ class SersicUtil(object):
         :return: derivative of deflection angle w.r.t radius
         """
         _dr = 0.00001
-        x_ = x - center_x
-        y_ = y - center_y
-        r = jnp.sqrt(x_**2 + y_**2)
+        x, y = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x**2 + y**2)
         alpha = self.alpha_abs(r, 0, n_sersic, r_eff, k_eff)
         alpha_dr = self.alpha_abs(r + _dr, 0, n_sersic, r_eff, k_eff)
         d_alpha_dr = (alpha_dr - alpha) / _dr

--- a/jaxtronomy/LensModel/Profiles/shear.py
+++ b/jaxtronomy/LensModel/Profiles/shear.py
@@ -1,7 +1,8 @@
 __author__ = "sibirrer"
 
-import jaxtronomy.Util.param_util as param_util
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
+import jaxtronomy.Util.param_util as param_util
+from jaxtronomy.Util.util import shift_center
 from jaxtronomy.LensModel.Profiles.convergence import Convergence
 import jax.numpy as jnp
 from jax import jit
@@ -29,9 +30,8 @@ class Shear(LensProfileBase):
         :param dec_0: y/dec position where shear deflection is 0
         :return: lensing potential
         """
-        x_ = x - ra_0
-        y_ = y - dec_0
-        f_ = 1 / 2.0 * (gamma1 * x_ * x_ + 2 * gamma2 * x_ * y_ - gamma1 * y_ * y_)
+        x, y = shift_center(x, y, ra_0, dec_0)
+        f_ = 1 / 2.0 * (gamma1 * x * x + 2 * gamma2 * x * y - gamma1 * y * y)
         return f_
 
     @staticmethod
@@ -47,10 +47,9 @@ class Shear(LensProfileBase):
         :param dec_0: y/dec position where shear deflection is 0
         :return: deflection angles
         """
-        x_ = x - ra_0
-        y_ = y - dec_0
-        f_x = gamma1 * x_ + gamma2 * y_
-        f_y = +gamma2 * x_ - gamma1 * y_
+        x, y = shift_center(x, y, ra_0, dec_0)
+        f_x = gamma1 * x + gamma2 * y
+        f_y = +gamma2 * x - gamma1 * y
         return f_x, f_y
 
     @staticmethod
@@ -112,7 +111,7 @@ class ShearGammaPsi(LensProfileBase):
         :return:
         """
         # change to polar coordinate
-        r, phi = param_util.cart2polar(x - ra_0, y - dec_0)
+        r, phi = param_util.cart2polar(x, y, ra_0, dec_0)
         f_ = 1.0 / 2 * gamma_ext * r**2 * jnp.cos(2 * (phi - psi_ext))
         return f_
 

--- a/jaxtronomy/LensModel/Profiles/shear.py
+++ b/jaxtronomy/LensModel/Profiles/shear.py
@@ -30,8 +30,8 @@ class Shear(LensProfileBase):
         :param dec_0: y/dec position where shear deflection is 0
         :return: lensing potential
         """
-        x, y = shift_center(x, y, ra_0, dec_0)
-        f_ = 1 / 2.0 * (gamma1 * x * x + 2 * gamma2 * x * y - gamma1 * y * y)
+        x_, y_ = shift_center(x, y, ra_0, dec_0)
+        f_ = 1 / 2.0 * (gamma1 * x_ * x_ + 2 * gamma2 * x_ * y_ - gamma1 * y_ * y_)
         return f_
 
     @staticmethod
@@ -47,9 +47,9 @@ class Shear(LensProfileBase):
         :param dec_0: y/dec position where shear deflection is 0
         :return: deflection angles
         """
-        x, y = shift_center(x, y, ra_0, dec_0)
-        f_x = gamma1 * x + gamma2 * y
-        f_y = +gamma2 * x - gamma1 * y
+        x_, y_ = shift_center(x, y, ra_0, dec_0)
+        f_x = gamma1 * x_ + gamma2 * y_
+        f_y = gamma2 * x_ - gamma1 * y_
         return f_x, f_y
 
     @staticmethod

--- a/jaxtronomy/LensModel/Profiles/sie.py
+++ b/jaxtronomy/LensModel/Profiles/sie.py
@@ -222,8 +222,8 @@ class SIE(LensProfileBase):
         :param center_y:
         :return:
         """
-        x, y = shift_center(x, y, center_x, center_y)
-        r = jnp.sqrt(x**2 + y**2)
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x_**2 + y_**2)
         mass_3d = self.mass_3d(r, rho0)
         pot = mass_3d / r
         return pot
@@ -269,8 +269,8 @@ class SIE(LensProfileBase):
         :param center_y:
         :return:
         """
-        x, y = shift_center(x, y, center_x, center_y)
-        r = jnp.sqrt(x**2 + y**2)
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x_**2 + y_**2)
         sigma = jnp.pi * rho0 / r
         return sigma
 

--- a/jaxtronomy/LensModel/Profiles/sie.py
+++ b/jaxtronomy/LensModel/Profiles/sie.py
@@ -2,6 +2,7 @@ from jax import jit, tree_util
 import jax.numpy as jnp
 from jaxtronomy.LensModel.Profiles.nie import NIE
 from jaxtronomy.LensModel.Profiles.epl import EPL
+from jaxtronomy.Util.util import shift_center
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
 __all__ = ["SIE"]
@@ -221,9 +222,8 @@ class SIE(LensProfileBase):
         :param center_y:
         :return:
         """
-        x_ = x - center_x
-        y_ = y - center_y
-        r = jnp.sqrt(x_**2 + y_**2)
+        x, y = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x**2 + y**2)
         mass_3d = self.mass_3d(r, rho0)
         pot = mass_3d / r
         return pot
@@ -269,9 +269,8 @@ class SIE(LensProfileBase):
         :param center_y:
         :return:
         """
-        x_ = x - center_x
-        y_ = y - center_y
-        r = jnp.sqrt(x_**2 + y_**2)
+        x, y = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x**2 + y**2)
         sigma = jnp.pi * rho0 / r
         return sigma
 

--- a/jaxtronomy/LensModel/Profiles/sis.py
+++ b/jaxtronomy/LensModel/Profiles/sis.py
@@ -1,7 +1,7 @@
 __author__ = "sibirrer"
 
-from functools import partial
 from jax import config, jit, numpy as jnp
+from jaxtronomy.Util.util import shift_center
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
 config.update("jax_enable_x64", True)  # 64-bit floats
@@ -28,22 +28,20 @@ class SIS(LensProfileBase):
     @staticmethod
     @jit
     def function(x, y, theta_E, center_x=0, center_y=0):
-        x_shift = x - center_x
-        y_shift = y - center_y
-        f_ = theta_E * jnp.sqrt(x_shift * x_shift + y_shift * y_shift)
+        x, y = shift_center(x, y, center_x, center_y)
+        f_ = theta_E * jnp.sqrt(x**2 + y**2)
         return f_
 
     @staticmethod
     @jit
     def derivatives(x, y, theta_E, center_x=0, center_y=0):
         """Returns df/dx and df/dy of the function."""
-        x_shift = x - center_x
-        y_shift = y - center_y
-        R = jnp.sqrt(x_shift * x_shift + y_shift * y_shift)
+        x, y = shift_center(x, y, center_x, center_y)
+        R = jnp.sqrt(x**2 + y**2)
         R = jnp.where(R < SIS._epsilon, SIS._epsilon, R)
         a = theta_E / jnp.maximum(R, SIS._epsilon)
-        f_x = a * x_shift
-        f_y = a * y_shift
+        f_x = a * x
+        f_y = a * y
         return f_x, f_y
 
     @staticmethod
@@ -51,14 +49,13 @@ class SIS(LensProfileBase):
     def hessian(x, y, theta_E, center_x=0, center_y=0):
         """Returns Hessian matrix of function d^2f/dx^2, d^2/dxdy, d^2/dydx,
         d^f/dy^2."""
-        x_shift = x - center_x
-        y_shift = y - center_y
-        R = (x_shift * x_shift + y_shift * y_shift) ** (3.0 / 2)
+        x, y = shift_center(x, y, center_x, center_y)
+        R = (x**2 + y**2) ** (3.0 / 2)
         R = jnp.where(R < SIS._epsilon, SIS._epsilon, R)
         prefac = theta_E / jnp.maximum(SIS._epsilon, R)
-        f_xx = y_shift * y_shift * prefac
-        f_yy = x_shift * x_shift * prefac
-        f_xy = -x_shift * y_shift * prefac
+        f_xx = y * y * prefac
+        f_yy = x * x * prefac
+        f_xy = -x * y * prefac
         return f_xx, f_xy, f_xy, f_yy
 
     @staticmethod

--- a/jaxtronomy/LensModel/Profiles/sis.py
+++ b/jaxtronomy/LensModel/Profiles/sis.py
@@ -28,20 +28,20 @@ class SIS(LensProfileBase):
     @staticmethod
     @jit
     def function(x, y, theta_E, center_x=0, center_y=0):
-        x, y = shift_center(x, y, center_x, center_y)
-        f_ = theta_E * jnp.sqrt(x**2 + y**2)
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        f_ = theta_E * jnp.sqrt(x_**2 + y_**2)
         return f_
 
     @staticmethod
     @jit
     def derivatives(x, y, theta_E, center_x=0, center_y=0):
         """Returns df/dx and df/dy of the function."""
-        x, y = shift_center(x, y, center_x, center_y)
-        R = jnp.sqrt(x**2 + y**2)
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        R = jnp.sqrt(x_**2 + y_**2)
         R = jnp.where(R < SIS._epsilon, SIS._epsilon, R)
         a = theta_E / jnp.maximum(R, SIS._epsilon)
-        f_x = a * x
-        f_y = a * y
+        f_x = a * x_
+        f_y = a * y_
         return f_x, f_y
 
     @staticmethod
@@ -49,13 +49,13 @@ class SIS(LensProfileBase):
     def hessian(x, y, theta_E, center_x=0, center_y=0):
         """Returns Hessian matrix of function d^2f/dx^2, d^2/dxdy, d^2/dydx,
         d^f/dy^2."""
-        x, y = shift_center(x, y, center_x, center_y)
-        R = (x**2 + y**2) ** (3.0 / 2)
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        R = (x_**2 + y_**2) ** (3.0 / 2)
         R = jnp.where(R < SIS._epsilon, SIS._epsilon, R)
         prefac = theta_E / jnp.maximum(SIS._epsilon, R)
-        f_xx = y * y * prefac
-        f_yy = x * x * prefac
-        f_xy = -x * y * prefac
+        f_xx = y_ * y_ * prefac
+        f_yy = x_ * x_ * prefac
+        f_xy = -x_ * y_ * prefac
         return f_xx, f_xy, f_xy, f_yy
 
     @staticmethod
@@ -134,8 +134,7 @@ class SIS(LensProfileBase):
         :param center_y:
         :return:
         """
-        x_ = x - center_x
-        y_ = y - center_y
+        x_, y_ = shift_center(x, y, center_x, center_y)
         r = jnp.sqrt(x_**2 + y_**2)
         mass_3d = SIS.mass_3d(r, rho0)
         pot = mass_3d / r
@@ -174,8 +173,7 @@ class SIS(LensProfileBase):
         :param center_y:
         :return:
         """
-        x_ = x - center_x
-        y_ = y - center_y
+        x_, y_ = shift_center(x, y, center_x, center_y)
         r = jnp.sqrt(x_**2 + y_**2)
         sigma = jnp.pi * rho0 / r
         return sigma

--- a/jaxtronomy/LensModel/Profiles/spp.py
+++ b/jaxtronomy/LensModel/Profiles/spp.py
@@ -94,9 +94,7 @@ class SPP(LensProfileBase):
             * (a / E**2) ** (eta / 2 - 1)
             * ((eta / 2 - 1) * (2 * x**2 - 2 * y**2) / a)
         )
-        gamma2 = (
-            4 * x * y * (1.0 / 2 - 1 / eta) * (a / E**2) ** (eta / 2 - 2) / E**2
-        )
+        gamma2 = 4 * x * y * (1.0 / 2 - 1 / eta) * (a / E**2) ** (eta / 2 - 2) / E**2
 
         f_xx = kappa + gamma1
         f_yy = kappa - gamma1

--- a/jaxtronomy/LensModel/Profiles/spp.py
+++ b/jaxtronomy/LensModel/Profiles/spp.py
@@ -44,12 +44,12 @@ class SPP(LensProfileBase):
         """
         gamma = SPP._gamma_limit(gamma)
 
-        x, y = shift_center(x, y, center_x, center_y)
+        x_, y_ = shift_center(x, y, center_x, center_y)
         E = theta_E / ((3.0 - gamma) / 2.0) ** (1.0 / (1.0 - gamma))
         # E = phi_E_spp
         eta = -gamma + 3
 
-        p2 = x**2 + y**2
+        p2 = x_**2 + y_**2
         s2 = 0.0  # softening
         return 2 * E**2 / eta**2 * ((p2 + s2) / E**2) ** (eta / 2)
 
@@ -58,15 +58,15 @@ class SPP(LensProfileBase):
     def derivatives(x, y, theta_E, gamma, center_x=0.0, center_y=0.0):
         gamma = SPP._gamma_limit(gamma)
 
-        x, y = shift_center(x, y, center_x, center_y)
+        x_, y_ = shift_center(x, y, center_x, center_y)
 
-        r2 = x**2 + y**2
+        r2 = x_**2 + y_**2
         a = jnp.maximum(r2, 0.000001)
         r = jnp.sqrt(a)
         alpha = theta_E * (r2 / theta_E**2) ** (1 - gamma / 2.0)
         fac = alpha / r
-        f_x = fac * x
-        f_y = fac * y
+        f_x = fac * x_
+        f_y = fac * y_
         return f_x, f_y
 
     @staticmethod
@@ -74,27 +74,27 @@ class SPP(LensProfileBase):
     def hessian(x, y, theta_E, gamma, center_x=0.0, center_y=0.0):
         gamma = SPP._gamma_limit(gamma)
 
-        x, y = shift_center(x, y, center_x, center_y)
+        x_, y_ = shift_center(x, y, center_x, center_y)
         E = theta_E / ((3.0 - gamma) / 2.0) ** (1.0 / (1.0 - gamma))
         # E = phi_E_spp
         eta = -gamma + 3.0
 
-        P2 = x**2 + y**2
+        P2 = x_**2 + y_**2
         a = jnp.where(P2 < 0.000001, 0.000001, P2)
 
         kappa = (
             1.0
             / eta
             * (a / E**2) ** (eta / 2 - 1)
-            * ((eta - 2) * (x**2 + y**2) / a + (1 + 1))
+            * ((eta - 2) * (x_**2 + y_**2) / a + (1 + 1))
         )
         gamma1 = (
             1.0
             / eta
             * (a / E**2) ** (eta / 2 - 1)
-            * ((eta / 2 - 1) * (2 * x**2 - 2 * y**2) / a)
+            * ((eta / 2 - 1) * (2 * x_**2 - 2 * y_**2) / a)
         )
-        gamma2 = 4 * x * y * (1.0 / 2 - 1 / eta) * (a / E**2) ** (eta / 2 - 2) / E**2
+        gamma2 = 4 * x_ * y_ * (1.0 / 2 - 1 / eta) * (a / E**2) ** (eta / 2 - 2) / E**2
 
         f_xx = kappa + gamma1
         f_yy = kappa - gamma1
@@ -218,8 +218,8 @@ class SPP(LensProfileBase):
         :param center_y:
         :return:
         """
-        x, y = shift_center(x, y, center_x, center_y)
-        r = jnp.sqrt(x**2 + y**2)
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x_**2 + y_**2)
         mass_3d = SPP.mass_3d(r, rho0, gamma)
         pot = mass_3d / r
         return pot
@@ -261,8 +261,8 @@ class SPP(LensProfileBase):
         :param center_y:
         :return:
         """
-        x, y = shift_center(x, y, center_x, center_y)
-        r = jnp.sqrt(x**2 + y**2)
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x_**2 + y_**2)
         sigma = (
             jnp.sqrt(jnp.pi)
             * special.gamma(1.0 / 2 * (-1 + gamma))

--- a/jaxtronomy/LensModel/Profiles/spp.py
+++ b/jaxtronomy/LensModel/Profiles/spp.py
@@ -4,6 +4,7 @@ from jax import jit
 import jax.numpy as jnp
 from jax.scipy import special
 
+from jaxtronomy.Util.util import shift_center
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 
 __all__ = ["SPP"]
@@ -43,13 +44,12 @@ class SPP(LensProfileBase):
         """
         gamma = SPP._gamma_limit(gamma)
 
-        x_ = x - center_x
-        y_ = y - center_y
+        x, y = shift_center(x, y, center_x, center_y)
         E = theta_E / ((3.0 - gamma) / 2.0) ** (1.0 / (1.0 - gamma))
         # E = phi_E_spp
         eta = -gamma + 3
 
-        p2 = x_**2 + y_**2
+        p2 = x**2 + y**2
         s2 = 0.0  # softening
         return 2 * E**2 / eta**2 * ((p2 + s2) / E**2) ** (eta / 2)
 
@@ -58,45 +58,44 @@ class SPP(LensProfileBase):
     def derivatives(x, y, theta_E, gamma, center_x=0.0, center_y=0.0):
         gamma = SPP._gamma_limit(gamma)
 
-        xt1 = x - center_x
-        xt2 = y - center_y
+        x, y = shift_center(x, y, center_x, center_y)
 
-        r2 = xt1 * xt1 + xt2 * xt2
+        r2 = x**2 + y**2
         a = jnp.maximum(r2, 0.000001)
         r = jnp.sqrt(a)
         alpha = theta_E * (r2 / theta_E**2) ** (1 - gamma / 2.0)
         fac = alpha / r
-        f_x = fac * xt1
-        f_y = fac * xt2
+        f_x = fac * x
+        f_y = fac * y
         return f_x, f_y
 
     @staticmethod
     @jit
     def hessian(x, y, theta_E, gamma, center_x=0.0, center_y=0.0):
         gamma = SPP._gamma_limit(gamma)
-        xt1 = x - center_x
-        xt2 = y - center_y
+
+        x, y = shift_center(x, y, center_x, center_y)
         E = theta_E / ((3.0 - gamma) / 2.0) ** (1.0 / (1.0 - gamma))
         # E = phi_E_spp
         eta = -gamma + 3.0
 
-        P2 = xt1**2 + xt2**2
+        P2 = x**2 + y**2
         a = jnp.where(P2 < 0.000001, 0.000001, P2)
 
         kappa = (
             1.0
             / eta
             * (a / E**2) ** (eta / 2 - 1)
-            * ((eta - 2) * (xt1**2 + xt2**2) / a + (1 + 1))
+            * ((eta - 2) * (x**2 + y**2) / a + (1 + 1))
         )
         gamma1 = (
             1.0
             / eta
             * (a / E**2) ** (eta / 2 - 1)
-            * ((eta / 2 - 1) * (2 * xt1**2 - 2 * xt2**2) / a)
+            * ((eta / 2 - 1) * (2 * x**2 - 2 * y**2) / a)
         )
         gamma2 = (
-            4 * xt1 * xt2 * (1.0 / 2 - 1 / eta) * (a / E**2) ** (eta / 2 - 2) / E**2
+            4 * x * y * (1.0 / 2 - 1 / eta) * (a / E**2) ** (eta / 2 - 2) / E**2
         )
 
         f_xx = kappa + gamma1
@@ -221,9 +220,8 @@ class SPP(LensProfileBase):
         :param center_y:
         :return:
         """
-        x_ = x - center_x
-        y_ = y - center_y
-        r = jnp.sqrt(x_**2 + y_**2)
+        x, y = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x**2 + y**2)
         mass_3d = SPP.mass_3d(r, rho0, gamma)
         pot = mass_3d / r
         return pot
@@ -265,9 +263,8 @@ class SPP(LensProfileBase):
         :param center_y:
         :return:
         """
-        x_ = x - center_x
-        y_ = y - center_y
-        r = jnp.sqrt(x_**2 + y_**2)
+        x, y = shift_center(x, y, center_x, center_y)
+        r = jnp.sqrt(x**2 + y**2)
         sigma = (
             jnp.sqrt(jnp.pi)
             * special.gamma(1.0 / 2 * (-1 + gamma))

--- a/jaxtronomy/LensModel/Profiles/tnfw.py
+++ b/jaxtronomy/LensModel/Profiles/tnfw.py
@@ -3,10 +3,10 @@ __author__ = "sibirrer"
 # this file contains a class to compute the truncated Navaro-Frank-White function (Baltz et al 2009)in mass/kappa space
 # the potential therefore is its integral
 
-from jax import config, jit, numpy as jnp, vmap
+from jax import config, jit, numpy as jnp
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 from jaxtronomy.LensModel.Profiles.nfw import NFW
-from functools import partial
+from jaxtronomy.Util.util import shift_center
 
 config.update("jax_enable_x64", True)
 
@@ -59,9 +59,8 @@ class TNFW(LensProfileBase):
         :return: lensing potential
         """
         rho0_input = TNFW.alpha2rho0(alpha_Rs=alpha_Rs, Rs=Rs)
-        x_ = jnp.array(x - center_x, dtype=float)
-        y_ = jnp.array(y - center_y, dtype=float)
-        R = jnp.sqrt(x_**2 + y_**2)
+        x, y = shift_center(x, y, center_x, center_y)
+        R = jnp.sqrt(x**2 + y**2)
         R = jnp.maximum(R, TNFW._s * Rs)
         f_ = TNFW.tnfw_potential(R, Rs, rho0_input, r_trunc)
 
@@ -83,11 +82,10 @@ class TNFW(LensProfileBase):
         :return: deflection angle in x, deflection angle in y
         """
         rho0_input = TNFW.alpha2rho0(alpha_Rs=alpha_Rs, Rs=Rs)
-        x_ = jnp.array(x - center_x, dtype=float)
-        y_ = jnp.array(y - center_y, dtype=float)
-        R = jnp.sqrt(x_**2 + y_**2)
+        x, y = shift_center(x, y, center_x, center_y)
+        R = jnp.sqrt(x**2 + y**2)
         R = jnp.maximum(R, TNFW._s * Rs)
-        f_x, f_y = TNFW.tnfw_alpha(R, Rs, rho0_input, r_trunc, x_, y_)
+        f_x, f_y = TNFW.tnfw_alpha(R, Rs, rho0_input, r_trunc, x, y)
         return f_x, f_y
 
     @staticmethod
@@ -106,13 +104,12 @@ class TNFW(LensProfileBase):
         """
 
         rho0_input = TNFW.alpha2rho0(alpha_Rs=alpha_Rs, Rs=Rs)
-        x_ = jnp.array(x - center_x, dtype=float)
-        y_ = jnp.array(y - center_y, dtype=float)
-        R = jnp.sqrt(x_**2 + y_**2)
+        x, y = shift_center(x, y, center_x, center_y)
+        R = jnp.sqrt(x**2 + y**2)
         R = jnp.maximum(R, TNFW._s * Rs)
 
-        kappa = TNFW.density_2d(x_, y_, Rs, rho0_input, r_trunc)
-        gamma1, gamma2 = TNFW.tnfw_gamma(R, Rs, rho0_input, r_trunc, x_, y_)
+        kappa = TNFW.density_2d(x, y, Rs, rho0_input, r_trunc)
+        gamma1, gamma2 = TNFW.tnfw_gamma(R, Rs, rho0_input, r_trunc, x, y)
         f_xx = kappa + gamma1
         f_yy = kappa - gamma1
         f_xy = gamma2
@@ -152,9 +149,8 @@ class TNFW(LensProfileBase):
         :type r_trunc: float > 0
         :return: Epsilon(R) projected density at radius R
         """
-        x_ = jnp.array(x - center_x, dtype=float)
-        y_ = jnp.array(y - center_y, dtype=float)
-        R = jnp.sqrt(x_**2 + y_**2)
+        x, y = shift_center(x, y, center_x, center_y)
+        R = jnp.sqrt(x**2 + y**2)
         x = R / Rs
         tau = r_trunc / Rs
         Fx = TNFW._F(x, tau)

--- a/jaxtronomy/LensModel/Profiles/tnfw.py
+++ b/jaxtronomy/LensModel/Profiles/tnfw.py
@@ -59,8 +59,8 @@ class TNFW(LensProfileBase):
         :return: lensing potential
         """
         rho0_input = TNFW.alpha2rho0(alpha_Rs=alpha_Rs, Rs=Rs)
-        x, y = shift_center(x, y, center_x, center_y)
-        R = jnp.sqrt(x**2 + y**2)
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        R = jnp.sqrt(x_**2 + y_**2)
         R = jnp.maximum(R, TNFW._s * Rs)
         f_ = TNFW.tnfw_potential(R, Rs, rho0_input, r_trunc)
 
@@ -82,10 +82,10 @@ class TNFW(LensProfileBase):
         :return: deflection angle in x, deflection angle in y
         """
         rho0_input = TNFW.alpha2rho0(alpha_Rs=alpha_Rs, Rs=Rs)
-        x, y = shift_center(x, y, center_x, center_y)
-        R = jnp.sqrt(x**2 + y**2)
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        R = jnp.sqrt(x_**2 + y_**2)
         R = jnp.maximum(R, TNFW._s * Rs)
-        f_x, f_y = TNFW.tnfw_alpha(R, Rs, rho0_input, r_trunc, x, y)
+        f_x, f_y = TNFW.tnfw_alpha(R, Rs, rho0_input, r_trunc, x_, y_)
         return f_x, f_y
 
     @staticmethod
@@ -104,12 +104,12 @@ class TNFW(LensProfileBase):
         """
 
         rho0_input = TNFW.alpha2rho0(alpha_Rs=alpha_Rs, Rs=Rs)
-        x, y = shift_center(x, y, center_x, center_y)
-        R = jnp.sqrt(x**2 + y**2)
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        R = jnp.sqrt(x_**2 + y_**2)
         R = jnp.maximum(R, TNFW._s * Rs)
 
-        kappa = TNFW.density_2d(x, y, Rs, rho0_input, r_trunc)
-        gamma1, gamma2 = TNFW.tnfw_gamma(R, Rs, rho0_input, r_trunc, x, y)
+        kappa = TNFW.density_2d(x_, y_, Rs, rho0_input, r_trunc)
+        gamma1, gamma2 = TNFW.tnfw_gamma(R, Rs, rho0_input, r_trunc, x_, y_)
         f_xx = kappa + gamma1
         f_yy = kappa - gamma1
         f_xy = gamma2
@@ -149,8 +149,8 @@ class TNFW(LensProfileBase):
         :type r_trunc: float > 0
         :return: Epsilon(R) projected density at radius R
         """
-        x, y = shift_center(x, y, center_x, center_y)
-        R = jnp.sqrt(x**2 + y**2)
+        x_, y_ = shift_center(x, y, center_x, center_y)
+        R = jnp.sqrt(x_**2 + y_**2)
         x = R / Rs
         tau = r_trunc / Rs
         Fx = TNFW._F(x, tau)

--- a/jaxtronomy/LensModel/lens_model.py
+++ b/jaxtronomy/LensModel/lens_model.py
@@ -665,7 +665,7 @@ class LensModel(object):
         """
         x = jnp.asarray(x, dtype=float)
         y = jnp.asarray(y, dtype=float)
-        
+
         alpha_ra_pp, alpha_dec_pp = self.alpha(x + diff / 2, y + diff / 2, kwargs, k=k)
         alpha_ra_pn, alpha_dec_pn = self.alpha(x + diff / 2, y - diff / 2, kwargs, k=k)
 

--- a/jaxtronomy/LensModel/lens_model.py
+++ b/jaxtronomy/LensModel/lens_model.py
@@ -10,7 +10,7 @@ from lenstronomy.Util.cosmo_util import get_astropy_cosmology
 from astropy.cosmology import default_cosmology
 
 from functools import partial
-from jax import jit
+from jax import jit, numpy as jnp
 from warnings import warn
 
 __all__ = ["LensModel"]
@@ -247,6 +247,8 @@ class LensModel(object):
         :type k: None, int, or tuple of ints
         :return: source plane positions corresponding to (x, y) in the image plane
         """
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
         return self.lens_model.ray_shooting(x, y, kwargs, k=k)
 
     @partial(jit, static_argnums=(0))
@@ -267,6 +269,9 @@ class LensModel(object):
         :return: fermat potential in arcsec**2 without geometry term (second part of Eqn
             1 in Suyu et al. 2013) as a list
         """
+        x_image = jnp.asarray(x_image, dtype=float)
+        y_image = jnp.asarray(y_image, dtype=float)
+
         # For SinglePlane
         if hasattr(self.lens_model, "fermat_potential"):
             return self.lens_model.fermat_potential(
@@ -308,6 +313,9 @@ class LensModel(object):
         :param y_source: source position (optional), otherwise computed with ray-tracing
         :return: arrival time of image positions in units of days
         """
+        x_image = jnp.asarray(x_image, dtype=float)
+        y_image = jnp.asarray(y_image, dtype=float)
+
         if hasattr(self.lens_model, "arrival_time"):
             arrival_time = self.lens_model.arrival_time(x_image, y_image, kwargs_lens)
         else:
@@ -336,6 +344,9 @@ class LensModel(object):
         :type k: None, int, or tuple of ints
         :return: lensing potential in units of arcsec^2
         """
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
+
         return self.lens_model.potential(x, y, kwargs, k=k)
 
     @partial(jit, static_argnums=(0, 4))
@@ -356,6 +367,9 @@ class LensModel(object):
             potential is analytically known
         :return: deflection angles in units of arcsec
         """
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
+
         if diff is None:
             return self.lens_model.alpha(x, y, kwargs, k=k)
         elif self.multi_plane is False:
@@ -384,6 +398,9 @@ class LensModel(object):
             differentials are computed from a cross or a square of points around (x, y)
         :return: f_xx, f_xy, f_yx, f_yy components
         """
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
+
         if diff is None:
             return self.lens_model.hessian(x, y, kwargs, k=k)
         elif diff_method == "square":
@@ -414,6 +431,8 @@ class LensModel(object):
             differentials are computed from a cross or a square of points around (x, y)
         :return: lensing convergence
         """
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
 
         f_xx, f_xy, f_yx, f_yy = self.hessian(
             x, y, kwargs, k=k, diff=diff, diff_method=diff_method
@@ -439,6 +458,9 @@ class LensModel(object):
          cross or a square of points around (x, y)
         :return: curl at position (x, y)
         """
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
+
         f_xx, f_xy, f_yx, f_yy = self.hessian(
             x, y, kwargs, k=k, diff=diff, diff_method=diff_method
         )
@@ -464,6 +486,8 @@ class LensModel(object):
          cross or a square of points around (x, y)
         :return: gamma1, gamma2
         """
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
 
         f_xx, f_xy, f_yx, f_yy = self.hessian(
             x, y, kwargs, k=k, diff=diff, diff_method=diff_method
@@ -492,6 +516,8 @@ class LensModel(object):
          cross or a square of points around (x, y)
         :return: magnification
         """
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
 
         f_xx, f_xy, f_yx, f_yy = self.hessian(
             x, y, kwargs, k=k, diff=diff, diff_method=diff_method
@@ -516,6 +542,9 @@ class LensModel(object):
             length of Hessian (optional)
         :return: f_xxx, f_xxy, f_xyy, f_yyy
         """
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
+
         if hessian_diff:
             hessian_diff_ = diff / 4
         else:
@@ -573,6 +602,9 @@ class LensModel(object):
         :param diff: finite differential length
         :return: f_x, f_y
         """
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
+
         phi_dx = self.lens_model.potential(x + diff / 2, y, kwargs=kwargs, k=k)
         phi_dy = self.lens_model.potential(x, y + diff / 2, kwargs=kwargs, k=k)
         phi_dx_ = self.lens_model.potential(x - diff / 2, y, kwargs=kwargs, k=k)
@@ -596,6 +628,9 @@ class LensModel(object):
             used to compute the differential)
         :return: f_xx, f_xy, f_yx, f_yy
         """
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
+
         alpha_ra_dx, alpha_dec_dx = self.alpha(x + diff / 2, y, kwargs, k=k)
         alpha_ra_dy, alpha_dec_dy = self.alpha(x, y + diff / 2, kwargs, k=k)
 
@@ -628,6 +663,9 @@ class LensModel(object):
             used to compute the differential
         :return: f_xx, f_xy, f_yx, f_yy
         """
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
+        
         alpha_ra_pp, alpha_dec_pp = self.alpha(x + diff / 2, y + diff / 2, kwargs, k=k)
         alpha_ra_pn, alpha_dec_pn = self.alpha(x + diff / 2, y - diff / 2, kwargs, k=k)
 

--- a/jaxtronomy/LensModel/lens_model_bulk.py
+++ b/jaxtronomy/LensModel/lens_model_bulk.py
@@ -2,7 +2,7 @@ from jaxtronomy.LensModel.single_plane_bulk import SinglePlaneBulk
 from jaxtronomy.LensModel.MultiPlane.multi_plane_bulk import MultiPlaneBulk
 
 from functools import partial
-from jax import jit
+from jax import jit, numpy as jnp
 
 __all__ = ["LensModelBulk"]
 
@@ -122,4 +122,7 @@ class LensModelBulk(object):
             MultiPlaneBulk.ray_shooting()
         :return: source plane positions corresponding to (x, y) in the image plane
         """
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
+
         return self.lens_model.ray_shooting(x, y, **ray_shooting_kwargs)

--- a/jaxtronomy/LensModel/single_plane.py
+++ b/jaxtronomy/LensModel/single_plane.py
@@ -52,6 +52,8 @@ class SinglePlane(ProfileListBase):
         :type k: None, int, or tuple of ints
         :return: source plane positions corresponding to (x, y) in the image plane
         """
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
 
         dx, dy = self.alpha(x, y, kwargs, k=k)
         return x - dx, y - dy
@@ -73,10 +75,15 @@ class SinglePlane(ProfileListBase):
         :return: fermat potential in arcsec**2 without geometry term (second part of Eqn
             1 in Suyu et al. 2013) as a list
         """
+        x_image = jnp.asarray(x_image, dtype=float)
+        y_image = jnp.asarray(y_image, dtype=float)
 
         potential = self.potential(x_image, y_image, kwargs_lens, k=k)
         if x_source is None or y_source is None:
             x_source, y_source = self.ray_shooting(x_image, y_image, kwargs_lens, k=k)
+        else:
+            x_source = jnp.asarray(x_source, dtype=float)
+            y_source = jnp.asarray(y_source, dtype=float)
         geometry = ((x_image - x_source) ** 2 + (y_image - y_source) ** 2) / 2.0
         return geometry - potential
 
@@ -94,8 +101,8 @@ class SinglePlane(ProfileListBase):
         :type k: None, int, or tuple of ints
         :return: lensing potential in units of arcsec^2
         """
-        x = jnp.array(x, dtype=float)
-        y = jnp.array(y, dtype=float)
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
         if isinstance(k, int):
             return self.func_list[k].function(x, y, **kwargs[k])
         bool_list = self._bool_list(k)
@@ -119,8 +126,8 @@ class SinglePlane(ProfileListBase):
         :type k: None, int, or tuple of ints
         :return: deflection angles in units of arcsec
         """
-        x = jnp.array(x, dtype=float)
-        y = jnp.array(y, dtype=float)
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
 
         if isinstance(k, int):
             return self.func_list[k].derivatives(x, y, **kwargs[k])
@@ -148,8 +155,8 @@ class SinglePlane(ProfileListBase):
         :type k: None, int, or tuple of ints
         :return: f_xx, f_xy, f_yx, f_yy components
         """
-        x = jnp.array(x, dtype=float)
-        y = jnp.array(y, dtype=float)
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
         if isinstance(k, int):
             f_xx, f_xy, f_yx, f_yy = self.func_list[k].hessian(x, y, **kwargs[k])
             return f_xx, f_xy, f_yx, f_yy

--- a/jaxtronomy/LensModel/single_plane_bulk.py
+++ b/jaxtronomy/LensModel/single_plane_bulk.py
@@ -121,6 +121,8 @@ class SinglePlaneBulk(ProfileListBase):
         :param index_list: list of ints, maps each element in lens_model_list to the
             unique_lens_model_list that was provided at class initialization
         """
+        x = jnp.asarray(x, dtype=float)
+        y = jnp.asarray(y, dtype=float)
 
         # This function is called iteratively by jax.lax.map to compute deflection angles for each deflector
         def body_fun(xs):

--- a/jaxtronomy/Util/param_util.py
+++ b/jaxtronomy/Util/param_util.py
@@ -18,9 +18,9 @@ def cart2polar(x, y, center_x=0, center_y=0):
     :type center_y: float
     :returns: array of same size with coords [r,phi]
     """
-    x, y = shift_center(x, y, center_x, center_y)
-    r = jnp.sqrt(x**2 + y**2)
-    phi = jnp.arctan2(y, x)
+    coord_shift_x, coord_shift_y = shift_center(x, y, center_x, center_y)
+    r = jnp.sqrt(coord_shift_x**2 + coord_shift_y**2)
+    phi = jnp.arctan2(coord_shift_y, coord_shift_x)
     return r, phi
 
 
@@ -115,10 +115,12 @@ def transform_e1e2_product_average(x, y, e1, e2, center_x, center_y):
     :param center_y: center of distortion
     :return: distorted coordinates x', y'
     """
-    x, y = shift_center(x, y, center_x, center_y)
+    x_shift, y_shift = shift_center(x, y, center_x, center_y)
 
     norm = jnp.maximum(jnp.sqrt(jnp.abs(1 - e1**2 - e2**2)), 0.000001)
-    return ((1 - e1) * x - e2 * y) / norm, (-e2 * x + (1 + e1) * y) / norm
+    x_ = ((1 - e1) * x_shift - e2 * y_shift) / norm
+    y_ = (-e2 * x_shift + (1 + e1) * y_shift) / norm
+    return x_, y_
 
 
 @jit
@@ -135,13 +137,13 @@ def transform_e1e2_square_average(x, y, e1, e2, center_x, center_y):
     :return: distorted coordinates x', y'
     """
     phi_g, q = ellipticity2phi_q(e1, e2)
-    x, y = shift_center(x, y, center_x, center_y)
+    x_shift, y_shift = shift_center(x, y, center_x, center_y)
     cos_phi = jnp.cos(phi_g)
     sin_phi = jnp.sin(phi_g)
     e = q2e(q)
-    x = (cos_phi * x + sin_phi * y) * jnp.sqrt(1 - e)
-    y = (-sin_phi * x + cos_phi * y) * jnp.sqrt(1 + e)
-    return x, y
+    x_ = (cos_phi * x_shift + sin_phi * y_shift) * jnp.sqrt(1 - e)
+    y_ = (-sin_phi * x_shift + cos_phi * y_shift) * jnp.sqrt(1 + e)
+    return x_, y_
 
 
 @jit

--- a/jaxtronomy/Util/param_util.py
+++ b/jaxtronomy/Util/param_util.py
@@ -1,5 +1,6 @@
 import jax.numpy as jnp
 from jax import jit
+from jaxtronomy.Util.util import shift_center
 
 
 @jit
@@ -17,10 +18,9 @@ def cart2polar(x, y, center_x=0, center_y=0):
     :type center_y: float
     :returns: array of same size with coords [r,phi]
     """
-    coord_shift_x = x - center_x
-    coord_shift_y = y - center_y
-    r = jnp.sqrt(coord_shift_x**2 + coord_shift_y**2)
-    phi = jnp.arctan2(coord_shift_y, coord_shift_x)
+    x, y = shift_center(x, y, center_x, center_y)
+    r = jnp.sqrt(x**2 + y**2)
+    phi = jnp.arctan2(y, x)
     return r, phi
 
 
@@ -38,6 +38,8 @@ def polar2cart(r, phi, center):
     :returns: array of same size with coords [x,y]
     :raises: AttributeError, KeyError
     """
+    r = jnp.asarray(r, dtype=float)
+    phi = jnp.asarray(phi, dtype=float)
     x = r * jnp.cos(phi)
     y = r * jnp.sin(phi)
     return x - center[0], y - center[1]
@@ -113,13 +115,12 @@ def transform_e1e2_product_average(x, y, e1, e2, center_x, center_y):
     :param center_y: center of distortion
     :return: distorted coordinates x', y'
     """
-    x_shift = x - center_x
-    y_shift = y - center_y
+    x, y = shift_center(x, y, center_x, center_y)
 
     norm = jnp.maximum(jnp.sqrt(jnp.abs(1 - e1**2 - e2**2)), 0.000001)
-    x_ = ((1 - e1) * x_shift - e2 * y_shift) / norm
-    y_ = (-e2 * x_shift + (1 + e1) * y_shift) / norm
-    return x_, y_
+    x = ((1 - e1) * x - e2 * y) / norm
+    y = (-e2 * x + (1 + e1) * y) / norm
+    return x, y
 
 
 @jit
@@ -136,14 +137,13 @@ def transform_e1e2_square_average(x, y, e1, e2, center_x, center_y):
     :return: distorted coordinates x', y'
     """
     phi_g, q = ellipticity2phi_q(e1, e2)
-    x_shift = x - center_x
-    y_shift = y - center_y
+    x, y = shift_center(x, y, center_x, center_y)
     cos_phi = jnp.cos(phi_g)
     sin_phi = jnp.sin(phi_g)
     e = q2e(q)
-    x_ = (cos_phi * x_shift + sin_phi * y_shift) * jnp.sqrt(1 - e)
-    y_ = (-sin_phi * x_shift + cos_phi * y_shift) * jnp.sqrt(1 + e)
-    return x_, y_
+    x = (cos_phi * x + sin_phi * y) * jnp.sqrt(1 - e)
+    y = (-sin_phi * x + cos_phi * y) * jnp.sqrt(1 + e)
+    return x, y
 
 
 @jit

--- a/jaxtronomy/Util/param_util.py
+++ b/jaxtronomy/Util/param_util.py
@@ -118,9 +118,7 @@ def transform_e1e2_product_average(x, y, e1, e2, center_x, center_y):
     x, y = shift_center(x, y, center_x, center_y)
 
     norm = jnp.maximum(jnp.sqrt(jnp.abs(1 - e1**2 - e2**2)), 0.000001)
-    x = ((1 - e1) * x - e2 * y) / norm
-    y = (-e2 * x + (1 + e1) * y) / norm
-    return x, y
+    return ((1 - e1) * x - e2 * y) / norm, (-e2 * x + (1 + e1) * y) / norm
 
 
 @jit

--- a/jaxtronomy/Util/util.py
+++ b/jaxtronomy/Util/util.py
@@ -122,3 +122,17 @@ def sigma2fwhm(sigma):
     """
     fwhm = sigma * (2 * jnp.sqrt(2 * jnp.log(2)))
     return fwhm
+
+@jit
+def shift_center(x, y, center_x=0, center_y=0):
+    """Converts the x and y coordinates to JAX arrays and shifts them so that
+    the origin is at the center.
+
+    :param x: x coordinate
+    :param y: y coordinate
+    :param center_x: x coordinate of center
+    :param center_y: y coordinate of center
+    """
+    x = jnp.asarray(x, dtype=float)
+    y = jnp.asarray(y, dtype=float)
+    return x - center_x, y - center_y

--- a/jaxtronomy/Util/util.py
+++ b/jaxtronomy/Util/util.py
@@ -123,10 +123,11 @@ def sigma2fwhm(sigma):
     fwhm = sigma * (2 * jnp.sqrt(2 * jnp.log(2)))
     return fwhm
 
+
 @jit
 def shift_center(x, y, center_x=0, center_y=0):
-    """Converts the x and y coordinates to JAX arrays and shifts them so that
-    the origin is at the center.
+    """Converts the x and y coordinates to JAX arrays and shifts them so that the origin
+    is at the center.
 
     :param x: x coordinate
     :param y: y coordinate

--- a/test/test_LensModel/test_Profiles/test_convergence.py
+++ b/test/test_LensModel/test_Profiles/test_convergence.py
@@ -14,11 +14,11 @@ class TestConvergence(object):
 
     def setup_method(self):
         self.convergence_ref = Convergence_ref()
-        self.kwargs_lens = {"kappa": 0.1}
+        self.kwargs_lens = {"kappa": 0.1, "ra_0": 0.5, "dec_0": 3}
 
     def test_function(self):
-        x = np.array([1])
-        y = np.array([0])
+        x = np.array([0.5])
+        y = np.array([3])
         values = Convergence.function(x, y, **self.kwargs_lens)
         values_ref = self.convergence_ref.function(x, y, **self.kwargs_lens)
         npt.assert_array_almost_equal(values, values_ref, decimal=7)
@@ -35,8 +35,8 @@ class TestConvergence(object):
         npt.assert_array_almost_equal(values, values_ref, decimal=7)
 
     def test_derivatives(self):
-        x = np.array([1])
-        y = np.array([2])
+        x = np.array([0.5])
+        y = np.array([3])
         f_x, f_y = Convergence.derivatives(x, y, **self.kwargs_lens)
         f_x_ref, f_y_ref = self.convergence_ref.derivatives(x, y, **self.kwargs_lens)
         npt.assert_almost_equal(f_x, f_x_ref, decimal=7)
@@ -50,8 +50,8 @@ class TestConvergence(object):
         npt.assert_almost_equal(f_y, f_y_ref, decimal=7)
 
     def test_hessian(self):
-        x = np.array([1])
-        y = np.array([2])
+        x = np.array([0.5])
+        y = np.array([3])
         f_xx, f_xy, f_yx, f_yy = Convergence.hessian(x, y, **self.kwargs_lens)
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.convergence_ref.hessian(
             x, y, **self.kwargs_lens

--- a/test/test_LensModel/test_Profiles/test_cored_steep_ellipsoid.py
+++ b/test/test_LensModel/test_Profiles/test_cored_steep_ellipsoid.py
@@ -31,18 +31,18 @@ class TestCSE_product_avg(object):
         npt.assert_raises(ValueError, CSE, axis="not_available")
 
     def test_function(self):
-        kwargs = {"a": 2, "s": 1, "e1": 0.1, "e2": -0.3, "center_x": 0, "center_y": 0}
+        kwargs = {"a": 2, "s": 1, "e1": 0.1, "e2": -0.3, "center_x": 2, "center_y": 3}
 
-        x = np.array([1.0, 2.0])
+        x = np.array([1.0, 0])
         y = np.array([2.0, 0])
         f_ = self.CSE.function(x, y, **kwargs)
         f_ref = self.CSE_ref.function(x, y, **kwargs)
         npt.assert_array_almost_equal(f_, f_ref, decimal=8)
 
     def test_derivatives(self):
-        kwargs = {"a": 2, "s": 1, "e1": 0.0, "e2": 0.0, "center_x": 0, "center_y": 0}
+        kwargs = {"a": 2, "s": 1, "e1": 0.3, "e2": 0.1, "center_x": 2, "center_y": 3}
 
-        x = np.array([1.0, 2.0])
+        x = np.array([1.0, 0])
         y = np.array([2.0, 0])
         f_x, f_y = self.CSE.derivatives(x, y, **kwargs)
         f_x_ref, f_y_ref = self.CSE_ref.derivatives(x, y, **kwargs)
@@ -50,10 +50,10 @@ class TestCSE_product_avg(object):
         npt.assert_almost_equal(f_y, f_y_ref, decimal=8)
 
     def test_hessian(self):
-        kwargs = {"a": 2, "s": 1, "e1": 0.0, "e2": 0.0, "center_x": 0, "center_y": 0}
+        kwargs = {"a": 2, "s": 1, "e1": 0.2, "e2": 0.1, "center_x": 2, "center_y": 3}
 
-        x = np.array([1.0, 2.0])
-        y = np.array([2.3, 0.5])
+        x = np.array([1.0, 0])
+        y = np.array([2.3, 0])
         f_xx, f_xy, f_yx, f_yy = self.CSE.hessian(x, y, **kwargs)
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.CSE_ref.hessian(x, y, **kwargs)
         npt.assert_almost_equal(f_xy, f_xy_ref, decimal=8)
@@ -76,7 +76,7 @@ class TestCSE_product_avg_set(object):
             "q": 0.3,
         }
 
-        x = np.array([1.0, 2.0])
+        x = np.array([1.0, 0])
         y = np.array([2.0, 0])
         f_ = CSEProductAvgSet.function(x, y, **kwargs)
         f_ref = self.CSEProductAvgSet_ref.function(x, y, **kwargs)
@@ -89,7 +89,7 @@ class TestCSE_product_avg_set(object):
             "q": 0.3,
         }
 
-        x = np.array([1.0, 2.0])
+        x = np.array([1.0, 0])
         y = np.array([2.0, 0])
         f_x, f_y = CSEProductAvgSet.derivatives(x, y, **kwargs)
         f_x_ref, f_y_ref = self.CSEProductAvgSet_ref.derivatives(x, y, **kwargs)
@@ -103,8 +103,8 @@ class TestCSE_product_avg_set(object):
             "q": 0.3,
         }
 
-        x = np.array([1.0, 2.0])
-        y = np.array([2.3, 0.5])
+        x = np.array([1.0, 0])
+        y = np.array([2.3, 0])
         f_xx, f_xy, f_yx, f_yy = CSEProductAvgSet.hessian(x, y, **kwargs)
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.CSEProductAvgSet_ref.hessian(
             x, y, **kwargs
@@ -126,7 +126,7 @@ class TestCSE_major(object):
     def test_function(self):
         kwargs = {"a": 2, "s": 1, "e1": 0.1, "e2": -0.3, "center_x": 0, "center_y": 0}
 
-        x = np.array([1.0, 2.0])
+        x = np.array([1.0, 0])
         y = np.array([2.0, 0])
         f_ = self.CSE.function(x, y, **kwargs)
         f_ref = self.CSE_ref.function(x, y, **kwargs)
@@ -135,7 +135,7 @@ class TestCSE_major(object):
     def test_derivatives(self):
         kwargs = {"a": 2, "s": 1, "e1": 0.0, "e2": 0.0, "center_x": 0, "center_y": 0}
 
-        x = np.array([1.0, 2.0])
+        x = np.array([1.0, 0])
         y = np.array([2.0, 0])
         f_x, f_y = self.CSE.derivatives(x, y, **kwargs)
         f_x_ref, f_y_ref = self.CSE_ref.derivatives(x, y, **kwargs)
@@ -145,8 +145,8 @@ class TestCSE_major(object):
     def test_hessian(self):
         kwargs = {"a": 2, "s": 1, "e1": 0.0, "e2": 0.0, "center_x": 0, "center_y": 0}
 
-        x = np.array([1.0, 2.0])
-        y = np.array([2.3, 0.5])
+        x = np.array([1.0, 0])
+        y = np.array([2.3, 0])
         f_xx, f_xy, f_yx, f_yy = self.CSE.hessian(x, y, **kwargs)
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.CSE_ref.hessian(x, y, **kwargs)
         npt.assert_almost_equal(f_xy, f_xy_ref, decimal=8)
@@ -169,7 +169,7 @@ class TestCSE_major_set(object):
             "q": 0.3,
         }
 
-        x = np.array([1.0, 2.0])
+        x = np.array([1.0, 0])
         y = np.array([2.0, 0])
         f_ = CSEMajorAxisSet.function(x, y, **kwargs)
         f_ref = self.CSEMajorAxisSet_ref.function(x, y, **kwargs)
@@ -182,7 +182,7 @@ class TestCSE_major_set(object):
             "q": 0.3,
         }
 
-        x = np.array([1.0, 2.0])
+        x = np.array([1.0, 0])
         y = np.array([2.0, 0])
         f_x, f_y = CSEMajorAxisSet.derivatives(x, y, **kwargs)
         f_x_ref, f_y_ref = self.CSEMajorAxisSet_ref.derivatives(x, y, **kwargs)
@@ -196,9 +196,7 @@ class TestCSE_major_set(object):
             "q": 0.3,
         }
 
-        # NOTE: If x and y are made to be integers, the tests fails due to a bug with lenstronomy.
-        #       Change the test when the bug in lenstronomy is fixed
-        x = np.array([1.0, 2.0])
+        x = np.array([1.0, 0])
         y = np.array([2.0, 0])
         f_xx, f_xy, f_yx, f_yy = CSEMajorAxisSet.hessian(x, y, **kwargs)
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.CSEMajorAxisSet_ref.hessian(

--- a/test/test_LensModel/test_Profiles/test_epl.py
+++ b/test/test_LensModel/test_Profiles/test_epl.py
@@ -82,14 +82,22 @@ class TestEPL(object):
         y = np.array([2])
         theta_E = 12.3
         gamma, e1, e2 = 1.7, 0.3, -0.2
-        values = self.profile.function(x, y, theta_E, gamma, e1, e2, **self.center_kwargs)
-        values_ref = self.profile_ref.function(x, y, theta_E, gamma, e1, e2, **self.center_kwargs)
+        values = self.profile.function(
+            x, y, theta_E, gamma, e1, e2, **self.center_kwargs
+        )
+        values_ref = self.profile_ref.function(
+            x, y, theta_E, gamma, e1, e2, **self.center_kwargs
+        )
         npt.assert_allclose(values, values_ref, atol=1e-12, rtol=1e-12)
 
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])
-        values = self.profile.function(x, y, theta_E, gamma, e1, e2, **self.center_kwargs)
-        values_ref = self.profile_ref.function(x, y, theta_E, gamma, e1, e2, **self.center_kwargs)
+        values = self.profile.function(
+            x, y, theta_E, gamma, e1, e2, **self.center_kwargs
+        )
+        values_ref = self.profile_ref.function(
+            x, y, theta_E, gamma, e1, e2, **self.center_kwargs
+        )
         npt.assert_allclose(values, values_ref, atol=1e-12, rtol=1e-12)
 
     def test_derivatives(self):
@@ -97,15 +105,23 @@ class TestEPL(object):
         y = np.array([2])
         theta_E = 1.0
         gamma, e1, e2 = 1.7, -0.1, 0.2
-        f_x, f_y = self.profile.derivatives(x, y, theta_E, gamma, e1, e2, **self.center_kwargs)
-        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, theta_E, gamma, e1, e2, **self.center_kwargs)
+        f_x, f_y = self.profile.derivatives(
+            x, y, theta_E, gamma, e1, e2, **self.center_kwargs
+        )
+        f_x_ref, f_y_ref = self.profile_ref.derivatives(
+            x, y, theta_E, gamma, e1, e2, **self.center_kwargs
+        )
         npt.assert_allclose(f_x, f_x_ref, atol=1e-12, rtol=1e-12)
         npt.assert_allclose(f_y, f_y_ref, atol=1e-12, rtol=1e-12)
 
         x = np.array([1, 3, 4])
         y = np.array([2, 1, 1])
-        f_x, f_y = self.profile.derivatives(x, y, theta_E, gamma, e1, e2, **self.center_kwargs)
-        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, theta_E, gamma, e1, e2, **self.center_kwargs)
+        f_x, f_y = self.profile.derivatives(
+            x, y, theta_E, gamma, e1, e2, **self.center_kwargs
+        )
+        f_x_ref, f_y_ref = self.profile_ref.derivatives(
+            x, y, theta_E, gamma, e1, e2, **self.center_kwargs
+        )
         npt.assert_allclose(f_x, f_x_ref, atol=1e-12, rtol=1e-12)
         npt.assert_allclose(f_y, f_y_ref, atol=1e-12, rtol=1e-12)
 
@@ -114,7 +130,9 @@ class TestEPL(object):
         y = np.array([2])
         theta_E = 1.0
         gamma, e1, e2 = 2.2, 0.1, -0.4
-        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, theta_E, gamma, e1, e2, **self.center_kwargs)
+        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(
+            x, y, theta_E, gamma, e1, e2, **self.center_kwargs
+        )
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
             x, y, theta_E, gamma, e1, e2, **self.center_kwargs
         )
@@ -125,7 +143,9 @@ class TestEPL(object):
 
         x = np.array([1, 3, 4])
         y = np.array([2, 1, 1])
-        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, theta_E, gamma, e1, e2, **self.center_kwargs)
+        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(
+            x, y, theta_E, gamma, e1, e2, **self.center_kwargs
+        )
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
             x, y, theta_E, gamma, e1, e2, **self.center_kwargs
         )
@@ -221,14 +241,22 @@ class TestEPLQPhi(object):
         y = np.array([2])
         theta_E = 12.3
         gamma, q, phi = 1.7, 0.3, -2.2
-        values = self.profile.function(x, y, theta_E, gamma, q, phi, **self.center_kwargs)
-        values_ref = self.profile_ref.function(x, y, theta_E, gamma, q, phi, **self.center_kwargs)
+        values = self.profile.function(
+            x, y, theta_E, gamma, q, phi, **self.center_kwargs
+        )
+        values_ref = self.profile_ref.function(
+            x, y, theta_E, gamma, q, phi, **self.center_kwargs
+        )
         npt.assert_allclose(values, values_ref, atol=1e-12, rtol=1e-12)
 
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])
-        values = self.profile.function(x, y, theta_E, gamma, q, phi, **self.center_kwargs)
-        values_ref = self.profile_ref.function(x, y, theta_E, gamma, q, phi, **self.center_kwargs)
+        values = self.profile.function(
+            x, y, theta_E, gamma, q, phi, **self.center_kwargs
+        )
+        values_ref = self.profile_ref.function(
+            x, y, theta_E, gamma, q, phi, **self.center_kwargs
+        )
         npt.assert_allclose(values, values_ref, atol=1e-12, rtol=1e-12)
 
     def test_derivatives(self):
@@ -236,15 +264,23 @@ class TestEPLQPhi(object):
         y = np.array([2])
         theta_E = 1.0
         gamma, q, phi = 1.7, 0.7, 2.2
-        f_x, f_y = self.profile.derivatives(x, y, theta_E, gamma, q, phi, **self.center_kwargs)
-        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, theta_E, gamma, q, phi, **self.center_kwargs)
+        f_x, f_y = self.profile.derivatives(
+            x, y, theta_E, gamma, q, phi, **self.center_kwargs
+        )
+        f_x_ref, f_y_ref = self.profile_ref.derivatives(
+            x, y, theta_E, gamma, q, phi, **self.center_kwargs
+        )
         npt.assert_allclose(f_x, f_x_ref, atol=1e-12, rtol=1e-12)
         npt.assert_allclose(f_y, f_y_ref, atol=1e-12, rtol=1e-12)
 
         x = np.array([1, 3, 4])
         y = np.array([2, 1, 1])
-        f_x, f_y = self.profile.derivatives(x, y, theta_E, gamma, q, phi, **self.center_kwargs)
-        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, theta_E, gamma, q, phi, **self.center_kwargs)
+        f_x, f_y = self.profile.derivatives(
+            x, y, theta_E, gamma, q, phi, **self.center_kwargs
+        )
+        f_x_ref, f_y_ref = self.profile_ref.derivatives(
+            x, y, theta_E, gamma, q, phi, **self.center_kwargs
+        )
         npt.assert_allclose(f_x, f_x_ref, atol=1e-12, rtol=1e-12)
         npt.assert_allclose(f_y, f_y_ref, atol=1e-12, rtol=1e-12)
 
@@ -253,7 +289,9 @@ class TestEPLQPhi(object):
         y = np.array([2])
         theta_E = 1.0
         gamma, q, phi = 2.2, 0.4, 1.4
-        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, theta_E, gamma, q, phi, **self.center_kwargs)
+        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(
+            x, y, theta_E, gamma, q, phi, **self.center_kwargs
+        )
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
             x, y, theta_E, gamma, q, phi, **self.center_kwargs
         )
@@ -264,7 +302,9 @@ class TestEPLQPhi(object):
 
         x = np.array([1, 3, 4])
         y = np.array([2, 1, 1])
-        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, theta_E, gamma, q, phi, **self.center_kwargs)
+        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(
+            x, y, theta_E, gamma, q, phi, **self.center_kwargs
+        )
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
             x, y, theta_E, gamma, q, phi, **self.center_kwargs
         )

--- a/test/test_LensModel/test_Profiles/test_epl.py
+++ b/test/test_LensModel/test_Profiles/test_epl.py
@@ -19,6 +19,7 @@ class TestEPL(object):
     def setup_method(self):
         self.profile = EPL()
         self.profile_ref = EPL_ref()
+        self.center_kwargs = {"center_x": 1, "center_y": 2}
 
     def test_param_conv(self):
         theta_E = 12.3
@@ -81,14 +82,14 @@ class TestEPL(object):
         y = np.array([2])
         theta_E = 12.3
         gamma, e1, e2 = 1.7, 0.3, -0.2
-        values = self.profile.function(x, y, theta_E, gamma, e1, e2)
-        values_ref = self.profile_ref.function(x, y, theta_E, gamma, e1, e2)
+        values = self.profile.function(x, y, theta_E, gamma, e1, e2, **self.center_kwargs)
+        values_ref = self.profile_ref.function(x, y, theta_E, gamma, e1, e2, **self.center_kwargs)
         npt.assert_allclose(values, values_ref, atol=1e-12, rtol=1e-12)
 
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])
-        values = self.profile.function(x, y, theta_E, gamma, e1, e2)
-        values_ref = self.profile_ref.function(x, y, theta_E, gamma, e1, e2)
+        values = self.profile.function(x, y, theta_E, gamma, e1, e2, **self.center_kwargs)
+        values_ref = self.profile_ref.function(x, y, theta_E, gamma, e1, e2, **self.center_kwargs)
         npt.assert_allclose(values, values_ref, atol=1e-12, rtol=1e-12)
 
     def test_derivatives(self):
@@ -96,15 +97,15 @@ class TestEPL(object):
         y = np.array([2])
         theta_E = 1.0
         gamma, e1, e2 = 1.7, -0.1, 0.2
-        f_x, f_y = self.profile.derivatives(x, y, theta_E, gamma, e1, e2)
-        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, theta_E, gamma, e1, e2)
+        f_x, f_y = self.profile.derivatives(x, y, theta_E, gamma, e1, e2, **self.center_kwargs)
+        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, theta_E, gamma, e1, e2, **self.center_kwargs)
         npt.assert_allclose(f_x, f_x_ref, atol=1e-12, rtol=1e-12)
         npt.assert_allclose(f_y, f_y_ref, atol=1e-12, rtol=1e-12)
 
         x = np.array([1, 3, 4])
         y = np.array([2, 1, 1])
-        f_x, f_y = self.profile.derivatives(x, y, theta_E, gamma, e1, e2)
-        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, theta_E, gamma, e1, e2)
+        f_x, f_y = self.profile.derivatives(x, y, theta_E, gamma, e1, e2, **self.center_kwargs)
+        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, theta_E, gamma, e1, e2, **self.center_kwargs)
         npt.assert_allclose(f_x, f_x_ref, atol=1e-12, rtol=1e-12)
         npt.assert_allclose(f_y, f_y_ref, atol=1e-12, rtol=1e-12)
 
@@ -113,9 +114,9 @@ class TestEPL(object):
         y = np.array([2])
         theta_E = 1.0
         gamma, e1, e2 = 2.2, 0.1, -0.4
-        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, theta_E, gamma, e1, e2)
+        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, theta_E, gamma, e1, e2, **self.center_kwargs)
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
-            x, y, theta_E, gamma, e1, e2
+            x, y, theta_E, gamma, e1, e2, **self.center_kwargs
         )
         npt.assert_allclose(f_xx, f_xx_ref, atol=1e-12, rtol=1e-12)
         npt.assert_allclose(f_xy, f_xy_ref, atol=1e-12, rtol=1e-12)
@@ -124,9 +125,9 @@ class TestEPL(object):
 
         x = np.array([1, 3, 4])
         y = np.array([2, 1, 1])
-        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, theta_E, gamma, e1, e2)
+        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, theta_E, gamma, e1, e2, **self.center_kwargs)
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
-            x, y, theta_E, gamma, e1, e2
+            x, y, theta_E, gamma, e1, e2, **self.center_kwargs
         )
         npt.assert_allclose(f_xx, f_xx_ref, atol=1e-12, rtol=1e-12)
         npt.assert_allclose(f_xy, f_xy_ref, atol=1e-12, rtol=1e-12)
@@ -213,20 +214,21 @@ class TestEPLQPhi(object):
     def setup_method(self):
         self.profile = EPLQPhi()
         self.profile_ref = EPLQPhi_ref()
+        self.center_kwargs = {"center_x": 0.3, "center_y": 0.5}
 
     def test_function(self):
         x = np.array([1])
         y = np.array([2])
         theta_E = 12.3
         gamma, q, phi = 1.7, 0.3, -2.2
-        values = self.profile.function(x, y, theta_E, gamma, q, phi)
-        values_ref = self.profile_ref.function(x, y, theta_E, gamma, q, phi)
+        values = self.profile.function(x, y, theta_E, gamma, q, phi, **self.center_kwargs)
+        values_ref = self.profile_ref.function(x, y, theta_E, gamma, q, phi, **self.center_kwargs)
         npt.assert_allclose(values, values_ref, atol=1e-12, rtol=1e-12)
 
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])
-        values = self.profile.function(x, y, theta_E, gamma, q, phi)
-        values_ref = self.profile_ref.function(x, y, theta_E, gamma, q, phi)
+        values = self.profile.function(x, y, theta_E, gamma, q, phi, **self.center_kwargs)
+        values_ref = self.profile_ref.function(x, y, theta_E, gamma, q, phi, **self.center_kwargs)
         npt.assert_allclose(values, values_ref, atol=1e-12, rtol=1e-12)
 
     def test_derivatives(self):
@@ -234,15 +236,15 @@ class TestEPLQPhi(object):
         y = np.array([2])
         theta_E = 1.0
         gamma, q, phi = 1.7, 0.7, 2.2
-        f_x, f_y = self.profile.derivatives(x, y, theta_E, gamma, q, phi)
-        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, theta_E, gamma, q, phi)
+        f_x, f_y = self.profile.derivatives(x, y, theta_E, gamma, q, phi, **self.center_kwargs)
+        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, theta_E, gamma, q, phi, **self.center_kwargs)
         npt.assert_allclose(f_x, f_x_ref, atol=1e-12, rtol=1e-12)
         npt.assert_allclose(f_y, f_y_ref, atol=1e-12, rtol=1e-12)
 
         x = np.array([1, 3, 4])
         y = np.array([2, 1, 1])
-        f_x, f_y = self.profile.derivatives(x, y, theta_E, gamma, q, phi)
-        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, theta_E, gamma, q, phi)
+        f_x, f_y = self.profile.derivatives(x, y, theta_E, gamma, q, phi, **self.center_kwargs)
+        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, theta_E, gamma, q, phi, **self.center_kwargs)
         npt.assert_allclose(f_x, f_x_ref, atol=1e-12, rtol=1e-12)
         npt.assert_allclose(f_y, f_y_ref, atol=1e-12, rtol=1e-12)
 
@@ -251,9 +253,9 @@ class TestEPLQPhi(object):
         y = np.array([2])
         theta_E = 1.0
         gamma, q, phi = 2.2, 0.4, 1.4
-        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, theta_E, gamma, q, phi)
+        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, theta_E, gamma, q, phi, **self.center_kwargs)
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
-            x, y, theta_E, gamma, q, phi
+            x, y, theta_E, gamma, q, phi, **self.center_kwargs
         )
         npt.assert_allclose(f_xx, f_xx_ref, atol=1e-12, rtol=1e-12)
         npt.assert_allclose(f_xy, f_xy_ref, atol=1e-12, rtol=1e-12)
@@ -262,9 +264,9 @@ class TestEPLQPhi(object):
 
         x = np.array([1, 3, 4])
         y = np.array([2, 1, 1])
-        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, theta_E, gamma, q, phi)
+        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, theta_E, gamma, q, phi, **self.center_kwargs)
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
-            x, y, theta_E, gamma, q, phi
+            x, y, theta_E, gamma, q, phi, **self.center_kwargs
         )
         npt.assert_allclose(f_xx, f_xx_ref, atol=1e-12, rtol=1e-12)
         npt.assert_allclose(f_xy, f_xy_ref, atol=1e-12, rtol=1e-12)

--- a/test/test_LensModel/test_Profiles/test_flexion.py
+++ b/test/test_LensModel/test_Profiles/test_flexion.py
@@ -20,6 +20,8 @@ class TestFlexion(object):
             "g2": -0.04,
             "g3": 0.07,
             "g4": -0.01,
+            "ra_0": 1,
+            "dec_0": 2,
         }
 
     def test_function(self):
@@ -38,7 +40,7 @@ class TestFlexion(object):
         y = np.repeat(np.linspace(-10, 10, 20), 20)
         values = Flexion.function(x, y, **self.kwargs_lens)
         values_ref = self.flexion_ref.function(x, y, **self.kwargs_lens)
-        npt.assert_allclose(values, values_ref, atol=1e-15, rtol=1e-15)
+        npt.assert_allclose(values, values_ref, atol=2e-15, rtol=2e-15)
 
     def test_derivatives(self):
         x = np.array([1])

--- a/test/test_LensModel/test_Profiles/test_gaussian.py
+++ b/test/test_LensModel/test_Profiles/test_gaussian.py
@@ -20,14 +20,15 @@ class TestGaussian(object):
     def setup_method(self):
         self.profile_ref = Gaussian_ref()
         self.profile = Gaussian()
+        self.center_kwargs = {"center_x": 1.0, "center_y": 1.3}
 
     def test_function(self):
         x = np.array([1])
         y = np.array([2])
         amp = 1.3
         sigma = 0.5
-        values_ref = self.profile_ref.function(x, y, amp, sigma)
-        values = self.profile.function(x, y, amp, sigma)
+        values_ref = self.profile_ref.function(x, y, amp, sigma, **self.center_kwargs)
+        values = self.profile.function(x, y, amp, sigma, **self.center_kwargs)
         npt.assert_array_almost_equal(values_ref, values, decimal=4)
 
         x = np.array([0])
@@ -40,8 +41,8 @@ class TestGaussian(object):
 
         x = np.array([2.0, 3.0, 4.0])
         y = np.array([1.0, 1.0, 1.0])
-        values_ref = self.profile_ref.function(x, y, amp, sigma)
-        values = self.profile.function(x, y, amp, sigma)
+        values_ref = self.profile_ref.function(x, y, amp, sigma, **self.center_kwargs)
+        values = self.profile.function(x, y, amp, sigma, **self.center_kwargs)
         npt.assert_almost_equal(values_ref, values, decimal=4)
 
     def test_derivatives(self):
@@ -49,8 +50,8 @@ class TestGaussian(object):
         y = np.array([2])
         amp = 1.3
         sigma = 0.5
-        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, amp, sigma)
-        f_x, f_y = self.profile.derivatives(x, y, amp, sigma)
+        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, amp, sigma, **self.center_kwargs)
+        f_x, f_y = self.profile.derivatives(x, y, amp, sigma, **self.center_kwargs)
         npt.assert_array_almost_equal(f_x_ref, f_x, decimal=6)
         npt.assert_array_almost_equal(f_y_ref, f_y, decimal=6)
         # NOTE: This test fails with 32 bit floats
@@ -65,8 +66,8 @@ class TestGaussian(object):
 
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])
-        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, amp, sigma)
-        f_x, f_y = self.profile.derivatives(x, y, amp, sigma)
+        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, amp, sigma, **self.center_kwargs)
+        f_x, f_y = self.profile.derivatives(x, y, amp, sigma, **self.center_kwargs)
         npt.assert_array_almost_equal(f_x_ref, f_x, decimal=6)
         npt.assert_array_almost_equal(f_y_ref, f_y, decimal=6)
 
@@ -76,9 +77,9 @@ class TestGaussian(object):
         amp = 1.3
         sigma = 0.5
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
-            x, y, amp, sigma
+            x, y, amp, sigma, **self.center_kwargs
         )
-        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, amp, sigma)
+        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, amp, sigma, **self.center_kwargs)
         npt.assert_array_almost_equal(f_xx_ref, f_xx, decimal=6)
         npt.assert_array_almost_equal(f_xy_ref, f_xy, decimal=6)
         npt.assert_array_almost_equal(f_yx_ref, f_yx, decimal=6)
@@ -98,9 +99,9 @@ class TestGaussian(object):
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
-            x, y, amp, sigma
+            x, y, amp, sigma, **self.center_kwargs
         )
-        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, amp, sigma)
+        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, amp, sigma, **self.center_kwargs)
         npt.assert_array_almost_equal(f_xx_ref, f_xx, decimal=6)
         npt.assert_array_almost_equal(f_xy_ref, f_xy, decimal=6)
         npt.assert_array_almost_equal(f_yx_ref, f_yx, decimal=6)
@@ -119,8 +120,8 @@ class TestGaussian(object):
         y = np.array([0, 1.3, 2.1, 3.2, 5.2])
         amp = 1.7
         sigma = 0.4
-        density = self.profile.density_2d(x, y, amp, sigma)
-        density_ref = self.profile_ref.density_2d(x, y, amp, sigma)
+        density = self.profile.density_2d(x, y, amp, sigma, **self.center_kwargs)
+        density_ref = self.profile_ref.density_2d(x, y, amp, sigma, **self.center_kwargs)
         npt.assert_array_almost_equal(density_ref, density, decimal=6)
 
     def test_mass2d(self):

--- a/test/test_LensModel/test_Profiles/test_gaussian.py
+++ b/test/test_LensModel/test_Profiles/test_gaussian.py
@@ -50,7 +50,9 @@ class TestGaussian(object):
         y = np.array([2])
         amp = 1.3
         sigma = 0.5
-        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, amp, sigma, **self.center_kwargs)
+        f_x_ref, f_y_ref = self.profile_ref.derivatives(
+            x, y, amp, sigma, **self.center_kwargs
+        )
         f_x, f_y = self.profile.derivatives(x, y, amp, sigma, **self.center_kwargs)
         npt.assert_array_almost_equal(f_x_ref, f_x, decimal=6)
         npt.assert_array_almost_equal(f_y_ref, f_y, decimal=6)
@@ -66,7 +68,9 @@ class TestGaussian(object):
 
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])
-        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, amp, sigma, **self.center_kwargs)
+        f_x_ref, f_y_ref = self.profile_ref.derivatives(
+            x, y, amp, sigma, **self.center_kwargs
+        )
         f_x, f_y = self.profile.derivatives(x, y, amp, sigma, **self.center_kwargs)
         npt.assert_array_almost_equal(f_x_ref, f_x, decimal=6)
         npt.assert_array_almost_equal(f_y_ref, f_y, decimal=6)
@@ -79,7 +83,9 @@ class TestGaussian(object):
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
             x, y, amp, sigma, **self.center_kwargs
         )
-        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, amp, sigma, **self.center_kwargs)
+        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(
+            x, y, amp, sigma, **self.center_kwargs
+        )
         npt.assert_array_almost_equal(f_xx_ref, f_xx, decimal=6)
         npt.assert_array_almost_equal(f_xy_ref, f_xy, decimal=6)
         npt.assert_array_almost_equal(f_yx_ref, f_yx, decimal=6)
@@ -101,7 +107,9 @@ class TestGaussian(object):
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
             x, y, amp, sigma, **self.center_kwargs
         )
-        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, amp, sigma, **self.center_kwargs)
+        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(
+            x, y, amp, sigma, **self.center_kwargs
+        )
         npt.assert_array_almost_equal(f_xx_ref, f_xx, decimal=6)
         npt.assert_array_almost_equal(f_xy_ref, f_xy, decimal=6)
         npt.assert_array_almost_equal(f_yx_ref, f_yx, decimal=6)
@@ -121,7 +129,9 @@ class TestGaussian(object):
         amp = 1.7
         sigma = 0.4
         density = self.profile.density_2d(x, y, amp, sigma, **self.center_kwargs)
-        density_ref = self.profile_ref.density_2d(x, y, amp, sigma, **self.center_kwargs)
+        density_ref = self.profile_ref.density_2d(
+            x, y, amp, sigma, **self.center_kwargs
+        )
         npt.assert_array_almost_equal(density_ref, density, decimal=6)
 
     def test_mass2d(self):

--- a/test/test_LensModel/test_Profiles/test_hernquist.py
+++ b/test/test_LensModel/test_Profiles/test_hernquist.py
@@ -45,7 +45,9 @@ class TestHernquist(object):
         y = np.array([2])
         Rs = 1.0
         sigma0 = 0.5
-        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, sigma0, Rs, **self.center_kwargs)
+        f_x_ref, f_y_ref = self.profile_ref.derivatives(
+            x, y, sigma0, Rs, **self.center_kwargs
+        )
         f_x, f_y = Hernquist.derivatives(x, y, sigma0, Rs, **self.center_kwargs)
         npt.assert_array_almost_equal(f_x_ref, f_x, decimal=8)
         npt.assert_array_almost_equal(f_y_ref, f_y, decimal=8)
@@ -61,7 +63,9 @@ class TestHernquist(object):
 
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])
-        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, sigma0, Rs, **self.center_kwargs)
+        f_x_ref, f_y_ref = self.profile_ref.derivatives(
+            x, y, sigma0, Rs, **self.center_kwargs
+        )
         f_x, f_y = Hernquist.derivatives(x, y, sigma0, Rs, **self.center_kwargs)
         npt.assert_array_almost_equal(f_x_ref, f_x, decimal=8)
         npt.assert_array_almost_equal(f_y_ref, f_y, decimal=8)
@@ -74,7 +78,9 @@ class TestHernquist(object):
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
             x, y, sigma0, Rs, **self.center_kwargs
         )
-        f_xx, f_xy, f_yx, f_yy = Hernquist.hessian(x, y, sigma0, Rs, **self.center_kwargs)
+        f_xx, f_xy, f_yx, f_yy = Hernquist.hessian(
+            x, y, sigma0, Rs, **self.center_kwargs
+        )
         npt.assert_array_almost_equal(f_xx_ref, f_xx, decimal=8)
         npt.assert_array_almost_equal(f_xy_ref, f_xy, decimal=8)
         npt.assert_array_almost_equal(f_yx_ref, f_yx, decimal=8)
@@ -97,7 +103,9 @@ class TestHernquist(object):
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
             x, y, sigma0, Rs, **self.center_kwargs
         )
-        f_xx, f_xy, f_yx, f_yy = Hernquist.hessian(x, y, sigma0, Rs, **self.center_kwargs)
+        f_xx, f_xy, f_yx, f_yy = Hernquist.hessian(
+            x, y, sigma0, Rs, **self.center_kwargs
+        )
         npt.assert_array_almost_equal(f_xx_ref, f_xx, decimal=8)
         npt.assert_array_almost_equal(f_xy_ref, f_xy, decimal=8)
         npt.assert_array_almost_equal(f_yx_ref, f_yx, decimal=8)

--- a/test/test_LensModel/test_Profiles/test_hernquist.py
+++ b/test/test_LensModel/test_Profiles/test_hernquist.py
@@ -15,14 +15,15 @@ class TestHernquist(object):
     def setup_method(self):
         self.profile_ref = Hernquist_ref()
         test_init = Hernquist()
+        self.center_kwargs = {"center_x": 0.1, "center_y": -0.3}
 
     def test_function(self):
         x = np.array([1])
         y = np.array([2])
         Rs = 1.0
         sigma0 = 0.5
-        values_ref = self.profile_ref.function(x, y, sigma0, Rs)
-        values = Hernquist.function(x, y, sigma0, Rs)
+        values_ref = self.profile_ref.function(x, y, sigma0, Rs, **self.center_kwargs)
+        values = Hernquist.function(x, y, sigma0, Rs, **self.center_kwargs)
         npt.assert_array_almost_equal(values_ref, values, decimal=6)
         # NOTE: This test fails with 32 bit floats
         x = np.array([0])
@@ -35,8 +36,8 @@ class TestHernquist(object):
 
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])
-        values_ref = self.profile_ref.function(x, y, sigma0, Rs)
-        values = Hernquist.function(x, y, sigma0, Rs)
+        values_ref = self.profile_ref.function(x, y, sigma0, Rs, **self.center_kwargs)
+        values = Hernquist.function(x, y, sigma0, Rs, **self.center_kwargs)
         npt.assert_almost_equal(values_ref, values, decimal=8)
 
     def test_derivatives(self):
@@ -44,8 +45,8 @@ class TestHernquist(object):
         y = np.array([2])
         Rs = 1.0
         sigma0 = 0.5
-        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, sigma0, Rs)
-        f_x, f_y = Hernquist.derivatives(x, y, sigma0, Rs)
+        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, sigma0, Rs, **self.center_kwargs)
+        f_x, f_y = Hernquist.derivatives(x, y, sigma0, Rs, **self.center_kwargs)
         npt.assert_array_almost_equal(f_x_ref, f_x, decimal=8)
         npt.assert_array_almost_equal(f_y_ref, f_y, decimal=8)
         # NOTE: This test fails with 32 bit floats
@@ -60,8 +61,8 @@ class TestHernquist(object):
 
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])
-        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, sigma0, Rs)
-        f_x, f_y = Hernquist.derivatives(x, y, sigma0, Rs)
+        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, sigma0, Rs, **self.center_kwargs)
+        f_x, f_y = Hernquist.derivatives(x, y, sigma0, Rs, **self.center_kwargs)
         npt.assert_array_almost_equal(f_x_ref, f_x, decimal=8)
         npt.assert_array_almost_equal(f_y_ref, f_y, decimal=8)
 
@@ -71,9 +72,9 @@ class TestHernquist(object):
         Rs = 1.0
         sigma0 = 0.5
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
-            x, y, sigma0, Rs
+            x, y, sigma0, Rs, **self.center_kwargs
         )
-        f_xx, f_xy, f_yx, f_yy = Hernquist.hessian(x, y, sigma0, Rs)
+        f_xx, f_xy, f_yx, f_yy = Hernquist.hessian(x, y, sigma0, Rs, **self.center_kwargs)
         npt.assert_array_almost_equal(f_xx_ref, f_xx, decimal=8)
         npt.assert_array_almost_equal(f_xy_ref, f_xy, decimal=8)
         npt.assert_array_almost_equal(f_yx_ref, f_yx, decimal=8)
@@ -94,9 +95,9 @@ class TestHernquist(object):
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
-            x, y, sigma0, Rs
+            x, y, sigma0, Rs, **self.center_kwargs
         )
-        f_xx, f_xy, f_yx, f_yy = Hernquist.hessian(x, y, sigma0, Rs)
+        f_xx, f_xy, f_yx, f_yy = Hernquist.hessian(x, y, sigma0, Rs, **self.center_kwargs)
         npt.assert_array_almost_equal(f_xx_ref, f_xx, decimal=8)
         npt.assert_array_almost_equal(f_xy_ref, f_xy, decimal=8)
         npt.assert_array_almost_equal(f_yx_ref, f_yx, decimal=8)
@@ -113,8 +114,8 @@ class TestHernquist(object):
         x, y = 1, 0
         rho0 = 1
         Rs = 3
-        grav_pot_ref = self.profile_ref.grav_pot(x, y, rho0, Rs, center_x=0, center_y=0)
-        grav_pot = Hernquist.grav_pot(x, y, rho0, Rs, center_x=0, center_y=0)
+        grav_pot_ref = self.profile_ref.grav_pot(x, y, rho0, Rs, **self.center_kwargs)
+        grav_pot = Hernquist.grav_pot(x, y, rho0, Rs, **self.center_kwargs)
         npt.assert_almost_equal(grav_pot, grav_pot_ref, decimal=8)
 
     def test_F(self):

--- a/test/test_LensModel/test_Profiles/test_hernquist_ellipse_cse.py
+++ b/test/test_LensModel/test_Profiles/test_hernquist_ellipse_cse.py
@@ -20,18 +20,18 @@ class TestHernquistEllipseCSE(object):
         test_init = HernquistEllipseCSE()
 
     def test_function(self):
-        x = np.linspace(0.01, 2, 10)
+        x = np.linspace(-2, 2, 10)
         y = np.zeros_like(x)
-        kwargs = {"sigma0": 2, "Rs": 2, "center_x": 0, "center_y": 0}
+        kwargs = {"sigma0": 2, "Rs": 2, "center_x": 0.2, "center_y": 0.3}
 
         f_ref = self.hernquist_cse_ref.function(x, y, e1=0, e2=0, **kwargs)
         f = HernquistEllipseCSE.function(x, y, e1=0, e2=0, **kwargs)
         npt.assert_array_almost_equal(f, f_ref, decimal=8)
 
     def test_derivatives(self):
-        x = np.linspace(0.01, 2, 10)
+        x = np.linspace(-2, 2, 10)
         y = np.zeros_like(x)
-        kwargs = {"sigma0": 0.5, "Rs": 2, "center_x": 0, "center_y": 0}
+        kwargs = {"sigma0": 0.5, "Rs": 2, "center_x": 0.2, "center_y": 0.3}
 
         f_x_ref, f_y_ref = self.hernquist_cse_ref.derivatives(
             x, y, e1=0, e2=0, **kwargs
@@ -41,9 +41,9 @@ class TestHernquistEllipseCSE(object):
         npt.assert_array_almost_equal(f_y, f_y_ref, decimal=8)
 
     def test_hessian(self):
-        x = np.linspace(0.01, 5, 30)
+        x = np.linspace(-5, 5, 30)
         y = np.zeros_like(x)
-        kwargs = {"sigma0": 0.5, "Rs": 2, "center_x": 0, "center_y": 0}
+        kwargs = {"sigma0": 0.5, "Rs": 2, "center_x": 0.2, "center_y": 0.3}
 
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.hernquist_cse_ref.hessian(
             x, y, e1=0, e2=0, **kwargs
@@ -83,8 +83,8 @@ class TestHernquistEllipseCSE(object):
         y = 4.2
         rho0 = 2.1
         Rs = 3
-        density_2d = HernquistEllipseCSE.density_2d(x, y, rho0, Rs)
-        density_2d_ref = self.hernquist_cse_ref.density_2d(x, y, rho0, Rs)
+        density_2d = HernquistEllipseCSE.density_2d(x, y, rho0, Rs, center_x=0.3, center_y=0.4)
+        density_2d_ref = self.hernquist_cse_ref.density_2d(x, y, rho0, Rs, center_x=0.3, center_y=0.4)
         npt.assert_almost_equal(density_2d, density_2d_ref, decimal=8)
 
     def test_mass_2d(self):

--- a/test/test_LensModel/test_Profiles/test_hernquist_ellipse_cse.py
+++ b/test/test_LensModel/test_Profiles/test_hernquist_ellipse_cse.py
@@ -83,8 +83,12 @@ class TestHernquistEllipseCSE(object):
         y = 4.2
         rho0 = 2.1
         Rs = 3
-        density_2d = HernquistEllipseCSE.density_2d(x, y, rho0, Rs, center_x=0.3, center_y=0.4)
-        density_2d_ref = self.hernquist_cse_ref.density_2d(x, y, rho0, Rs, center_x=0.3, center_y=0.4)
+        density_2d = HernquistEllipseCSE.density_2d(
+            x, y, rho0, Rs, center_x=0.3, center_y=0.4
+        )
+        density_2d_ref = self.hernquist_cse_ref.density_2d(
+            x, y, rho0, Rs, center_x=0.3, center_y=0.4
+        )
         npt.assert_almost_equal(density_2d, density_2d_ref, decimal=8)
 
     def test_mass_2d(self):

--- a/test/test_LensModel/test_Profiles/test_nfw.py
+++ b/test/test_LensModel/test_Profiles/test_nfw.py
@@ -155,7 +155,9 @@ class TestNFW(object):
             ]
         )
         y_array = np.zeros_like(x_array)
-        f_x_ref, f_y_ref = self.nfw_ref.derivatives(x_array, y_array, Rs, alpha_Rs, **self.center_kwargs)
+        f_x_ref, f_y_ref = self.nfw_ref.derivatives(
+            x_array, y_array, Rs, alpha_Rs, **self.center_kwargs
+        )
         f_x, f_y = NFW.derivatives(x_array, y_array, Rs, alpha_Rs, **self.center_kwargs)
 
         npt.assert_array_almost_equal(f_x_ref, f_x, decimal=8)

--- a/test/test_LensModel/test_Profiles/test_nfw.py
+++ b/test/test_LensModel/test_Profiles/test_nfw.py
@@ -13,6 +13,7 @@ class TestNFW(object):
 
     def setup_method(self):
         self.nfw_ref = NFW_ref()
+        self.center_kwargs = {"center_x": 0.3, "center_y": -0.2}
 
     def test_init(self):
         npt.assert_raises(Exception, NFW, interpol=True)
@@ -23,11 +24,11 @@ class TestNFW(object):
         Rs = 1.0
         rho0 = 1
         alpha_Rs_ref = self.nfw_ref.rho02alpha(rho0, Rs)
-        values_ref = self.nfw_ref.function(x, y, Rs, alpha_Rs_ref)
+        values_ref = self.nfw_ref.function(x, y, Rs, alpha_Rs_ref, **self.center_kwargs)
         alpha_Rs = NFW.rho02alpha(rho0, Rs)
-        values = NFW.function(x, y, Rs, alpha_Rs_ref)
+        values = NFW.function(x, y, Rs, alpha_Rs_ref, **self.center_kwargs)
         npt.assert_array_almost_equal(alpha_Rs_ref, alpha_Rs, decimal=8)
-        npt.assert_array_almost_equal(values_ref, values, decimal=5)
+        npt.assert_array_almost_equal(values_ref, values, decimal=8)
 
         x = np.array([0])
         y = np.array([0])
@@ -38,13 +39,13 @@ class TestNFW(object):
         values_ref = self.nfw_ref.function(x, y, Rs, alpha_Rs_ref)
         values = NFW.function(x, y, Rs, alpha_Rs_ref)
         npt.assert_array_almost_equal(alpha_Rs_ref, alpha_Rs, decimal=8)
-        npt.assert_array_almost_equal(values_ref, values, decimal=5)
+        npt.assert_array_almost_equal(values_ref, values, decimal=8)
 
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])
-        values_ref = self.nfw_ref.function(x, y, Rs, alpha_Rs_ref)
-        values = NFW.function(x, y, Rs, alpha_Rs_ref)
-        npt.assert_array_almost_equal(values_ref, values, decimal=5)
+        values_ref = self.nfw_ref.function(x, y, Rs, alpha_Rs_ref, **self.center_kwargs)
+        values = NFW.function(x, y, Rs, alpha_Rs_ref, **self.center_kwargs)
+        npt.assert_array_almost_equal(values_ref, values, decimal=8)
 
     def test_derivatives(self):
         Rs = 0.1
@@ -154,15 +155,15 @@ class TestNFW(object):
             ]
         )
         y_array = np.zeros_like(x_array)
-        f_x_ref, f_y_ref = self.nfw_ref.derivatives(x_array, y_array, Rs, alpha_Rs)
-        f_x, f_y = NFW.derivatives(x_array, y_array, Rs, alpha_Rs)
+        f_x_ref, f_y_ref = self.nfw_ref.derivatives(x_array, y_array, Rs, alpha_Rs, **self.center_kwargs)
+        f_x, f_y = NFW.derivatives(x_array, y_array, Rs, alpha_Rs, **self.center_kwargs)
 
         npt.assert_array_almost_equal(f_x_ref, f_x, decimal=8)
         npt.assert_array_almost_equal(f_y_ref, f_y, decimal=8)
 
     def test_hessian(self):
-        x = np.array([1])
-        y = np.array([2])
+        x = np.array([0])
+        y = np.array([0])
         Rs = 1.0
         rho0 = 1
         alpha_Rs = NFW.rho02alpha(rho0, Rs)
@@ -178,9 +179,9 @@ class TestNFW(object):
         x = np.array([1, 3, 4])
         y = np.array([2, 1, 1])
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.nfw_ref.hessian(
-            x, y, Rs, alpha_Rs
+            x, y, Rs, alpha_Rs, **self.center_kwargs
         )
-        f_xx, f_xy, f_yx, f_yy = NFW.hessian(x, y, Rs, alpha_Rs)
+        f_xx, f_xy, f_yx, f_yy = NFW.hessian(x, y, Rs, alpha_Rs, **self.center_kwargs)
         npt.assert_array_almost_equal(f_xx, f_xx_ref, decimal=8)
         npt.assert_array_almost_equal(f_xy, f_xy_ref, decimal=8)
         npt.assert_array_almost_equal(f_yx, f_yx_ref, decimal=8)

--- a/test/test_LensModel/test_Profiles/test_nfw_ellipse_cse.py
+++ b/test/test_LensModel/test_Profiles/test_nfw_ellipse_cse.py
@@ -22,7 +22,7 @@ class TestNFWELLIPSE(object):
     def test_function(self):
         x = np.linspace(0.01, 2, 10)
         y = np.zeros_like(x)
-        kwargs = {"alpha_Rs": 2, "Rs": 2, "center_x": 0, "center_y": 0}
+        kwargs = {"alpha_Rs": 2, "Rs": 2, "center_x": 0.01, "center_y": 0}
 
         f_ = self.high_accuracy.function(x, y, e1=0, e2=0, **kwargs)
         f_ref = self.high_accuracy_ref.function(x, y, e1=0, e2=0, **kwargs)
@@ -35,7 +35,7 @@ class TestNFWELLIPSE(object):
     def test_derivatives(self):
         x = np.linspace(0.01, 2, 10)
         y = np.zeros_like(x)
-        kwargs = {"alpha_Rs": 0.5, "Rs": 2, "center_x": 0, "center_y": 0}
+        kwargs = {"alpha_Rs": 0.5, "Rs": 2, "center_x": 0.01, "center_y": 0}
 
         f_x, f_y = self.high_accuracy.derivatives(x, y, e1=0, e2=0, **kwargs)
         f_x_ref, f_y_ref = self.high_accuracy_ref.derivatives(
@@ -52,7 +52,7 @@ class TestNFWELLIPSE(object):
     def test_hessian(self):
         x = np.linspace(0.01, 2, 10)
         y = np.zeros_like(x)
-        kwargs = {"alpha_Rs": 0.5, "Rs": 2, "center_x": 0, "center_y": 0}
+        kwargs = {"alpha_Rs": 0.5, "Rs": 2, "center_x": 0.01, "center_y": 0}
 
         f_xx, f_xy, f_yx, f_yy = self.high_accuracy.hessian(x, y, e1=0, e2=0, **kwargs)
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.high_accuracy_ref.hessian(

--- a/test/test_LensModel/test_Profiles/test_nie.py
+++ b/test/test_LensModel/test_Profiles/test_nie.py
@@ -18,17 +18,18 @@ class TestNIE(object):
     def setup_method(self):
         self.nie = NIE()
         self.nie_ref = NIE_ref()
+        self.center_kwargs = {"center_x": 1, "center_y": 2}
 
     def test_function(self):
         y = np.array([1.0, 2])
-        x = np.array([0.0, 0.0])
+        x = np.array([2.0, 0.0])
         theta_E = 1.0
         e1 = 0.1
         e2 = 0.3
         s = 0.00001
 
-        f_ = self.nie.function(x, y, theta_E, e1, e2, s)
-        f_ref = self.nie_ref.function(x, y, theta_E, e1, e2, s)
+        f_ = self.nie.function(x, y, theta_E, e1, e2, s, **self.center_kwargs)
+        f_ref = self.nie_ref.function(x, y, theta_E, e1, e2, s, **self.center_kwargs)
         npt.assert_almost_equal(f_, f_ref, decimal=7)
 
     def test_derivatives(self):
@@ -39,8 +40,8 @@ class TestNIE(object):
         e2 = 0.3
         s = 0.00001
 
-        f_x, f_y = self.nie.derivatives(x, y, theta_E, e1, e2, s)
-        f_x_ref, f_y_ref = self.nie_ref.derivatives(x, y, theta_E, e1, e2, s)
+        f_x, f_y = self.nie.derivatives(x, y, theta_E, e1, e2, s, **self.center_kwargs)
+        f_x_ref, f_y_ref = self.nie_ref.derivatives(x, y, theta_E, e1, e2, s, **self.center_kwargs)
         npt.assert_almost_equal(f_x, f_x_ref, decimal=7)
         npt.assert_almost_equal(f_y, f_y_ref, decimal=7)
 
@@ -52,9 +53,9 @@ class TestNIE(object):
         e2 = 0.3
         s = 0.00001
 
-        f_xx, f_xy, f_yx, f_yy = self.nie.hessian(x, y, theta_E, e1, e2, s)
+        f_xx, f_xy, f_yx, f_yy = self.nie.hessian(x, y, theta_E, e1, e2, s, **self.center_kwargs)
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.nie_ref.hessian(
-            x, y, theta_E, e1, e2, s
+            x, y, theta_E, e1, e2, s, **self.center_kwargs
         )
         npt.assert_almost_equal(f_xx, f_xx_ref, decimal=5)
         npt.assert_almost_equal(f_yy, f_yy_ref, decimal=5)

--- a/test/test_LensModel/test_Profiles/test_nie.py
+++ b/test/test_LensModel/test_Profiles/test_nie.py
@@ -41,7 +41,9 @@ class TestNIE(object):
         s = 0.00001
 
         f_x, f_y = self.nie.derivatives(x, y, theta_E, e1, e2, s, **self.center_kwargs)
-        f_x_ref, f_y_ref = self.nie_ref.derivatives(x, y, theta_E, e1, e2, s, **self.center_kwargs)
+        f_x_ref, f_y_ref = self.nie_ref.derivatives(
+            x, y, theta_E, e1, e2, s, **self.center_kwargs
+        )
         npt.assert_almost_equal(f_x, f_x_ref, decimal=7)
         npt.assert_almost_equal(f_y, f_y_ref, decimal=7)
 
@@ -53,7 +55,9 @@ class TestNIE(object):
         e2 = 0.3
         s = 0.00001
 
-        f_xx, f_xy, f_yx, f_yy = self.nie.hessian(x, y, theta_E, e1, e2, s, **self.center_kwargs)
+        f_xx, f_xy, f_yx, f_yy = self.nie.hessian(
+            x, y, theta_E, e1, e2, s, **self.center_kwargs
+        )
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.nie_ref.hessian(
             x, y, theta_E, e1, e2, s, **self.center_kwargs
         )

--- a/test/test_LensModel/test_Profiles/test_null.py
+++ b/test/test_LensModel/test_Profiles/test_null.py
@@ -8,24 +8,25 @@ from jaxtronomy.LensModel.Profiles.null import Null
 class TestGaussian(object):
     def setup_method(self):
         self.profile = Null()
+        self.center_kwargs = {"center_x": 0.3, "center_y": 0.1}
 
     def test_function(self):
         x = np.tile(np.linspace(-5, 5, 20), 20)
         y = np.repeat(np.linspace(-5, 5, 20), 20)
-        values = self.profile.function(x, y)
+        values = self.profile.function(x, y, **self.center_kwargs)
         npt.assert_allclose(values, np.zeros_like(x), atol=1e-16)
 
     def test_derivatives(self):
         x = np.tile(np.linspace(-5, 5, 20), 20)
         y = np.repeat(np.linspace(-5, 5, 20), 20)
-        f_x, f_y = self.profile.derivatives(x, y)
+        f_x, f_y = self.profile.derivatives(x, y, **self.center_kwargs)
         npt.assert_allclose(f_x, np.zeros_like(x), atol=1e-16)
         npt.assert_allclose(f_y, np.zeros_like(x), atol=1e-16)
 
     def test_hessian(self):
         x = np.tile(np.linspace(-5, 5, 20), 20)
         y = np.repeat(np.linspace(-5, 5, 20), 20)
-        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y)
+        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, **self.center_kwargs)
         npt.assert_allclose(f_xx, np.zeros_like(x), atol=1e-16)
         npt.assert_allclose(f_xy, np.zeros_like(x), atol=1e-16)
         npt.assert_allclose(f_yx, np.zeros_like(x), atol=1e-16)

--- a/test/test_LensModel/test_Profiles/test_p_jaffe.py
+++ b/test/test_LensModel/test_Profiles/test_p_jaffe.py
@@ -18,14 +18,15 @@ class TestP_JAFFW(object):
     def setup_method(self):
         self.profile = PseudoJaffe()
         self.profile_ref = Pjaffe_ref()
+        self.center_kwargs = {"center_x": -1.3, "center_y": -4.2}
 
     def test_function(self):
         x = np.array([1])
         y = np.array([2])
         sigma0 = 1.0
         Ra, Rs = 0.5, 0.8
-        values = self.profile.function(x, y, sigma0, Ra, Rs)
-        values_ref = self.profile_ref.function(x, y, sigma0, Ra, Rs)
+        values = self.profile.function(x, y, sigma0, Ra, Rs, **self.center_kwargs)
+        values_ref = self.profile_ref.function(x, y, sigma0, Ra, Rs, **self.center_kwargs)
         npt.assert_almost_equal(values, values_ref, decimal=6)
 
         x = np.array([0])
@@ -38,8 +39,8 @@ class TestP_JAFFW(object):
 
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])
-        values = self.profile.function(x, y, sigma0, Ra, Rs)
-        values_ref = self.profile_ref.function(x, y, sigma0, Ra, Rs)
+        values = self.profile.function(x, y, sigma0, Ra, Rs, **self.center_kwargs)
+        values_ref = self.profile_ref.function(x, y, sigma0, Ra, Rs, **self.center_kwargs)
         npt.assert_almost_equal(values, values_ref, decimal=6)
 
     def test_derivatives(self):
@@ -47,8 +48,8 @@ class TestP_JAFFW(object):
         y = np.array([2])
         sigma0 = 1.0
         Ra, Rs = 0.5, 0.8
-        f_x, f_y = self.profile.derivatives(x, y, sigma0, Ra, Rs)
-        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, sigma0, Ra, Rs)
+        f_x, f_y = self.profile.derivatives(x, y, sigma0, Ra, Rs, **self.center_kwargs)
+        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, sigma0, Ra, Rs, **self.center_kwargs)
         npt.assert_almost_equal(f_x, f_x_ref, decimal=8)
         npt.assert_almost_equal(f_y, f_y_ref, decimal=7)
 
@@ -61,14 +62,14 @@ class TestP_JAFFW(object):
 
         x = np.array([1, 3, 4])
         y = np.array([2, 1, 1])
-        f_x, f_y = self.profile.derivatives(x, y, sigma0, Ra, Rs)
-        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, sigma0, Ra, Rs)
+        f_x, f_y = self.profile.derivatives(x, y, sigma0, Ra, Rs, **self.center_kwargs)
+        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, sigma0, Ra, Rs, **self.center_kwargs)
         npt.assert_array_almost_equal(f_x, f_x_ref, decimal=6)
         npt.assert_array_almost_equal(f_y, f_y_ref, decimal=7)
 
     def test_hessian(self):
-        x = np.array([1])
-        y = np.array([2])
+        x = np.array([0])
+        y = np.array([0])
         sigma0 = 1.0
         Ra, Rs = 0.5, 0.8
         f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, sigma0, Ra, Rs)
@@ -82,9 +83,9 @@ class TestP_JAFFW(object):
 
         x = np.array([1, 3, 4])
         y = np.array([2, 1, 1])
-        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, sigma0, Ra, Rs)
+        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, sigma0, Ra, Rs, **self.center_kwargs)
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
-            x, y, sigma0, Ra, Rs
+            x, y, sigma0, Ra, Rs, **self.center_kwargs
         )
         npt.assert_array_almost_equal(f_xx, f_xx_ref, decimal=7)
         npt.assert_array_almost_equal(f_xy, f_xy_ref, decimal=7)
@@ -128,8 +129,8 @@ class TestP_JAFFW(object):
         y = 2
         rho0 = 1.0
         Ra, Rs = 0.5, 0.8
-        density2d = self.profile.density_2d(x, y, rho0, Ra, Rs)
-        density2d_ref = self.profile_ref.density_2d(x, y, rho0, Ra, Rs)
+        density2d = self.profile.density_2d(x, y, rho0, Ra, Rs, **self.center_kwargs)
+        density2d_ref = self.profile_ref.density_2d(x, y, rho0, Ra, Rs, **self.center_kwargs)
         npt.assert_almost_equal(density2d, density2d_ref, decimal=8)
 
     def test_mass_2d(self):

--- a/test/test_LensModel/test_Profiles/test_p_jaffe.py
+++ b/test/test_LensModel/test_Profiles/test_p_jaffe.py
@@ -26,7 +26,9 @@ class TestP_JAFFW(object):
         sigma0 = 1.0
         Ra, Rs = 0.5, 0.8
         values = self.profile.function(x, y, sigma0, Ra, Rs, **self.center_kwargs)
-        values_ref = self.profile_ref.function(x, y, sigma0, Ra, Rs, **self.center_kwargs)
+        values_ref = self.profile_ref.function(
+            x, y, sigma0, Ra, Rs, **self.center_kwargs
+        )
         npt.assert_almost_equal(values, values_ref, decimal=6)
 
         x = np.array([0])
@@ -40,7 +42,9 @@ class TestP_JAFFW(object):
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])
         values = self.profile.function(x, y, sigma0, Ra, Rs, **self.center_kwargs)
-        values_ref = self.profile_ref.function(x, y, sigma0, Ra, Rs, **self.center_kwargs)
+        values_ref = self.profile_ref.function(
+            x, y, sigma0, Ra, Rs, **self.center_kwargs
+        )
         npt.assert_almost_equal(values, values_ref, decimal=6)
 
     def test_derivatives(self):
@@ -49,7 +53,9 @@ class TestP_JAFFW(object):
         sigma0 = 1.0
         Ra, Rs = 0.5, 0.8
         f_x, f_y = self.profile.derivatives(x, y, sigma0, Ra, Rs, **self.center_kwargs)
-        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, sigma0, Ra, Rs, **self.center_kwargs)
+        f_x_ref, f_y_ref = self.profile_ref.derivatives(
+            x, y, sigma0, Ra, Rs, **self.center_kwargs
+        )
         npt.assert_almost_equal(f_x, f_x_ref, decimal=8)
         npt.assert_almost_equal(f_y, f_y_ref, decimal=7)
 
@@ -63,7 +69,9 @@ class TestP_JAFFW(object):
         x = np.array([1, 3, 4])
         y = np.array([2, 1, 1])
         f_x, f_y = self.profile.derivatives(x, y, sigma0, Ra, Rs, **self.center_kwargs)
-        f_x_ref, f_y_ref = self.profile_ref.derivatives(x, y, sigma0, Ra, Rs, **self.center_kwargs)
+        f_x_ref, f_y_ref = self.profile_ref.derivatives(
+            x, y, sigma0, Ra, Rs, **self.center_kwargs
+        )
         npt.assert_array_almost_equal(f_x, f_x_ref, decimal=6)
         npt.assert_array_almost_equal(f_y, f_y_ref, decimal=7)
 
@@ -83,7 +91,9 @@ class TestP_JAFFW(object):
 
         x = np.array([1, 3, 4])
         y = np.array([2, 1, 1])
-        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, sigma0, Ra, Rs, **self.center_kwargs)
+        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(
+            x, y, sigma0, Ra, Rs, **self.center_kwargs
+        )
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
             x, y, sigma0, Ra, Rs, **self.center_kwargs
         )
@@ -130,7 +140,9 @@ class TestP_JAFFW(object):
         rho0 = 1.0
         Ra, Rs = 0.5, 0.8
         density2d = self.profile.density_2d(x, y, rho0, Ra, Rs, **self.center_kwargs)
-        density2d_ref = self.profile_ref.density_2d(x, y, rho0, Ra, Rs, **self.center_kwargs)
+        density2d_ref = self.profile_ref.density_2d(
+            x, y, rho0, Ra, Rs, **self.center_kwargs
+        )
         npt.assert_almost_equal(density2d, density2d_ref, decimal=8)
 
     def test_mass_2d(self):

--- a/test/test_LensModel/test_Profiles/test_p_jaffe_ellipse.py
+++ b/test/test_LensModel/test_Profiles/test_p_jaffe_ellipse.py
@@ -25,6 +25,7 @@ class TestP_JAFFW(object):
     def setup_method(self):
         self.profile = PseudoJaffeEllipsePotential()
         self.profile_ref = PJaffe_Ellipse_ref()
+        self.center_kwargs = {"center_x": -0.3, "center_y": 0.4}
 
     def test_function(self):
         x = np.array([1])
@@ -34,11 +35,11 @@ class TestP_JAFFW(object):
         q, phi_G = 0.8, 0
         e1, e2 = param_util.phi_q2_ellipticity(phi_G, q)
         values = self.profile.function(
-            x, y, sigma0, Ra, Rs, e1, e2, center_x=0, center_y=0
+            x, y, sigma0, Ra, Rs, e1, e2, **self.center_kwargs
         )
         e1, e2 = param_util_ref.phi_q2_ellipticity(phi_G, q)
         values_ref = self.profile_ref.function(
-            x, y, sigma0, Ra, Rs, e1, e2, center_x=0, center_y=0
+            x, y, sigma0, Ra, Rs, e1, e2, **self.center_kwargs
         )
         npt.assert_almost_equal(values, values_ref, decimal=8)
 
@@ -55,10 +56,10 @@ class TestP_JAFFW(object):
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])
         values = self.profile.function(
-            x, y, sigma0, Ra, Rs, e1, e2, center_x=0, center_y=0
+            x, y, sigma0, Ra, Rs, e1, e2, **self.center_kwargs
         )
         values_ref = self.profile_ref.function(
-            x, y, sigma0, Ra, Rs, e1, e2, center_x=0, center_y=0
+            x, y, sigma0, Ra, Rs, e1, e2, **self.center_kwargs
         )
         npt.assert_array_almost_equal(values, values_ref, decimal=8)
 
@@ -70,11 +71,11 @@ class TestP_JAFFW(object):
         q, phi_G = 0.8, 0
         e1, e2 = param_util.phi_q2_ellipticity(phi_G, q)
         f_x, f_y = self.profile.derivatives(
-            x, y, sigma0, Ra, Rs, e1, e2, center_x=0, center_y=0
+            x, y, sigma0, Ra, Rs, e1, e2, **self.center_kwargs
         )
         e1, e2 = param_util_ref.phi_q2_ellipticity(phi_G, q)
         f_x_ref, f_y_ref = self.profile_ref.derivatives(
-            x, y, sigma0, Ra, Rs, e1, e2, center_x=0, center_y=0
+            x, y, sigma0, Ra, Rs, e1, e2, **self.center_kwargs
         )
         npt.assert_almost_equal(f_x, f_x_ref, decimal=8)
         npt.assert_almost_equal(f_y, f_y_ref, decimal=8)
@@ -93,27 +94,27 @@ class TestP_JAFFW(object):
         x = np.array([1, 3, 4])
         y = np.array([2, 1, 1])
         f_x, f_y = self.profile.derivatives(
-            x, y, sigma0, Ra, Rs, e1, e2, center_x=0, center_y=0
+            x, y, sigma0, Ra, Rs, e1, e2, **self.center_kwargs
         )
         f_x_ref, f_y_ref = self.profile_ref.derivatives(
-            x, y, sigma0, Ra, Rs, e1, e2, center_x=0, center_y=0
+            x, y, sigma0, Ra, Rs, e1, e2, **self.center_kwargs
         )
         npt.assert_array_almost_equal(f_x, f_x_ref, decimal=8)
         npt.assert_array_almost_equal(f_y, f_y_ref, decimal=8)
 
     def test_hessian(self):
-        x = np.array([1])
-        y = np.array([2])
+        x = np.array([0])
+        y = np.array([0])
         sigma0 = 1.0
         Ra, Rs = 0.5, 0.8
         q, phi_G = 0.8, 0
         e1, e2 = param_util.phi_q2_ellipticity(phi_G, q)
         f_xx, f_xy, f_yx, f_yy = self.profile.hessian(
-            x, y, sigma0, Ra, Rs, e1, e2, center_x=0, center_y=0
+            x, y, sigma0, Ra, Rs, e1, e2
         )
         e1, e2 = param_util_ref.phi_q2_ellipticity(phi_G, q)
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
-            x, y, sigma0, Ra, Rs, e1, e2, center_x=0, center_y=0
+            x, y, sigma0, Ra, Rs, e1, e2
         )
         npt.assert_almost_equal(f_xx, f_xx_ref, decimal=8)
         npt.assert_almost_equal(f_xy, f_xy_ref, decimal=8)
@@ -123,10 +124,10 @@ class TestP_JAFFW(object):
         x = np.array([1, 3, 4])
         y = np.array([2, 1, 1])
         f_xx, f_xy, f_yx, f_yy = self.profile.hessian(
-            x, y, sigma0, Ra, Rs, e1, e2, center_x=0, center_y=0
+            x, y, sigma0, Ra, Rs, e1, e2, **self.center_kwargs
         )
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
-            x, y, sigma0, Ra, Rs, e1, e2, center_x=0, center_y=0
+            x, y, sigma0, Ra, Rs, e1, e2, **self.center_kwargs
         )
         npt.assert_array_almost_equal(f_xx, f_xx_ref, decimal=8)
         npt.assert_array_almost_equal(f_xy, f_xy_ref, decimal=8)

--- a/test/test_LensModel/test_Profiles/test_p_jaffe_ellipse.py
+++ b/test/test_LensModel/test_Profiles/test_p_jaffe_ellipse.py
@@ -109,9 +109,7 @@ class TestP_JAFFW(object):
         Ra, Rs = 0.5, 0.8
         q, phi_G = 0.8, 0
         e1, e2 = param_util.phi_q2_ellipticity(phi_G, q)
-        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(
-            x, y, sigma0, Ra, Rs, e1, e2
-        )
+        f_xx, f_xy, f_yx, f_yy = self.profile.hessian(x, y, sigma0, Ra, Rs, e1, e2)
         e1, e2 = param_util_ref.phi_q2_ellipticity(phi_G, q)
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.profile_ref.hessian(
             x, y, sigma0, Ra, Rs, e1, e2

--- a/test/test_LensModel/test_Profiles/test_shear.py
+++ b/test/test_LensModel/test_Profiles/test_shear.py
@@ -143,7 +143,9 @@ class TestShearReduced(object):
         y = np.array([2, 1, 1])
         gamma1, gamma2 = 0.1, 0.5
         values = ShearReduced.function(x, y, gamma1, gamma2, **self.center_kwargs)
-        values_ref = self.shearreduced_ref.function(x, y, gamma1, gamma2, **self.center_kwargs)
+        values_ref = self.shearreduced_ref.function(
+            x, y, gamma1, gamma2, **self.center_kwargs
+        )
         npt.assert_array_almost_equal(values, values_ref, decimal=12)
 
     def test_derivatives(self):
@@ -151,7 +153,9 @@ class TestShearReduced(object):
         y = np.array([2, 1, 1])
         gamma1, gamma2 = 0.2, 0.4
         values = ShearReduced.derivatives(x, y, gamma1, gamma2, **self.center_kwargs)
-        values_ref = self.shearreduced_ref.derivatives(x, y, gamma1, gamma2, **self.center_kwargs)
+        values_ref = self.shearreduced_ref.derivatives(
+            x, y, gamma1, gamma2, **self.center_kwargs
+        )
         npt.assert_array_almost_equal(values, values_ref, decimal=12)
 
     def test_hessian(self):
@@ -159,7 +163,9 @@ class TestShearReduced(object):
         y = np.array([2, 1, 1])
         gamma1, gamma2 = 0.1, 0.3
         values = ShearReduced.hessian(x, y, gamma1, gamma2, **self.center_kwargs)
-        values_ref = self.shearreduced_ref.hessian(x, y, gamma1, gamma2, **self.center_kwargs)
+        values_ref = self.shearreduced_ref.hessian(
+            x, y, gamma1, gamma2, **self.center_kwargs
+        )
         npt.assert_array_almost_equal(values, values_ref, decimal=12)
 
 

--- a/test/test_LensModel/test_Profiles/test_shear.py
+++ b/test/test_LensModel/test_Profiles/test_shear.py
@@ -19,40 +19,40 @@ class TestShear(object):
     def setup_method(self):
         self.shear_ref = Shear_ref()
         gamma1, gamma2 = 0.1, 0.1
-        self.kwargs_lens = {"gamma1": gamma1, "gamma2": gamma2}
+        self.kwargs_lens = {"gamma1": gamma1, "gamma2": gamma2, "ra_0": 1, "dec_0": 2}
 
     def test_function(self):
         x = np.array([1])
         y = np.array([2])
         values = Shear.function(x, y, **self.kwargs_lens)
         values_ref = self.shear_ref.function(x, y, **self.kwargs_lens)
-        npt.assert_array_almost_equal(values, values_ref, decimal=7)
+        npt.assert_array_almost_equal(values, values_ref, decimal=12)
         x = np.array([0])
         y = np.array([0])
         values = Shear.function(x, y, **self.kwargs_lens)
         values_ref = self.shear_ref.function(x, y, **self.kwargs_lens)
-        npt.assert_array_almost_equal(values, values_ref, decimal=7)
+        npt.assert_array_almost_equal(values, values_ref, decimal=12)
 
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])
         values = Shear.function(x, y, **self.kwargs_lens)
         values_ref = self.shear_ref.function(x, y, **self.kwargs_lens)
-        npt.assert_array_almost_equal(values, values_ref, decimal=7)
+        npt.assert_array_almost_equal(values, values_ref, decimal=12)
 
     def test_derivatives(self):
         x = np.array([1])
         y = np.array([2])
         f_x, f_y = Shear.derivatives(x, y, **self.kwargs_lens)
         f_x_ref, f_y_ref = self.shear_ref.derivatives(x, y, **self.kwargs_lens)
-        npt.assert_array_almost_equal(f_x, f_x_ref, decimal=7)
-        npt.assert_array_almost_equal(f_y, f_y_ref, decimal=7)
+        npt.assert_array_almost_equal(f_x, f_x_ref, decimal=12)
+        npt.assert_array_almost_equal(f_y, f_y_ref, decimal=12)
 
         x = np.array([1, 3, 4])
         y = np.array([2, 1, 1])
         f_x, f_y = Shear.derivatives(x, y, **self.kwargs_lens)
         f_x_ref, f_y_ref = self.shear_ref.derivatives(x, y, **self.kwargs_lens)
-        npt.assert_array_almost_equal(f_x, f_x_ref, decimal=7)
-        npt.assert_array_almost_equal(f_y, f_y_ref, decimal=7)
+        npt.assert_array_almost_equal(f_x, f_x_ref, decimal=12)
+        npt.assert_array_almost_equal(f_y, f_y_ref, decimal=12)
 
     def test_hessian(self):
         x = np.array([1])
@@ -62,10 +62,10 @@ class TestShear(object):
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.shear_ref.hessian(
             x, y, **self.kwargs_lens
         )
-        npt.assert_array_almost_equal(f_xx, f_xx_ref, decimal=7)
-        npt.assert_array_almost_equal(f_xy, f_xy_ref, decimal=7)
-        npt.assert_array_almost_equal(f_yx, f_yx_ref, decimal=7)
-        npt.assert_array_almost_equal(f_yy, f_yy_ref, decimal=7)
+        npt.assert_array_almost_equal(f_xx, f_xx_ref, decimal=12)
+        npt.assert_array_almost_equal(f_xy, f_xy_ref, decimal=12)
+        npt.assert_array_almost_equal(f_yx, f_yx_ref, decimal=12)
+        npt.assert_array_almost_equal(f_yy, f_yy_ref, decimal=12)
 
         x = np.array([1, 3, 4])
         y = np.array([2, 1, 1])
@@ -73,10 +73,10 @@ class TestShear(object):
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.shear_ref.hessian(
             x, y, **self.kwargs_lens
         )
-        npt.assert_array_almost_equal(f_xx, f_xx_ref, decimal=7)
-        npt.assert_array_almost_equal(f_xy, f_xy_ref, decimal=7)
-        npt.assert_array_almost_equal(f_yx, f_yx_ref, decimal=7)
-        npt.assert_array_almost_equal(f_yy, f_yy_ref, decimal=7)
+        npt.assert_array_almost_equal(f_xx, f_xx_ref, decimal=12)
+        npt.assert_array_almost_equal(f_xy, f_xy_ref, decimal=12)
+        npt.assert_array_almost_equal(f_yx, f_yx_ref, decimal=12)
+        npt.assert_array_almost_equal(f_yy, f_yy_ref, decimal=12)
 
         gamma1, gamma2 = 0.1, -0.1
         kwargs = {"gamma1": gamma1, "gamma2": gamma2}
@@ -84,8 +84,8 @@ class TestShear(object):
         lensModel_ref = LensModel_ref(["SHEAR"])
         gamma1, gamma2 = lensModel.gamma(x, y, [kwargs])
         gamma1_ref, gamma2_ref = lensModel_ref.gamma(x, y, [kwargs])
-        npt.assert_array_almost_equal(gamma1, gamma1_ref, decimal=9)
-        npt.assert_array_almost_equal(gamma2, gamma2_ref, decimal=9)
+        npt.assert_array_almost_equal(gamma1, gamma1_ref, decimal=12)
+        npt.assert_array_almost_equal(gamma2, gamma2_ref, decimal=12)
 
 
 class TestShearGammaPsi(object):
@@ -100,7 +100,7 @@ class TestShearGammaPsi(object):
         gamma, psi = 0.1, 0.5
         values = ShearGammaPsi.function(x, y, gamma, psi)
         values_ref = self.sheargammapsi_ref.function(x, y, gamma, psi)
-        npt.assert_array_almost_equal(values, values_ref, decimal=7)
+        npt.assert_array_almost_equal(values, values_ref, decimal=12)
 
     def test_derivatives(self):
         x = np.array([1, 3, 4])
@@ -108,7 +108,7 @@ class TestShearGammaPsi(object):
         gamma, psi = 0.1, 0.5
         values = ShearGammaPsi.derivatives(x, y, gamma, psi)
         values_ref = self.sheargammapsi_ref.derivatives(x, y, gamma, psi)
-        npt.assert_array_almost_equal(values, values_ref, decimal=7)
+        npt.assert_array_almost_equal(values, values_ref, decimal=12)
 
     def test_hessian(self):
         x = np.array([1, 3, 4])
@@ -116,7 +116,7 @@ class TestShearGammaPsi(object):
         gamma, psi = 0.1, 0.5
         values = ShearGammaPsi.hessian(x, y, gamma, psi)
         values_ref = self.sheargammapsi_ref.hessian(x, y, gamma, psi)
-        npt.assert_array_almost_equal(values, values_ref, decimal=7)
+        npt.assert_array_almost_equal(values, values_ref, decimal=12)
 
 
 class TestShearReduced(object):
@@ -124,6 +124,7 @@ class TestShearReduced(object):
     def setup_method(self):
         self.shearreduced_ref = ShearReduced_ref()
         test_init = ShearReduced()
+        self.center_kwargs = {"ra_0": 1, "dec_0": 2}
 
     def test_kappa_reduced(self):
         x = np.array([1, 3, 4])
@@ -133,33 +134,33 @@ class TestShearReduced(object):
         kappa_ref, gamma1_ref_, gamma2_ref_ = self.shearreduced_ref._kappa_reduced(
             gamma1, gamma2
         )
-        npt.assert_array_almost_equal(kappa, kappa_ref, decimal=7)
-        npt.assert_array_almost_equal(gamma1_, gamma1_ref_, decimal=7)
-        npt.assert_array_almost_equal(gamma2_, gamma2_ref_, decimal=7)
+        npt.assert_array_almost_equal(kappa, kappa_ref, decimal=12)
+        npt.assert_array_almost_equal(gamma1_, gamma1_ref_, decimal=12)
+        npt.assert_array_almost_equal(gamma2_, gamma2_ref_, decimal=12)
 
     def test_function(self):
         x = np.array([1, 3, 4])
         y = np.array([2, 1, 1])
         gamma1, gamma2 = 0.1, 0.5
-        values = ShearReduced.function(x, y, gamma1, gamma2)
-        values_ref = self.shearreduced_ref.function(x, y, gamma1, gamma2)
-        npt.assert_array_almost_equal(values, values_ref, decimal=7)
+        values = ShearReduced.function(x, y, gamma1, gamma2, **self.center_kwargs)
+        values_ref = self.shearreduced_ref.function(x, y, gamma1, gamma2, **self.center_kwargs)
+        npt.assert_array_almost_equal(values, values_ref, decimal=12)
 
     def test_derivatives(self):
         x = np.array([1, 3, 4])
         y = np.array([2, 1, 1])
         gamma1, gamma2 = 0.2, 0.4
-        values = ShearReduced.derivatives(x, y, gamma1, gamma2)
-        values_ref = self.shearreduced_ref.derivatives(x, y, gamma1, gamma2)
-        npt.assert_array_almost_equal(values, values_ref, decimal=7)
+        values = ShearReduced.derivatives(x, y, gamma1, gamma2, **self.center_kwargs)
+        values_ref = self.shearreduced_ref.derivatives(x, y, gamma1, gamma2, **self.center_kwargs)
+        npt.assert_array_almost_equal(values, values_ref, decimal=12)
 
     def test_hessian(self):
         x = np.array([1, 3, 4])
         y = np.array([2, 1, 1])
         gamma1, gamma2 = 0.1, 0.3
-        values = ShearReduced.hessian(x, y, gamma1, gamma2)
-        values_ref = self.shearreduced_ref.hessian(x, y, gamma1, gamma2)
-        npt.assert_array_almost_equal(values, values_ref, decimal=7)
+        values = ShearReduced.hessian(x, y, gamma1, gamma2, **self.center_kwargs)
+        values_ref = self.shearreduced_ref.hessian(x, y, gamma1, gamma2, **self.center_kwargs)
+        npt.assert_array_almost_equal(values, values_ref, decimal=12)
 
 
 if __name__ == "__main__":

--- a/test/test_LensModel/test_Profiles/test_sie.py
+++ b/test/test_LensModel/test_Profiles/test_sie.py
@@ -31,7 +31,9 @@ class TestSIE_NIE(object):
         theta_E = 1.0
         e1, e2 = 0.1, -0.3
         f_x, f_y = self.sie.derivatives(x, y, theta_E, e1, e2, **self.center_kwargs)
-        f_x_ref, f_y_ref = self.sie_ref.derivatives(x, y, theta_E, e1, e2, **self.center_kwargs)
+        f_x_ref, f_y_ref = self.sie_ref.derivatives(
+            x, y, theta_E, e1, e2, **self.center_kwargs
+        )
         npt.assert_almost_equal(f_x, f_x_ref, decimal=8)
         npt.assert_almost_equal(f_y, f_y_ref, decimal=8)
 
@@ -40,7 +42,9 @@ class TestSIE_NIE(object):
         y = np.array([2, 0.7, -2.1])
         theta_E = 1.0
         e1, e2 = 0.1, -0.3
-        f_xx, f_xy, f_yx, f_yy = self.sie.hessian(x, y, theta_E, e1, e2, **self.center_kwargs)
+        f_xx, f_xy, f_yx, f_yy = self.sie.hessian(
+            x, y, theta_E, e1, e2, **self.center_kwargs
+        )
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.sie_ref.hessian(
             x, y, theta_E, e1, e2, **self.center_kwargs
         )
@@ -120,7 +124,7 @@ class TestSIE_EPL(object):
     def setup_method(self):
         self.sie = SIE(NIE=False)
         self.sie_ref = SIE_ref(NIE=False)
-        self.center_kwargs = {'center_x': -3.1, "center_y": 0.7}
+        self.center_kwargs = {"center_x": -3.1, "center_y": 0.7}
 
     def test_function(self):
         x = np.array([1, -3.1, 2.7])
@@ -137,7 +141,9 @@ class TestSIE_EPL(object):
         theta_E = 1.0
         e1, e2 = 0.1, -0.3
         f_x, f_y = self.sie.derivatives(x, y, theta_E, e1, e2, **self.center_kwargs)
-        f_x_ref, f_y_ref = self.sie_ref.derivatives(x, y, theta_E, e1, e2, **self.center_kwargs)
+        f_x_ref, f_y_ref = self.sie_ref.derivatives(
+            x, y, theta_E, e1, e2, **self.center_kwargs
+        )
         npt.assert_almost_equal(f_x, f_x_ref, decimal=8)
         npt.assert_almost_equal(f_y, f_y_ref, decimal=8)
 
@@ -146,7 +152,9 @@ class TestSIE_EPL(object):
         y = np.array([2, 0.7, -2.1])
         theta_E = 1.0
         e1, e2 = 0.1, -0.3
-        f_xx, f_xy, f_yx, f_yy = self.sie.hessian(x, y, theta_E, e1, e2, **self.center_kwargs)
+        f_xx, f_xy, f_yx, f_yy = self.sie.hessian(
+            x, y, theta_E, e1, e2, **self.center_kwargs
+        )
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.sie_ref.hessian(
             x, y, theta_E, e1, e2, **self.center_kwargs
         )

--- a/test/test_LensModel/test_Profiles/test_sie.py
+++ b/test/test_LensModel/test_Profiles/test_sie.py
@@ -14,14 +14,15 @@ class TestSIE_NIE(object):
     def setup_method(self):
         self.sie = SIE(NIE=True)
         self.sie_ref = SIE_ref(NIE=True)
+        self.center_kwargs = {"center_x": -3.1, "center_y": 0.7}
 
     def test_function(self):
         x = np.array([1, -3.1, 2.7])
         y = np.array([2, 0.7, -2.1])
         theta_E = 1.0
         e1, e2 = 0.1, -0.3
-        f = self.sie.function(x, y, theta_E, e1, e2)
-        f_ref = self.sie_ref.function(x, y, theta_E, e1, e2)
+        f = self.sie.function(x, y, theta_E, e1, e2, **self.center_kwargs)
+        f_ref = self.sie_ref.function(x, y, theta_E, e1, e2, **self.center_kwargs)
         npt.assert_almost_equal(f, f_ref, decimal=8)
 
     def test_derivatives(self):
@@ -29,8 +30,8 @@ class TestSIE_NIE(object):
         y = np.array([2, 0.7, -2.1])
         theta_E = 1.0
         e1, e2 = 0.1, -0.3
-        f_x, f_y = self.sie.derivatives(x, y, theta_E, e1, e2)
-        f_x_ref, f_y_ref = self.sie_ref.derivatives(x, y, theta_E, e1, e2)
+        f_x, f_y = self.sie.derivatives(x, y, theta_E, e1, e2, **self.center_kwargs)
+        f_x_ref, f_y_ref = self.sie_ref.derivatives(x, y, theta_E, e1, e2, **self.center_kwargs)
         npt.assert_almost_equal(f_x, f_x_ref, decimal=8)
         npt.assert_almost_equal(f_y, f_y_ref, decimal=8)
 
@@ -39,9 +40,9 @@ class TestSIE_NIE(object):
         y = np.array([2, 0.7, -2.1])
         theta_E = 1.0
         e1, e2 = 0.1, -0.3
-        f_xx, f_xy, f_yx, f_yy = self.sie.hessian(x, y, theta_E, e1, e2)
+        f_xx, f_xy, f_yx, f_yy = self.sie.hessian(x, y, theta_E, e1, e2, **self.center_kwargs)
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.sie_ref.hessian(
-            x, y, theta_E, e1, e2
+            x, y, theta_E, e1, e2, **self.center_kwargs
         )
         npt.assert_almost_equal(f_xx, f_xx_ref, decimal=5)
         npt.assert_almost_equal(f_xy, f_xy_ref, decimal=5)
@@ -108,8 +109,8 @@ class TestSIE_NIE(object):
         x = np.array([1, -2.4, 2.7])
         y = np.array([2, 0.27, -3.1])
         rho0 = 1.00003234
-        density_ref = self.sie_ref.density_2d(x, y, rho0)
-        density = self.sie.density_2d(x, y, rho0)
+        density_ref = self.sie_ref.density_2d(x, y, rho0, **self.center_kwargs)
+        density = self.sie.density_2d(x, y, rho0, **self.center_kwargs)
         npt.assert_almost_equal(density, density_ref, decimal=8)
 
 
@@ -119,14 +120,15 @@ class TestSIE_EPL(object):
     def setup_method(self):
         self.sie = SIE(NIE=False)
         self.sie_ref = SIE_ref(NIE=False)
+        self.center_kwargs = {'center_x': -3.1, "center_y": 0.7}
 
     def test_function(self):
         x = np.array([1, -3.1, 2.7])
         y = np.array([2, 0.7, -2.1])
         theta_E = 1.0
         e1, e2 = 0.1, -0.3
-        f = self.sie.function(x, y, theta_E, e1, e2)
-        f_ref = self.sie_ref.function(x, y, theta_E, e1, e2)
+        f = self.sie.function(x, y, theta_E, e1, e2, **self.center_kwargs)
+        f_ref = self.sie_ref.function(x, y, theta_E, e1, e2, **self.center_kwargs)
         npt.assert_almost_equal(f, f_ref, decimal=8)
 
     def test_derivatives(self):
@@ -134,8 +136,8 @@ class TestSIE_EPL(object):
         y = np.array([2, 0.7, -2.1])
         theta_E = 1.0
         e1, e2 = 0.1, -0.3
-        f_x, f_y = self.sie.derivatives(x, y, theta_E, e1, e2)
-        f_x_ref, f_y_ref = self.sie_ref.derivatives(x, y, theta_E, e1, e2)
+        f_x, f_y = self.sie.derivatives(x, y, theta_E, e1, e2, **self.center_kwargs)
+        f_x_ref, f_y_ref = self.sie_ref.derivatives(x, y, theta_E, e1, e2, **self.center_kwargs)
         npt.assert_almost_equal(f_x, f_x_ref, decimal=8)
         npt.assert_almost_equal(f_y, f_y_ref, decimal=8)
 
@@ -144,9 +146,9 @@ class TestSIE_EPL(object):
         y = np.array([2, 0.7, -2.1])
         theta_E = 1.0
         e1, e2 = 0.1, -0.3
-        f_xx, f_xy, f_yx, f_yy = self.sie.hessian(x, y, theta_E, e1, e2)
+        f_xx, f_xy, f_yx, f_yy = self.sie.hessian(x, y, theta_E, e1, e2, **self.center_kwargs)
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.sie_ref.hessian(
-            x, y, theta_E, e1, e2
+            x, y, theta_E, e1, e2, **self.center_kwargs
         )
         npt.assert_almost_equal(f_xx, f_xx_ref, decimal=8)
         npt.assert_almost_equal(f_xy, f_xy_ref, decimal=8)

--- a/test/test_LensModel/test_Profiles/test_sis.py
+++ b/test/test_LensModel/test_Profiles/test_sis.py
@@ -18,69 +18,73 @@ class TestSIS(object):
     def setup_method(self):
         self.SIS = SIS()
         self.SIS_ref = SIS_ref()
+        self.center_kwargs = {"center_x": 0.3, "center_y": 0.7}
 
     def test_function(self):
         x = np.array([1])
         y = np.array([2])
         phi_E = 1.0
-        values = self.SIS.function(x, y, phi_E)
-        values_ref = self.SIS_ref.function(x, y, phi_E)
-        npt.assert_almost_equal(values[0], 2.2360679774997898, decimal=9)
-        npt.assert_almost_equal(values, values_ref, decimal=7)
+        values = self.SIS.function(x, y, phi_E, **self.center_kwargs)
+        values_ref = self.SIS_ref.function(x, y, phi_E, **self.center_kwargs)
+        npt.assert_almost_equal(values, values_ref, decimal=10)
+
         x = np.array([0])
         y = np.array([0])
         phi_E = 1.0
         values = self.SIS.function(x, y, phi_E)
-        assert values[0] == 0
+        values_ref = self.SIS_ref.function(x, y, phi_E)
+        npt.assert_almost_equal(values, values_ref, decimal=10)
 
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])
-        values = self.SIS.function(x, y, phi_E)
-        values_ref = self.SIS_ref.function(x, y, phi_E)
-        npt.assert_almost_equal(values[0], 2.2360679774997898, decimal=9)
-        npt.assert_almost_equal(values[1], 3.1622776601683795, decimal=9)
-        npt.assert_almost_equal(values[2], 4.1231056256176606, decimal=9)
-        npt.assert_almost_equal(values, values_ref, decimal=7)
+        values = self.SIS.function(x, y, phi_E, **self.center_kwargs)
+        values_ref = self.SIS_ref.function(x, y, phi_E, **self.center_kwargs)
+        npt.assert_almost_equal(values, values_ref, decimal=10)
 
     def test_derivatives(self):
         x = np.array([1])
         y = np.array([2])
         phi_E = 1.0
-        f_x, f_y = self.SIS.derivatives(x, y, phi_E)
-        f_x_ref, f_y_ref = self.SIS_ref.derivatives(x, y, phi_E)
-        npt.assert_almost_equal(f_x, f_x_ref, decimal=8)
-        npt.assert_almost_equal(f_y, f_y_ref, decimal=8)
+        f_x, f_y = self.SIS.derivatives(x, y, phi_E, **self.center_kwargs)
+        f_x_ref, f_y_ref = self.SIS_ref.derivatives(x, y, phi_E, **self.center_kwargs)
+        npt.assert_almost_equal(f_x, f_x_ref, decimal=10)
+        npt.assert_almost_equal(f_y, f_y_ref, decimal=10)
+
         x = np.array([0])
         y = np.array([0])
         f_x, f_y = self.SIS.derivatives(x, y, phi_E)
-        assert f_x[0] == 0
-        assert f_y[0] == 0
+        f_x_ref, f_y_ref = self.SIS_ref.derivatives(x, y, phi_E)
+        npt.assert_almost_equal(f_x, f_x_ref, decimal=10)
+        npt.assert_almost_equal(f_y, f_y_ref, decimal=10)
 
     def test_hessian(self):
-        x = np.array([1])
-        y = np.array([2])
+        x = np.array([0])
+        y = np.array([0])
         phi_E = 1.0
         f_xx, f_xy, f_yx, f_yy = self.SIS.hessian(x, y, phi_E)
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.SIS_ref.hessian(x, y, phi_E)
-        npt.assert_almost_equal(f_xy, f_yx, decimal=8)
-        npt.assert_almost_equal(f_xx, f_xx_ref, decimal=9)
-        npt.assert_almost_equal(f_xy, f_xy_ref, decimal=9)
-        npt.assert_almost_equal(f_yx, f_yx_ref, decimal=9)
-        npt.assert_almost_equal(f_yy, f_yy_ref, decimal=9)
+        npt.assert_almost_equal(f_xy, f_yx, decimal=10)
+        npt.assert_almost_equal(f_xx, f_xx_ref, decimal=10)
+        npt.assert_almost_equal(f_xy, f_xy_ref, decimal=10)
+        npt.assert_almost_equal(f_yx, f_yx_ref, decimal=10)
+        npt.assert_almost_equal(f_yy, f_yy_ref, decimal=10)
         x = np.array([1, 3, 4])
         y = np.array([2, 1, 1])
-        values = self.SIS.hessian(x, y, phi_E)
-        values_ref = self.SIS_ref.hessian(x, y, phi_E)
+        values = self.SIS.hessian(x, y, phi_E, **self.center_kwargs)
+        values_ref = self.SIS_ref.hessian(x, y, phi_E, **self.center_kwargs)
         npt.assert_almost_equal(values, values_ref)
 
     def test_theta2rho(self):
         theta_E = 2.0
         rho0 = self.SIS.theta2rho(theta_E)
-        theta_E_new = self.SIS.rho2theta(rho0)
         rho0_ref = self.SIS_ref.theta2rho(theta_E)
-        theta_E_new_ref = self.SIS_ref.rho2theta(rho0)
-        npt.assert_almost_equal(theta_E_new, theta_E, decimal=7)
-        npt.assert_almost_equal(theta_E_new, theta_E_new_ref, decimal=7)
+        npt.assert_almost_equal(rho0, rho0_ref, decimal=10)
+
+    def test_rho2theta(self):
+        rho0 = 1.3
+        theta_E = self.SIS.rho2theta(rho0)
+        theta_E_ref = self.SIS_ref.rho2theta(rho0)
+        npt.assert_almost_equal(theta_E_ref, theta_E, decimal=10)
 
     def test_mass_3d(self):
         r = 2.5
@@ -127,8 +131,8 @@ class TestSIS(object):
         x = 0.5
         y = -0.3
         rho0 = 1.3
-        density_2d = self.SIS.density_2d(x, y, rho0)
-        density_2d_ref = self.SIS_ref.density_2d(x, y, rho0)
+        density_2d = self.SIS.density_2d(x, y, rho0, **self.center_kwargs)
+        density_2d_ref = self.SIS_ref.density_2d(x, y, rho0, **self.center_kwargs)
 
         npt.assert_almost_equal(density_2d, density_2d_ref)
 

--- a/test/test_LensModel/test_Profiles/test_spp.py
+++ b/test/test_LensModel/test_Profiles/test_spp.py
@@ -13,6 +13,7 @@ class TestSPP(object):
 
     def setup_method(self):
         self.SPP_ref = SPP_ref()
+        self.center_kwargs = {"center_x": 0.3, "center_y": 0.1}
 
     def test_function(self):
         x = np.array([1])
@@ -20,8 +21,8 @@ class TestSPP(object):
         theta_E = 1.3
         gamma = 1.9
 
-        values_ref = self.SPP_ref.function(x, y, theta_E, gamma)
-        values = SPP.function(x, y, theta_E, gamma)
+        values_ref = self.SPP_ref.function(x, y, theta_E, gamma, **self.center_kwargs)
+        values = SPP.function(x, y, theta_E, gamma, **self.center_kwargs)
         npt.assert_array_almost_equal(values, values_ref, decimal=8)
 
         x = np.array([0])
@@ -42,8 +43,8 @@ class TestSPP(object):
         theta_E = 1.3
         gamma = 1.9
 
-        f_x_ref, f_y_ref = self.SPP_ref.derivatives(x, y, theta_E, gamma)
-        f_x, f_y = SPP.derivatives(x, y, theta_E, gamma)
+        f_x_ref, f_y_ref = self.SPP_ref.derivatives(x, y, theta_E, gamma, **self.center_kwargs)
+        f_x, f_y = SPP.derivatives(x, y, theta_E, gamma, **self.center_kwargs)
         npt.assert_array_almost_equal(f_x, f_x_ref, decimal=8)
         npt.assert_array_almost_equal(f_y, f_y_ref, decimal=8)
 
@@ -56,8 +57,8 @@ class TestSPP(object):
 
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])
-        f_x_ref, f_y_ref = self.SPP_ref.derivatives(x, y, theta_E, gamma)
-        f_x, f_y = SPP.derivatives(x, y, theta_E, gamma)
+        f_x_ref, f_y_ref = self.SPP_ref.derivatives(x, y, theta_E, gamma, **self.center_kwargs)
+        f_x, f_y = SPP.derivatives(x, y, theta_E, gamma, **self.center_kwargs)
         npt.assert_array_almost_equal(f_x, f_x_ref, decimal=8)
         npt.assert_array_almost_equal(f_y, f_y_ref, decimal=8)
 
@@ -68,9 +69,9 @@ class TestSPP(object):
         gamma = 1.9
 
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.SPP_ref.hessian(
-            x, y, theta_E, gamma
+            x, y, theta_E, gamma, **self.center_kwargs
         )
-        f_xx, f_xy, f_yx, f_yy = SPP.hessian(x, y, theta_E, gamma)
+        f_xx, f_xy, f_yx, f_yy = SPP.hessian(x, y, theta_E, gamma, **self.center_kwargs)
         npt.assert_array_almost_equal(f_xx, f_xx_ref, decimal=8)
         npt.assert_array_almost_equal(f_xy, f_xy_ref, decimal=8)
         npt.assert_array_almost_equal(f_yx, f_yx_ref, decimal=8)
@@ -90,9 +91,9 @@ class TestSPP(object):
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.SPP_ref.hessian(
-            x, y, theta_E, gamma
+            x, y, theta_E, gamma, **self.center_kwargs
         )
-        f_xx, f_xy, f_yx, f_yy = SPP.hessian(x, y, theta_E, gamma)
+        f_xx, f_xy, f_yx, f_yy = SPP.hessian(x, y, theta_E, gamma, **self.center_kwargs)
         npt.assert_array_almost_equal(f_xx, f_xx_ref, decimal=8)
         npt.assert_array_almost_equal(f_xy, f_xy_ref, decimal=8)
         npt.assert_array_almost_equal(f_yx, f_yx_ref, decimal=8)
@@ -173,8 +174,8 @@ class TestSPP(object):
         y = 2.38123
         rho0 = 1.00003234
         gamma = 2.12989
-        density_ref = self.SPP_ref.density_2d(x, y, rho0, gamma)
-        density = SPP.density_2d(x, y, rho0, gamma)
+        density_ref = self.SPP_ref.density_2d(x, y, rho0, gamma, **self.center_kwargs)
+        density = SPP.density_2d(x, y, rho0, gamma, **self.center_kwargs)
         npt.assert_almost_equal(density, density_ref, decimal=8)
 
 

--- a/test/test_LensModel/test_Profiles/test_spp.py
+++ b/test/test_LensModel/test_Profiles/test_spp.py
@@ -43,7 +43,9 @@ class TestSPP(object):
         theta_E = 1.3
         gamma = 1.9
 
-        f_x_ref, f_y_ref = self.SPP_ref.derivatives(x, y, theta_E, gamma, **self.center_kwargs)
+        f_x_ref, f_y_ref = self.SPP_ref.derivatives(
+            x, y, theta_E, gamma, **self.center_kwargs
+        )
         f_x, f_y = SPP.derivatives(x, y, theta_E, gamma, **self.center_kwargs)
         npt.assert_array_almost_equal(f_x, f_x_ref, decimal=8)
         npt.assert_array_almost_equal(f_y, f_y_ref, decimal=8)
@@ -57,7 +59,9 @@ class TestSPP(object):
 
         x = np.array([2, 3, 4])
         y = np.array([1, 1, 1])
-        f_x_ref, f_y_ref = self.SPP_ref.derivatives(x, y, theta_E, gamma, **self.center_kwargs)
+        f_x_ref, f_y_ref = self.SPP_ref.derivatives(
+            x, y, theta_E, gamma, **self.center_kwargs
+        )
         f_x, f_y = SPP.derivatives(x, y, theta_E, gamma, **self.center_kwargs)
         npt.assert_array_almost_equal(f_x, f_x_ref, decimal=8)
         npt.assert_array_almost_equal(f_y, f_y_ref, decimal=8)

--- a/test/test_LensModel/test_Profiles/test_tnfw.py
+++ b/test/test_LensModel/test_Profiles/test_tnfw.py
@@ -34,14 +34,18 @@ class TestTNFW(object):
         Rs = 2.4
         alpha_Rs = 1.5
         r_trunc = 1.2
-        values_ref = self.tnfw_ref.function(x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs)
+        values_ref = self.tnfw_ref.function(
+            x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs
+        )
         values = TNFW.function(x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs)
         npt.assert_allclose(values_ref, values, atol=1e-12, rtol=1e-12)
 
         Rs = 4
         alpha_Rs = 0.5
         r_trunc = 8
-        values_ref = self.tnfw_ref.function(x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs)
+        values_ref = self.tnfw_ref.function(
+            x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs
+        )
         values = TNFW.function(x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs)
         npt.assert_allclose(values_ref, values, atol=1e-12, rtol=1e-12)
 
@@ -61,7 +65,9 @@ class TestTNFW(object):
         Rs = 2.4
         alpha_Rs = 1.5
         r_trunc = 1.2
-        f_x_ref, f_y_ref = self.tnfw_ref.derivatives(x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs)
+        f_x_ref, f_y_ref = self.tnfw_ref.derivatives(
+            x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs
+        )
         f_x, f_y = TNFW.derivatives(x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs)
         npt.assert_allclose(f_x_ref, f_x, atol=1e-12, rtol=1e-12)
         npt.assert_allclose(f_y_ref, f_y, atol=1e-12, rtol=1e-12)
@@ -69,7 +75,9 @@ class TestTNFW(object):
         Rs = 4
         alpha_Rs = 0.5
         r_trunc = 8
-        f_x_ref, f_y_ref = self.tnfw_ref.derivatives(x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs)
+        f_x_ref, f_y_ref = self.tnfw_ref.derivatives(
+            x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs
+        )
         f_x, f_y = TNFW.derivatives(x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs)
         npt.assert_allclose(f_x_ref, f_x, atol=1e-12, rtol=1e-12)
         npt.assert_allclose(f_y_ref, f_y, atol=1e-12, rtol=1e-12)
@@ -97,7 +105,9 @@ class TestTNFW(object):
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.tnfw_ref.hessian(
             x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs
         )
-        f_xx, f_xy, f_yx, f_yy = TNFW.hessian(x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs)
+        f_xx, f_xy, f_yx, f_yy = TNFW.hessian(
+            x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs
+        )
         npt.assert_allclose(f_xx_ref, f_xx, atol=1e-12, rtol=1e-12)
         npt.assert_allclose(f_xy_ref, f_xy, atol=1e-12, rtol=1e-12)
         npt.assert_allclose(f_yx_ref, f_yx, atol=1e-12, rtol=1e-12)
@@ -109,7 +119,9 @@ class TestTNFW(object):
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.tnfw_ref.hessian(
             x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs
         )
-        f_xx, f_xy, f_yx, f_yy = TNFW.hessian(x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs)
+        f_xx, f_xy, f_yx, f_yy = TNFW.hessian(
+            x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs
+        )
         npt.assert_allclose(f_xx_ref, f_xx, atol=1e-12, rtol=1e-12)
         npt.assert_allclose(f_xy_ref, f_xy, atol=1e-12, rtol=1e-12)
         npt.assert_allclose(f_yx_ref, f_yx, atol=1e-12, rtol=1e-12)
@@ -153,7 +165,9 @@ class TestTNFW(object):
         Rs = 4
         rho0 = 1.1
         r_trunc = 8
-        density_ref = self.tnfw_ref.density_2d(x, y, Rs, rho0, r_trunc, **self.center_kwargs)
+        density_ref = self.tnfw_ref.density_2d(
+            x, y, Rs, rho0, r_trunc, **self.center_kwargs
+        )
         density = TNFW.density_2d(x, y, Rs, rho0, r_trunc, **self.center_kwargs)
         npt.assert_allclose(density, density_ref, atol=1e-12, rtol=1e-12)
 

--- a/test/test_LensModel/test_Profiles/test_tnfw.py
+++ b/test/test_LensModel/test_Profiles/test_tnfw.py
@@ -17,6 +17,7 @@ class TestTNFW(object):
 
     def setup_method(self):
         self.tnfw_ref = TNFW_ref()
+        self.center_kwargs = {"center_x": 0.3, "center_y": -0.3}
 
     def test_function(self):
         x = np.array([0])
@@ -33,15 +34,15 @@ class TestTNFW(object):
         Rs = 2.4
         alpha_Rs = 1.5
         r_trunc = 1.2
-        values_ref = self.tnfw_ref.function(x, y, Rs, alpha_Rs, r_trunc)
-        values = TNFW.function(x, y, Rs, alpha_Rs, r_trunc)
+        values_ref = self.tnfw_ref.function(x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs)
+        values = TNFW.function(x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs)
         npt.assert_allclose(values_ref, values, atol=1e-12, rtol=1e-12)
 
         Rs = 4
         alpha_Rs = 0.5
         r_trunc = 8
-        values_ref = self.tnfw_ref.function(x, y, Rs, alpha_Rs, r_trunc)
-        values = TNFW.function(x, y, Rs, alpha_Rs, r_trunc)
+        values_ref = self.tnfw_ref.function(x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs)
+        values = TNFW.function(x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs)
         npt.assert_allclose(values_ref, values, atol=1e-12, rtol=1e-12)
 
     def test_derivatives(self):
@@ -60,16 +61,16 @@ class TestTNFW(object):
         Rs = 2.4
         alpha_Rs = 1.5
         r_trunc = 1.2
-        f_x_ref, f_y_ref = self.tnfw_ref.derivatives(x, y, Rs, alpha_Rs, r_trunc)
-        f_x, f_y = TNFW.derivatives(x, y, Rs, alpha_Rs, r_trunc)
+        f_x_ref, f_y_ref = self.tnfw_ref.derivatives(x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs)
+        f_x, f_y = TNFW.derivatives(x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs)
         npt.assert_allclose(f_x_ref, f_x, atol=1e-12, rtol=1e-12)
         npt.assert_allclose(f_y_ref, f_y, atol=1e-12, rtol=1e-12)
 
         Rs = 4
         alpha_Rs = 0.5
         r_trunc = 8
-        f_x_ref, f_y_ref = self.tnfw_ref.derivatives(x, y, Rs, alpha_Rs, r_trunc)
-        f_x, f_y = TNFW.derivatives(x, y, Rs, alpha_Rs, r_trunc)
+        f_x_ref, f_y_ref = self.tnfw_ref.derivatives(x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs)
+        f_x, f_y = TNFW.derivatives(x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs)
         npt.assert_allclose(f_x_ref, f_x, atol=1e-12, rtol=1e-12)
         npt.assert_allclose(f_y_ref, f_y, atol=1e-12, rtol=1e-12)
 
@@ -94,9 +95,9 @@ class TestTNFW(object):
         alpha_Rs = 1.5
         r_trunc = 1.2
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.tnfw_ref.hessian(
-            x, y, Rs, alpha_Rs, r_trunc
+            x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs
         )
-        f_xx, f_xy, f_yx, f_yy = TNFW.hessian(x, y, Rs, alpha_Rs, r_trunc)
+        f_xx, f_xy, f_yx, f_yy = TNFW.hessian(x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs)
         npt.assert_allclose(f_xx_ref, f_xx, atol=1e-12, rtol=1e-12)
         npt.assert_allclose(f_xy_ref, f_xy, atol=1e-12, rtol=1e-12)
         npt.assert_allclose(f_yx_ref, f_yx, atol=1e-12, rtol=1e-12)
@@ -106,9 +107,9 @@ class TestTNFW(object):
         alpha_Rs = 0.5
         r_trunc = 8
         f_xx_ref, f_xy_ref, f_yx_ref, f_yy_ref = self.tnfw_ref.hessian(
-            x, y, Rs, alpha_Rs, r_trunc
+            x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs
         )
-        f_xx, f_xy, f_yx, f_yy = TNFW.hessian(x, y, Rs, alpha_Rs, r_trunc)
+        f_xx, f_xy, f_yx, f_yy = TNFW.hessian(x, y, Rs, alpha_Rs, r_trunc, **self.center_kwargs)
         npt.assert_allclose(f_xx_ref, f_xx, atol=1e-12, rtol=1e-12)
         npt.assert_allclose(f_xy_ref, f_xy, atol=1e-12, rtol=1e-12)
         npt.assert_allclose(f_yx_ref, f_yx, atol=1e-12, rtol=1e-12)
@@ -152,8 +153,8 @@ class TestTNFW(object):
         Rs = 4
         rho0 = 1.1
         r_trunc = 8
-        density_ref = self.tnfw_ref.density_2d(x, y, Rs, rho0, r_trunc)
-        density = TNFW.density_2d(x, y, Rs, rho0, r_trunc)
+        density_ref = self.tnfw_ref.density_2d(x, y, Rs, rho0, r_trunc, **self.center_kwargs)
+        density = TNFW.density_2d(x, y, Rs, rho0, r_trunc, **self.center_kwargs)
         npt.assert_allclose(density, density_ref, atol=1e-12, rtol=1e-12)
 
     def test_mass_2d(self):

--- a/test/test_Util/test_util.py
+++ b/test/test_Util/test_util.py
@@ -85,6 +85,18 @@ def test_sigma2fwhm():
     fwhm_ref = util_ref.sigma2fwhm(sigma)
     npt.assert_array_almost_equal(fwhm, fwhm_ref, decimal=8)
 
+def test_shift_center():
+    x = [1, 3, 4, 6]
+    y = [3, 40, 5, 2]
+    center_x = 3
+    center_y = 6
+
+    new_x, new_y = util.shift_center(x, y, center_x, center_y)
+    assert isinstance(new_x, jax.numpy.ndarray)
+    assert isinstance(new_y, jax.numpy.ndarray)
+
+    npt.assert_equal(np.array(new_x), [-2, 0, 1, 3])
+    npt.assert_equal(np.array(new_y), [-3, 34, -1, -4])
 
 if __name__ == "__main__":
     pytest.main()

--- a/test/test_Util/test_util.py
+++ b/test/test_Util/test_util.py
@@ -85,6 +85,7 @@ def test_sigma2fwhm():
     fwhm_ref = util_ref.sigma2fwhm(sigma)
     npt.assert_array_almost_equal(fwhm, fwhm_ref, decimal=8)
 
+
 def test_shift_center():
     x = [1, 3, 4, 6]
     y = [3, 40, 5, 2]
@@ -97,6 +98,7 @@ def test_shift_center():
 
     npt.assert_equal(np.array(new_x), [-2, 0, 1, 3])
     npt.assert_equal(np.array(new_y), [-3, 34, -1, -4])
+
 
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
Explicitly converts all input coordinates to JAX arrays of dtype `float` when computing any LensModel functions.
This avoids crashes in situations where the input coordinates are integers (rare) or lists (e.g. lenstronomy often supplies point source positions as lists), resulting in unsupported operations between data types.