### PR TITLE
Removal of JAX configuration flags spread across many files and unused imports

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -41,7 +41,6 @@ jobs:
       #    flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with pytest
         run: |
-          export JAX_ENABLE_X64=False
           pytest --cov=./ --cov-report=xml
           codecov
 

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -15,7 +15,6 @@ jobs:
     strategy:
       matrix:
         python-version: [3.11]
-        enable_x64: [True, False]
 
     steps:
       - uses: actions/checkout@v4
@@ -40,9 +39,9 @@ jobs:
       #    flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
       #    flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - name: Test with pytest (64 bits set to ${{ matrix.enable_x64 }})
+      - name: Test with pytest
         run: |
-          export JAX_ENABLE_X64=${{ matrix.enable_x64 }}
+          export JAX_ENABLE_X64=False
           pytest --cov=./ --cov-report=xml
           codecov
 

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.11]
+        enable_x64: [True, False]
 
     steps:
       - uses: actions/checkout@v4
@@ -39,9 +40,10 @@ jobs:
       #    flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
       #    flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - name: Test with pytest
+      - name: Test with pytest (64 bits set to ${{ matrix.enable_x64 }})
+        env:
+          JAX_ENABLE_X64: ${{ matrix.enable_x64 }}
         run: |
-          export JAX_ENABLE_X64=True
           pytest --cov=./ --cov-report=xml
           codecov
 

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -41,9 +41,8 @@ jobs:
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
       #    flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with pytest (64 bits set to ${{ matrix.enable_x64 }})
-        env:
-          JAX_ENABLE_X64: ${{ matrix.enable_x64 }}
         run: |
+          export JAX_ENABLE_X64=${{ matrix.enable_x64 }}
           pytest --cov=./ --cov-report=xml
           codecov
 

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -41,6 +41,7 @@ jobs:
       #    flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with pytest
         run: |
+          export JAX_ENABLE_X64=True
           pytest --cov=./ --cov-report=xml
           codecov
 

--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,13 @@ indicating the number CPU devices to use. For example, to use 16 CPU cores, this
 
   os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=16"
 
+**Default Behavior and Configuration Flags**
+
+By default, JAX uses 32 bit datatypes when performing computations. Users of JAXtronomy are highly recommended
+to overwrite this behavior and use 64 bit datatypes instead, since 32 bit simulations have not been well-tested.
+Typically, this can be done by setting an environment variable or a configuration flag before any JAX operations
+are performed. For details, see `JAX documentation on configuration flags <https://docs.jax.dev/en/latest/config_options.html>`_
+
 **Example notebook**:
 `An example notebook <https://github.com/lenstronomy/JAXtronomy/blob/main/notebooks/modeling_a_simple_Einstein_ring.ipynb>`_ has been made available, which
 showcases the features and improvements in JAXtronomy.

--- a/jaxtronomy/ImSim/de_lens.py
+++ b/jaxtronomy/ImSim/de_lens.py
@@ -1,11 +1,7 @@
 __author__ = "sibirrer"
 
 from functools import partial
-from jax import config, jit, numpy as jnp
-
-config.update("jax_enable_x64", True)
-
-import numpy as np
+from jax import jit, numpy as jnp
 import sys
 
 EPSILON = sys.float_info.epsilon

--- a/jaxtronomy/ImSim/image_linear_solve.py
+++ b/jaxtronomy/ImSim/image_linear_solve.py
@@ -1,10 +1,8 @@
 from functools import partial
 from jax import jit, numpy as jnp
-import numpy as np
 
 import jaxtronomy.ImSim.de_lens as de_lens
 from jaxtronomy.ImSim.image_model import ImageModel
-from jaxtronomy.Util import util
 from jaxtronomy.ImSim.Numerics.convolution import PixelKernelConvolution
 
 __all__ = ["ImageLinearFit"]

--- a/jaxtronomy/LensModel/LineOfSight/single_plane_los.py
+++ b/jaxtronomy/LensModel/LineOfSight/single_plane_los.py
@@ -7,7 +7,6 @@ import copy
 from functools import partial
 from jax import debug, jit, numpy as jnp
 
-
 __all__ = ["SinglePlaneLOS"]
 
 

--- a/jaxtronomy/LensModel/LineOfSight/single_plane_los.py
+++ b/jaxtronomy/LensModel/LineOfSight/single_plane_los.py
@@ -5,9 +5,7 @@ from jaxtronomy.LensModel.profile_list_base import lens_class
 
 import copy
 from functools import partial
-from jax import config, debug, jit, numpy as jnp
-
-config.update("jax_enable_x64", True)  # 64-bit floats
+from jax import debug, jit, numpy as jnp
 
 
 __all__ = ["SinglePlaneLOS"]

--- a/jaxtronomy/LensModel/MultiPlane/decoupled_multi_plane.py
+++ b/jaxtronomy/LensModel/MultiPlane/decoupled_multi_plane.py
@@ -1,9 +1,7 @@
 __author__ = "dangilman"
 
 from functools import partial
-from jax import config, jit, numpy as jnp
-
-config.update("jax_enable_x64", True)
+from jax import jit, numpy as jnp
 
 from lenstronomy.LensModel.MultiPlane.multi_plane import MultiPlane
 from lenstronomy.Cosmo.background import Background

--- a/jaxtronomy/LensModel/Profiles/epl.py
+++ b/jaxtronomy/LensModel/Profiles/epl.py
@@ -1,9 +1,7 @@
 __author__ = "ntessore"
 
 from functools import partial
-from jax import config, custom_jvp, jvp, jit, lax, numpy as jnp, tree_util
-
-config.update("jax_enable_x64", True)  # 64-bit floats, consistent with numpy
+from jax import custom_jvp, jvp, jit, lax, numpy as jnp, tree_util
 
 from jaxtronomy.Util.hyp2f1_util import hyp2f1_lopez_temme_8 as hyp2f1
 from jaxtronomy.Util.util import rotate, shift_center

--- a/jaxtronomy/LensModel/Profiles/epl_multipole_m1m3m4.py
+++ b/jaxtronomy/LensModel/Profiles/epl_multipole_m1m3m4.py
@@ -1,8 +1,6 @@
 __author__ = "dangilman"
 
-from jax import config, jit, numpy as jnp
-
-config.update("jax_enable_x64", True)  # 64-bit floats, consistent with numpy
+from jax import jit, numpy as jnp
 
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 import jaxtronomy.Util.param_util as param_util

--- a/jaxtronomy/LensModel/Profiles/epl_multipole_m3m4.py
+++ b/jaxtronomy/LensModel/Profiles/epl_multipole_m3m4.py
@@ -1,8 +1,6 @@
 __author__ = "dangilman"
 
-from jax import config, jit, numpy as jnp
-
-config.update("jax_enable_x64", True)  # 64-bit floats, consistent with numpy
+from jax import jit, numpy as jnp
 
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 import jaxtronomy.Util.param_util as param_util

--- a/jaxtronomy/LensModel/Profiles/gaussian.py
+++ b/jaxtronomy/LensModel/Profiles/gaussian.py
@@ -1,7 +1,6 @@
 __author__ = "sibirrer"
 # this file contains a class to make a gaussian
 
-import jax
 from jax import jit, lax, numpy as jnp
 import jax.scipy.special
 import numpy as np
@@ -9,8 +8,6 @@ import numpy as np
 from jaxtronomy.Util.util import shift_center
 from jaxtronomy.LensModel.Profiles.gaussian_potential import GaussianPotential
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
-
-jax.config.update("jax_enable_x64", True)
 
 __all__ = ["Gaussian"]
 

--- a/jaxtronomy/LensModel/Profiles/multipole.py
+++ b/jaxtronomy/LensModel/Profiles/multipole.py
@@ -1,8 +1,6 @@
 __author__ = "lynevdv"
 
-from jax import config, jit, numpy as jnp, lax
-
-config.update("jax_enable_x64", True)  # 64-bit floats, consistent with numpy
+from jax import jit, numpy as jnp, lax
 
 import jaxtronomy.Util.param_util as param_util
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase

--- a/jaxtronomy/LensModel/Profiles/nfw.py
+++ b/jaxtronomy/LensModel/Profiles/nfw.py
@@ -2,13 +2,11 @@ __author__ = "sibirrer"
 
 # this file contains a class to compute the Navaro-Frenk-White profile
 
-from jax import config, jit
+from jax import jit
 import jax.numpy as jnp
 
 from jaxtronomy.Util.util import shift_center
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
-
-config.update("jax_enable_x64", True)
 
 __all__ = ["NFW"]
 

--- a/jaxtronomy/LensModel/Profiles/null.py
+++ b/jaxtronomy/LensModel/Profiles/null.py
@@ -1,9 +1,6 @@
-import jax
 from jax import jit, numpy as jnp
 
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
-
-jax.config.update("jax_enable_x64", True)
 
 __all__ = ["Null"]
 

--- a/jaxtronomy/LensModel/Profiles/sis.py
+++ b/jaxtronomy/LensModel/Profiles/sis.py
@@ -1,10 +1,8 @@
 __author__ = "sibirrer"
 
-from jax import config, jit, numpy as jnp
+from jax import jit, numpy as jnp
 from jaxtronomy.Util.util import shift_center
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
-
-config.update("jax_enable_x64", True)  # 64-bit floats
 
 __all__ = ["SIS"]
 

--- a/jaxtronomy/LensModel/Profiles/tnfw.py
+++ b/jaxtronomy/LensModel/Profiles/tnfw.py
@@ -3,12 +3,10 @@ __author__ = "sibirrer"
 # this file contains a class to compute the truncated Navaro-Frank-White function (Baltz et al 2009)in mass/kappa space
 # the potential therefore is its integral
 
-from jax import config, jit, numpy as jnp
+from jax import jit, numpy as jnp
 from lenstronomy.LensModel.Profiles.base_profile import LensProfileBase
 from jaxtronomy.LensModel.Profiles.nfw import NFW
 from jaxtronomy.Util.util import shift_center
-
-config.update("jax_enable_x64", True)
 
 __all__ = ["TNFW"]
 

--- a/jaxtronomy/LensModel/single_plane.py
+++ b/jaxtronomy/LensModel/single_plane.py
@@ -1,11 +1,8 @@
 __author__ = "sibirrer"
 
-import jax
 from jax import jit, numpy as jnp
 from jaxtronomy.LensModel.profile_list_base import ProfileListBase
 from functools import partial
-
-jax.config.update("jax_enable_x64", True)
 
 __all__ = ["SinglePlane"]
 

--- a/jaxtronomy/LensModel/single_plane_bulk.py
+++ b/jaxtronomy/LensModel/single_plane_bulk.py
@@ -1,12 +1,9 @@
 __author__ = "sibirrer"
 
-import jax
 from jax import jit, lax, numpy as jnp
 from jaxtronomy.LensModel.profile_list_base import ProfileListBase, _select_kwargs
 from functools import partial
 import numpy as np
-
-jax.config.update("jax_enable_x64", True)
 
 __all__ = ["SinglePlaneBulk"]
 

--- a/jaxtronomy/PointSource/point_source.py
+++ b/jaxtronomy/PointSource/point_source.py
@@ -1,7 +1,6 @@
 import copy
 from functools import partial
 from jax import jit, lax, numpy as jnp
-import numpy as np
 
 __all__ = ["PointSource"]
 

--- a/jaxtronomy/Sampling/Likelihoods/position_likelihood.py
+++ b/jaxtronomy/Sampling/Likelihoods/position_likelihood.py
@@ -1,10 +1,8 @@
 from functools import partial
-from jax import config, debug, jit, lax, numpy as jnp, vmap
+from jax import debug, jit, numpy as jnp, vmap
 import warnings
 
 # from lenstronomy.Util.cosmo_util import get_astropy_cosmology
-
-config.update("jax_enable_x64", True)
 
 __all__ = ["PositionLikelihood"]
 

--- a/jaxtronomy/Sampling/Samplers/optax.py
+++ b/jaxtronomy/Sampling/Samplers/optax.py
@@ -1,8 +1,6 @@
 __author__ = "ahuang314"
 
 import jax
-
-jax.config.update("jax_enable_x64", True)
 from jax import jit, numpy as jnp
 from functools import partial
 import optax

--- a/jaxtronomy/Sampling/likelihood.py
+++ b/jaxtronomy/Sampling/likelihood.py
@@ -2,8 +2,6 @@ __author__ = "sibirrer"
 
 from functools import partial
 import jax
-
-jax.config.update("jax_enable_x64", True)
 from jax import jit, lax, numpy as jnp
 import numpy as np
 

--- a/jaxtronomy/Workflow/fitting_sequence.py
+++ b/jaxtronomy/Workflow/fitting_sequence.py
@@ -14,11 +14,8 @@ from lenstronomy.Sampling.Samplers.nautilus_sampler import NautilusSampler
 from lenstronomy.Sampling.Samplers.cobaya_sampler import CobayaSampler
 
 import copy
-import jax
 import numpy as np
 import lenstronomy.Util.analysis_util as analysis_util
-
-jax.config.update("jax_enable_x64", True)
 
 
 __all__ = ["FittingSequence"]

--- a/jaxtronomy/Workflow/fitting_sequence.py
+++ b/jaxtronomy/Workflow/fitting_sequence.py
@@ -17,7 +17,6 @@ import copy
 import numpy as np
 import lenstronomy.Util.analysis_util as analysis_util
 
-
 __all__ = ["FittingSequence"]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 lenstronomy @ https://github.com/lenstronomy/lenstronomy/archive/refs/heads/main.zip
 numpy>=2.0.0
-jax>=0.7.0, <0.10.0
-numpyro>=0.19.0
+jax>=0.10.0
+numpyro>=0.21.0
 optax>=0.2.5
 scipy
 tqdm

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ from setuptools import setup, find_packages
 requires = [
     "lenstronomy>=1.13.6",
     "numpy>=2.0.0",
-    "jax>=0.7.0,<0.10.0",
-    "numpyro>=0.19.0",
+    "jax>=0.10.0",
+    "numpyro>=0.21.0",
     "optax>=0.2.5",
     "tqdm",
     "scipy",

--- a/test/test_ImSim/test_MultiBand/test_multi_linear.py
+++ b/test/test_ImSim/test_MultiBand/test_multi_linear.py
@@ -1,9 +1,6 @@
 import numpy.testing as npt
 import pytest
 import numpy as np
-import jax
-
-jax.config.update("jax_enable_x64", True)
 
 from jaxtronomy.ImSim.MultiBand.multi_linear import MultiLinear
 from lenstronomy.ImSim.MultiBand.multi_linear import MultiLinear as MultiLinear_ref

--- a/test/test_ImSim/test_Numerics/test_numerics.py
+++ b/test/test_ImSim/test_Numerics/test_numerics.py
@@ -1,5 +1,4 @@
 import pytest
-import jax
 import numpy.testing as npt
 
 import lenstronomy.Util.util as util
@@ -18,8 +17,6 @@ from lenstronomy.ImSim.Numerics.numerics import Numerics as Numerics_ref
 from lenstronomy.Data.pixel_grid import PixelGrid
 from lenstronomy.Data.psf import PSF
 from lenstronomy.LightModel.light_model import LightModel
-
-jax.config.update("jax_enable_x64", True)
 
 
 class TestNumerics(object):

--- a/test/test_ImSim/test_Numerics/test_numerics_subframe.py
+++ b/test/test_ImSim/test_Numerics/test_numerics_subframe.py
@@ -1,5 +1,4 @@
 import pytest
-import jax
 import numpy as np
 import numpy.testing as npt
 
@@ -21,8 +20,6 @@ from lenstronomy.ImSim.Numerics.numerics_subframe import (
 from lenstronomy.Data.pixel_grid import PixelGrid
 from lenstronomy.Data.psf import PSF
 from lenstronomy.LightModel.light_model import LightModel
-
-jax.config.update("jax_enable_x64", True)
 
 
 class TestNumericsSubFrame(object):

--- a/test/test_ImSim/test_Numerics/test_point_source_rendering.py
+++ b/test/test_ImSim/test_Numerics/test_point_source_rendering.py
@@ -6,13 +6,10 @@ from lenstronomy.Data.psf import PSF
 
 from jaxtronomy.ImSim.Numerics.point_source_rendering import PointSourceRendering
 
-from jax import config
 import numpy as np
 import numpy.testing as npt
 import pytest
 import unittest
-
-config.update("jax_enable_x64", True)
 
 
 class TestPointSourceRendering(object):

--- a/test/test_ImSim/test_de_lens.py
+++ b/test/test_ImSim/test_de_lens.py
@@ -1,8 +1,5 @@
 __author__ = "sibirrer"
 
-from jax import config
-
-config.update("jax_enable_x64", True)
 import numpy as np
 import numpy.testing as npt
 from lenstronomy.ImSim import de_lens as de_lens_ref

--- a/test/test_ImSim/test_image_linear_solve.py
+++ b/test/test_ImSim/test_image_linear_solve.py
@@ -1,9 +1,5 @@
 __author__ = "sibirrer"
 
-import jax
-
-jax.config.update("jax_enable_x64", True)
-
 import numpy as np
 import numpy.testing as npt
 

--- a/test/test_ImSim/test_image_model.py
+++ b/test/test_ImSim/test_image_model.py
@@ -1,6 +1,6 @@
 __author__ = "sibirrer"
 
-from jax import grad, config
+from jax import grad
 import numpy.testing as npt
 import numpy as np
 import pytest
@@ -20,8 +20,6 @@ from jaxtronomy.LensModel.lens_model import LensModel
 from jaxtronomy.LightModel.light_model import LightModel
 from jaxtronomy.ImSim.image_model import ImageModel
 from jaxtronomy.PointSource.point_source import PointSource
-
-config.update("jax_enable_x64", True)
 
 
 class TestImageModel(object):

--- a/test/test_LensModel/test_LineOfSight/test_single_plane_los.py
+++ b/test/test_LensModel/test_LineOfSight/test_single_plane_los.py
@@ -13,10 +13,6 @@ from jaxtronomy.LensModel.profile_list_base import _JAXXED_MODELS
 
 from astropy.cosmology import default_cosmology
 
-import jax
-
-jax.config.update("jax_enable_x64", True)  # 64-bit floats
-
 cosmo = default_cosmology.get()
 
 try:

--- a/test/test_LensModel/test_MultiPlane/test_multi_plane.py
+++ b/test/test_LensModel/test_MultiPlane/test_multi_plane.py
@@ -1,7 +1,3 @@
-import jax
-
-jax.config.update("jax_enable_x64", True)
-
 import numpy.testing as npt
 import numpy as np
 import pytest

--- a/test/test_LensModel/test_MultiPlane/test_multi_plane_bulk.py
+++ b/test/test_LensModel/test_MultiPlane/test_multi_plane_bulk.py
@@ -1,7 +1,3 @@
-import jax
-
-jax.config.update("jax_enable_x64", True)
-
 import numpy.testing as npt
 import numpy as np
 import pytest

--- a/test/test_LensModel/test_MultiPlane/test_multi_plane_decoupled.py
+++ b/test/test_LensModel/test_MultiPlane/test_multi_plane_decoupled.py
@@ -2,9 +2,6 @@ __author__ = "dangilman"
 
 import copy
 
-from jax import config
-
-config.update("jax_enable_x64", True)
 import numpy.testing as npt
 from jaxtronomy.LensModel.lens_model import LensModel
 from lenstronomy.LensModel.lens_model import LensModel as LensModel_ref

--- a/test/test_LensModel/test_Profiles/test_epl.py
+++ b/test/test_LensModel/test_Profiles/test_epl.py
@@ -8,9 +8,6 @@ from jaxtronomy.LensModel.Profiles.epl import EPL, EPLMajorAxis, EPLQPhi
 import numpy as np
 import numpy.testing as npt
 import pytest
-import jax
-
-jax.config.update("jax_enable_x64", True)  # 64-bit floats, consistent with numpy
 import jax.numpy as jnp
 
 

--- a/test/test_LensModel/test_Profiles/test_epl_multipole_m1m3m4.py
+++ b/test/test_LensModel/test_Profiles/test_epl_multipole_m1m3m4.py
@@ -1,7 +1,3 @@
-from jax import config
-
-config.update("jax_enable_x64", True)
-
 import numpy.testing as npt
 import numpy as np
 import pytest

--- a/test/test_LensModel/test_Profiles/test_epl_multipole_m3m4 .py
+++ b/test/test_LensModel/test_Profiles/test_epl_multipole_m3m4 .py
@@ -1,7 +1,3 @@
-from jax import config
-
-config.update("jax_enable_x64", True)
-
 import numpy.testing as npt
 import numpy as np
 import pytest

--- a/test/test_LensModel/test_Profiles/test_flexion.py
+++ b/test/test_LensModel/test_Profiles/test_flexion.py
@@ -1,7 +1,3 @@
-import jax
-
-jax.config.update("jax_enable_x64", True)
-
 import numpy as np
 import numpy.testing as npt
 import pytest

--- a/test/test_LensModel/test_Profiles/test_gaussian.py
+++ b/test/test_LensModel/test_Profiles/test_gaussian.py
@@ -1,6 +1,5 @@
 __author__ = "sibirrer"
 
-import jax
 import numpy as np
 import numpy.testing as npt
 import pytest
@@ -12,8 +11,6 @@ from lenstronomy.LensModel.Profiles.gaussian_potential import (
     GaussianPotential as GaussianPotential_ref,
 )
 from jaxtronomy.LensModel.Profiles.gaussian_potential import GaussianPotential
-
-jax.config.update("jax_enable_x64", True)
 
 
 class TestGaussian(object):

--- a/test/test_LensModel/test_Profiles/test_hernquist.py
+++ b/test/test_LensModel/test_Profiles/test_hernquist.py
@@ -1,14 +1,11 @@
 __author__ = "sibirrer"
 
-import jax
 import numpy as np
 import numpy.testing as npt
 import pytest
 
 from lenstronomy.LensModel.Profiles.hernquist import Hernquist as Hernquist_ref
 from jaxtronomy.LensModel.Profiles.hernquist import Hernquist
-
-jax.config.update("jax_enable_x64", True)
 
 
 class TestHernquist(object):

--- a/test/test_LensModel/test_Profiles/test_multipole.py
+++ b/test/test_LensModel/test_Profiles/test_multipole.py
@@ -1,7 +1,3 @@
-from jax import config
-
-config.update("jax_enable_x64", True)
-
 from jaxtronomy.LensModel.Profiles.multipole import (
     Multipole,
     EllipticalMultipole,

--- a/test/test_LensModel/test_Profiles/test_nie.py
+++ b/test/test_LensModel/test_Profiles/test_nie.py
@@ -4,12 +4,9 @@ __author__ = "sibirrer"
 import numpy as np
 import numpy.testing as npt
 import pytest
-import jax
 from jaxtronomy.LensModel.Profiles.nie import NIE, NIEMajorAxis
 from lenstronomy.LensModel.Profiles.nie import NIE as NIE_ref
 from lenstronomy.LensModel.Profiles.nie import NIEMajorAxis as NIEMajorAxis_ref
-
-jax.config.update("jax_enable_x64", True)
 
 
 class TestNIE(object):

--- a/test/test_LensModel/test_Profiles/test_p_jaffe.py
+++ b/test/test_LensModel/test_Profiles/test_p_jaffe.py
@@ -6,9 +6,6 @@ from lenstronomy.LensModel.Profiles.pseudo_jaffe import PseudoJaffe as Pjaffe_re
 import numpy as np
 import numpy.testing as npt
 import pytest
-import jax
-
-jax.config.update("jax_enable_x64", True)  # 64-bit floats, consistent with numpy
 import jax.numpy as jnp
 
 
@@ -154,32 +151,6 @@ class TestP_JAFFW(object):
         mass2d = self.profile.mass_2d(r, rho0, Ra, Rs)
         mass2d_ref = self.profile_ref.mass_2d(r, rho0, Ra, Rs)
         npt.assert_almost_equal(mass2d, mass2d_ref, decimal=8)
-
-    def test_jax_jit(self):
-        x = jnp.array([1])
-        y = jnp.array([2])
-        sigma0 = 1.0
-        Ra, Rs = 0.5, 0.8
-        jitted = jax.jit(self.profile.function)
-        npt.assert_almost_equal(
-            self.profile.function(x, y, sigma0, Ra, Rs),
-            jitted(x, y, sigma0, Ra, Rs),
-            decimal=8,
-        )
-
-        jitted = jax.jit(self.profile.derivatives)
-        npt.assert_array_almost_equal(
-            self.profile.derivatives(x, y, sigma0, Ra, Rs),
-            jitted(x, y, sigma0, Ra, Rs),
-            decimal=8,
-        )
-
-        jitted = jax.jit(self.profile.hessian)
-        npt.assert_array_almost_equal(
-            self.profile.hessian(x, y, sigma0, Ra, Rs),
-            jitted(x, y, sigma0, Ra, Rs),
-            decimal=8,
-        )
 
 
 if __name__ == "__main__":

--- a/test/test_LensModel/test_Profiles/test_p_jaffe_ellipse.py
+++ b/test/test_LensModel/test_Profiles/test_p_jaffe_ellipse.py
@@ -13,9 +13,6 @@ import lenstronomy.Util.param_util as param_util_ref
 import numpy as np
 import numpy.testing as npt
 import pytest
-import jax
-
-jax.config.update("jax_enable_x64", True)  # 64-bit floats, consistent with numpy
 import jax.numpy as jnp
 
 
@@ -138,34 +135,6 @@ class TestP_JAFFW(object):
             r=1, sigma0=1, Ra=0.5, Rs=0.8, e1=0, e2=0
         )
         npt.assert_almost_equal(mass, mass_ref, decimal=8)
-
-    def test_jax_jit(self):
-        x = jnp.array([1])
-        y = jnp.array([2])
-        sigma0 = 1.0
-        Ra, Rs = 0.5, 0.8
-        q, phi_G = 0.8, 0.1
-        e1, e2 = param_util.phi_q2_ellipticity(phi_G, q)
-        jitted = jax.jit(self.profile.function)
-        npt.assert_almost_equal(
-            self.profile.function(x, y, sigma0, Ra, Rs, e1, e2),
-            jitted(x, y, sigma0, Ra, Rs, e1, e2),
-            decimal=8,
-        )
-
-        jitted = jax.jit(self.profile.derivatives)
-        npt.assert_array_almost_equal(
-            self.profile.derivatives(x, y, sigma0, Ra, Rs, e1, e2),
-            jitted(x, y, sigma0, Ra, Rs, e1, e2),
-            decimal=8,
-        )
-
-        jitted = jax.jit(self.profile.hessian)
-        npt.assert_array_almost_equal(
-            self.profile.hessian(x, y, sigma0, Ra, Rs, e1, e2),
-            jitted(x, y, sigma0, Ra, Rs, e1, e2),
-            decimal=8,
-        )
 
 
 if __name__ == "__main__":

--- a/test/test_LensModel/test_Profiles/test_sie.py
+++ b/test/test_LensModel/test_Profiles/test_sie.py
@@ -3,7 +3,6 @@ __author__ = "sibirrer"
 import numpy as np
 import numpy.testing as npt
 import pytest
-import jaxtronomy.Util.param_util as param_util
 from jaxtronomy.LensModel.Profiles.sie import SIE
 from lenstronomy.LensModel.Profiles.sie import SIE as SIE_ref
 

--- a/test/test_LensModel/test_Profiles/test_sis.py
+++ b/test/test_LensModel/test_Profiles/test_sis.py
@@ -6,11 +6,6 @@ from lenstronomy.LensModel.Profiles.sis import SIS as SIS_ref
 import numpy as np
 import numpy.testing as npt
 import pytest
-import jax
-
-jax.config.update("jax_enable_x64", True)
-import jax.numpy as jnp
-
 
 class TestSIS(object):
     """Tests the Gaussian methods."""

--- a/test/test_LensModel/test_Profiles/test_sis.py
+++ b/test/test_LensModel/test_Profiles/test_sis.py
@@ -7,6 +7,7 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
+
 class TestSIS(object):
     """Tests the Gaussian methods."""
 

--- a/test/test_LensModel/test_Profiles/test_spp.py
+++ b/test/test_LensModel/test_Profiles/test_spp.py
@@ -7,6 +7,7 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
+
 class TestSPP(object):
     """Tests the Gaussian methods."""
 

--- a/test/test_LensModel/test_Profiles/test_spp.py
+++ b/test/test_LensModel/test_Profiles/test_spp.py
@@ -7,7 +7,6 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
-
 class TestSPP(object):
     """Tests the Gaussian methods."""
 

--- a/test/test_LensModel/test_Profiles/test_tnfw.py
+++ b/test/test_LensModel/test_Profiles/test_tnfw.py
@@ -1,9 +1,5 @@
 __author__ = "sibirrer"
 
-import jax
-
-jax.config.update("jax_enable_x64", True)
-
 import numpy as np
 import numpy.testing as npt
 import pytest

--- a/test/test_LensModel/test_Solver/test_lens_equation_solver.py
+++ b/test/test_LensModel/test_Solver/test_lens_equation_solver.py
@@ -1,6 +1,5 @@
 __author__ = "sibirrer"
 
-import jax
 import numpy.testing as npt
 import pytest
 from lenstronomy.LensModel.Solver.lens_equation_solver import (
@@ -12,8 +11,6 @@ from jaxtronomy.LensModel.Solver.lens_equation_solver import (
 )
 from lenstronomy.LensModel.lens_model import LensModel as LensModel_ref
 from jaxtronomy.LensModel.lens_model import LensModel
-
-jax.config.update("jax_enable_x64", True)
 
 # NOTE: The jaxtronomy solver sometimes finds more solutions than the
 #       lenstronomy solver for min_distance >= 0.05, not sure why

--- a/test/test_LensModel/test_lens_model.py
+++ b/test/test_LensModel/test_lens_model.py
@@ -9,10 +9,6 @@ from lenstronomy.LensModel.lens_model import LensModel as LensModel_ref
 from lenstronomy.Util.util import make_grid
 import unittest
 
-import jax
-
-jax.config.update("jax_enable_x64", True)  # 64-bit floats
-
 
 class TestLensModel(object):
     """Tests the source model routines."""

--- a/test/test_LensModel/test_lens_model_bulk.py
+++ b/test/test_LensModel/test_lens_model_bulk.py
@@ -1,7 +1,3 @@
-import jax
-
-jax.config.update("jax_enable_x64", True)
-
 import numpy.testing as npt
 import numpy as np
 import pytest

--- a/test/test_LensModel/test_single_plane.py
+++ b/test/test_LensModel/test_single_plane.py
@@ -1,9 +1,5 @@
 __author__ = "sibirrer"
 
-import jax
-
-jax.config.update("jax_enable_x64", True)  # 64-bit floats
-
 import numpy.testing as npt
 import pytest
 

--- a/test/test_LensModel/test_single_plane_bulk.py
+++ b/test/test_LensModel/test_single_plane_bulk.py
@@ -1,7 +1,3 @@
-import jax
-
-jax.config.update("jax_enable_x64", True)
-
 import numpy.testing as npt
 import numpy as np
 import pytest

--- a/test/test_LightModel/test_Profiles/test_shapelets.py
+++ b/test/test_LightModel/test_Profiles/test_shapelets.py
@@ -2,10 +2,6 @@ import numpy as np
 import pytest
 import numpy.testing as npt
 
-import jax
-
-jax.config.update("jax_enable_x64", True)
-
 from jaxtronomy.LightModel.Profiles.shapelets import (
     Shapelets,
     ShapeletSet,

--- a/test/test_LightModel/test_linear_basis.py
+++ b/test/test_LightModel/test_linear_basis.py
@@ -1,7 +1,3 @@
-import jax
-
-jax.config.update("jax_enable_x64", True)
-
 import numpy as np, numpy.testing as npt
 
 from jaxtronomy.LightModel.linear_basis import LinearBasis

--- a/test/test_PointSource/test_point_source.py
+++ b/test/test_PointSource/test_point_source.py
@@ -1,7 +1,4 @@
-import jax, jax.numpy as jnp
-
-jax.config.update("jax_enable_x64", True)
-
+import jax.numpy as jnp
 import pytest
 import copy
 import numpy as np

--- a/test/test_Sampling/test_Likelihoods/test_position_likelihood.py
+++ b/test/test_Sampling/test_Likelihoods/test_position_likelihood.py
@@ -2,7 +2,6 @@ import pytest
 import numpy.testing as npt
 import numpy as np
 import copy
-from jax import config
 
 from jaxtronomy.Sampling.Likelihoods.position_likelihood import PositionLikelihood
 from jaxtronomy.PointSource.point_source import PointSource
@@ -14,8 +13,6 @@ from lenstronomy.Sampling.Likelihoods.position_likelihood import (
 )
 from lenstronomy.PointSource.point_source import PointSource as PointSource_ref
 from lenstronomy.LensModel.lens_model import LensModel as LensModel_ref
-
-config.update("jax_enable_x64", True)
 
 
 class TestPositionLikelihood(object):

--- a/test/test_Sampling/test_Samplers/test_optax.py
+++ b/test/test_Sampling/test_Samplers/test_optax.py
@@ -3,13 +3,6 @@ __author__ = "ahuang314"
 import numpy as np
 import numpy.testing as npt
 
-# --------------------------------------------------------------------------
-# Remove these lines when numpyro gets updated for JAX v0.7.0 compatibility
-import jax.experimental.pjit
-from jax.extend.core.primitives import jit_p
-
-jax.experimental.pjit.pjit_p = jit_p
-# --------------------------------------------------------------------------
 from numpyro.infer.util import unconstrain_fn
 import pytest
 

--- a/test/test_Sampling/test_likelihood.py
+++ b/test/test_Sampling/test_likelihood.py
@@ -1,6 +1,6 @@
 __author__ = "sibirrer"
 
-from jax import config, numpy as jnp, grad, jit
+from jax import numpy as jnp, grad, jit
 import pytest
 import numpy as np
 import numpy.testing as npt
@@ -23,8 +23,6 @@ from jaxtronomy.LightModel.light_model_base import (
 from jaxtronomy.LensModel.lens_model import LensModel
 from jaxtronomy.LightModel.light_model import LightModel
 from jaxtronomy.Sampling.likelihood import ImageLikelihood
-
-config.update("jax_enable_x64", True)
 
 
 class TestLikelihoodModule(object):

--- a/test/test_Util/test_herm_util.py
+++ b/test/test_Util/test_herm_util.py
@@ -1,11 +1,8 @@
 import pytest
-
-import jax
 import numpy as np, numpy.testing as npt
 from numpy.polynomial.hermite import hermval as hermval_ref
 from scipy.special import eval_hermite as eval_hermite_ref
 
-jax.config.update("jax_enable_x64", True)  # 64-bit floats, consistent witsh numpy
 from jaxtronomy.Util.herm_util import eval_hermite, hermval
 
 A_TOL = 1e-10

--- a/test/test_Util/test_hyp2f1_util.py
+++ b/test/test_Util/test_hyp2f1_util.py
@@ -2,9 +2,7 @@ import pytest
 from scipy.special import hyp2f1 as hyp2f1_ref
 import numpy.testing as npt
 
-from jax import config, numpy as jnp
-
-config.update("jax_enable_x64", True)  # 64-bit floats, consistent with numpy
+from jax import numpy as jnp
 
 from jaxtronomy.Util.hyp2f1_util import (
     hyp2f1,

--- a/test/test_Util/test_image_util.py
+++ b/test/test_Util/test_image_util.py
@@ -1,14 +1,11 @@
 __author__ = "sibirrer"
 
 import pytest
-from jax import config
 import numpy as np
 import numpy.testing as npt
 
 import lenstronomy.Util.image_util as image_util_ref
 import jaxtronomy.Util.image_util as image_util
-
-config.update("jax_enable_x64", True)
 
 
 def test_add_layer2image():

--- a/test/test_Util/test_kernel_util.py
+++ b/test/test_Util/test_kernel_util.py
@@ -1,11 +1,8 @@
 import lenstronomy.Util.kernel_util as kernel_util_ref
 import jaxtronomy.Util.kernel_util as kernel_util
 
-from jax import config
 import numpy as np, numpy.testing as npt
 import pytest
-
-config.update("jax_enable_x64", True)
 
 
 def test_estimate_amp():

--- a/test/test_Util/test_param_util.py
+++ b/test/test_Util/test_param_util.py
@@ -1,13 +1,8 @@
 import numpy as np
 import pytest
 import numpy.testing as npt
-from lenstronomy.Util import util
 import jaxtronomy.Util.param_util as param_util
 import lenstronomy.Util.param_util as param_util_ref
-import jax
-
-jax.config.update("jax_enable_x64", True)  # 64-bit floats, consistent with numpy
-import jax.numpy as jnp
 
 
 def test_cart2polar():

--- a/test/test_Util/test_util.py
+++ b/test/test_Util/test_util.py
@@ -8,6 +8,7 @@ import pytest
 import numpy.testing as npt
 import jax.numpy as jnp
 
+
 def test_array2image():
     x = np.array([0, 1, 2, 5, 7, 3], dtype=float)
     npt.assert_raises(ValueError, util.array2image, x)

--- a/test/test_Util/test_util.py
+++ b/test/test_Util/test_util.py
@@ -3,12 +3,9 @@ __author__ = "sibirrer"
 import lenstronomy.Util.util as util_ref
 import jaxtronomy.Util.util as util
 
-import jax
 import numpy as np
 import pytest
 import numpy.testing as npt
-
-jax.config.update("jax_enable_x64", True)
 
 
 def test_array2image():

--- a/test/test_Util/test_util.py
+++ b/test/test_Util/test_util.py
@@ -6,7 +6,7 @@ import jaxtronomy.Util.util as util
 import numpy as np
 import pytest
 import numpy.testing as npt
-
+import jax.numpy as jnp
 
 def test_array2image():
     x = np.array([0, 1, 2, 5, 7, 3], dtype=float)
@@ -90,8 +90,8 @@ def test_shift_center():
     center_y = 6
 
     new_x, new_y = util.shift_center(x, y, center_x, center_y)
-    assert isinstance(new_x, jax.numpy.ndarray)
-    assert isinstance(new_y, jax.numpy.ndarray)
+    assert isinstance(new_x, jnp.ndarray)
+    assert isinstance(new_y, jnp.ndarray)
 
     npt.assert_equal(np.array(new_x), [-2, 0, 1, 3])
     npt.assert_equal(np.array(new_y), [-3, 34, -1, -4])


### PR DESCRIPTION
By default, JAX uses 32 bit datatypes for computations. Previously, JAXtronomy overwrote this behavior by setting configuration flags at the top of most files, forcing 64 bit datatype usage, making JAXtronomy incompatible with certain operating systems. There are two options:

1. Remove all configuration flags and allow the user to choose whether to use 32 or 64 bit datatypes. This restores JAXtronomy's compatibility with operating systems or devices that can only use 32 bit datatypes. However, JAXtronomy's simulations are not well tested with 32 bits.
2. Remove configuration flags that have been inconsistently scattered across many files, placing it instead within the top level `__init__.py` file so that any time JAXtronomy or a submodule is imported, 64 bit usage is automatically enabled.

This PR implements the first option and updates documentation accordingly. The CI-tests have been set to run using 64 bit datatypes only (this change was in the previous PR).