### PR TITLE
memory/speed optimizations

### DIFF
--- a/jaxtronomy/ImSim/image_linear_solve.py
+++ b/jaxtronomy/ImSim/image_linear_solve.py
@@ -1,9 +1,8 @@
 from functools import partial
-from jax import jit, numpy as jnp
+from jax import jit, lax, numpy as jnp
 
 import jaxtronomy.ImSim.de_lens as de_lens
 from jaxtronomy.ImSim.image_model import ImageModel
-from jaxtronomy.ImSim.Numerics.convolution import PixelKernelConvolution
 
 __all__ = ["ImageLinearFit"]
 
@@ -414,10 +413,9 @@ class ImageLinearFit(ImageModel):
 
         num_response = self.num_data_evaluate
         A = jnp.zeros((num_param, num_response))
-        n = 0
         # response of lensed source profile
-        for i in range(0, n_source):
-            image = source_light_response[i]
+        def body_fun(i, A):
+            image = source_light_response.at[i].get()
 
             # NOTE: Primary beam not supported in jaxtronomy
             # multiply with primary beam before convolution
@@ -426,9 +424,13 @@ class ImageLinearFit(ImageModel):
 
             # image *= extinction
             image = self.ImageNumerics.re_size_convolve(image, unconvolved=unconvolved)
-            A = A.at[n].set(jnp.nan_to_num(self.image2array_masked(image)))
-            n += 1
+            A = A.at[i].set(jnp.nan_to_num(self.image2array_masked(image)))
+            return A
+
+        A = lax.fori_loop(0, n_source, body_fun, A)
+
         # response of deflector light profile (or any other un-lensed extended components)
+        n = n_source
         for i in range(0, n_lens_light):
             image = lens_light_response[i]
 

--- a/jaxtronomy/ImSim/image_linear_solve.py
+++ b/jaxtronomy/ImSim/image_linear_solve.py
@@ -1,5 +1,6 @@
 from functools import partial
 from jax import jit, lax, numpy as jnp
+import jax
 
 import jaxtronomy.ImSim.de_lens as de_lens
 from jaxtronomy.ImSim.image_model import ImageModel
@@ -430,12 +431,15 @@ class ImageLinearFit(ImageModel):
             return A, n, light_response
 
         # response of lensed source profile
-        A, _, _ = lax.fori_loop(0, n_source, body_fun, (A, 0, source_light_response))
+        # this if-statement is needed to prevent compiler from trying to index into an empty array
+        if n_source != 0:
+            A, _, _ = lax.fori_loop(0, n_source, body_fun, (A, 0, source_light_response))
 
         # response of deflector light profile (or any other un-lensed extended components)
-        A, _, _ = lax.fori_loop(
-            0, n_lens_light, body_fun, (A, n_source, lens_light_response)
-        )
+        if n_lens_light != 0:
+            A, _, _ = lax.fori_loop(
+                0, n_lens_light, body_fun, (A, n_source, lens_light_response)
+            )
 
         # response of point sources
         n = n_source + n_lens_light

--- a/jaxtronomy/ImSim/image_linear_solve.py
+++ b/jaxtronomy/ImSim/image_linear_solve.py
@@ -433,7 +433,9 @@ class ImageLinearFit(ImageModel):
         # response of lensed source profile
         # this if-statement is needed to prevent compiler from trying to index into an empty array
         if n_source != 0:
-            A, _, _ = lax.fori_loop(0, n_source, body_fun, (A, 0, source_light_response))
+            A, _, _ = lax.fori_loop(
+                0, n_source, body_fun, (A, 0, source_light_response)
+            )
 
         # response of deflector light profile (or any other un-lensed extended components)
         if n_lens_light != 0:

--- a/jaxtronomy/ImSim/image_linear_solve.py
+++ b/jaxtronomy/ImSim/image_linear_solve.py
@@ -426,14 +426,16 @@ class ImageLinearFit(ImageModel):
 
             # image *= extinction
             image = self.ImageNumerics.re_size_convolve(image, unconvolved=unconvolved)
-            A = A.at[i+n].set(jnp.nan_to_num(self.image2array_masked(image)))
+            A = A.at[i + n].set(jnp.nan_to_num(self.image2array_masked(image)))
             return A, n, light_response
 
         # response of lensed source profile
         A, _, _ = lax.fori_loop(0, n_source, body_fun, (A, 0, source_light_response))
 
         # response of deflector light profile (or any other un-lensed extended components)
-        A, _, _ = lax.fori_loop(0, n_lens_light, body_fun, (A, n_source, lens_light_response))
+        A, _, _ = lax.fori_loop(
+            0, n_lens_light, body_fun, (A, n_source, lens_light_response)
+        )
 
         # response of point sources
         for i in range(0, n_points):

--- a/jaxtronomy/ImSim/image_linear_solve.py
+++ b/jaxtronomy/ImSim/image_linear_solve.py
@@ -438,6 +438,7 @@ class ImageLinearFit(ImageModel):
         )
 
         # response of point sources
+        n = n_source + n_lens_light
         for i in range(0, n_points):
             # NOTE: Primary beam not supported in jaxtronomy
             # raise warnings when primary beam is attempted to be applied for point sources
@@ -447,8 +448,7 @@ class ImageLinearFit(ImageModel):
             image = self.ImageNumerics.point_source_rendering(
                 ra_pos[i], dec_pos[i], amp[i]
             )
-            A = A.at[n].set(jnp.nan_to_num(self.image2array_masked(image)))
-            n += 1
+            A = A.at[i + n].set(jnp.nan_to_num(self.image2array_masked(image)))
         return A * self._flux_scaling
 
     @partial(jit, static_argnums=(0,))

--- a/jaxtronomy/ImSim/image_linear_solve.py
+++ b/jaxtronomy/ImSim/image_linear_solve.py
@@ -413,9 +413,11 @@ class ImageLinearFit(ImageModel):
 
         num_response = self.num_data_evaluate
         A = jnp.zeros((num_param, num_response))
-        # response of lensed source profile
-        def body_fun(i, A):
-            image = source_light_response.at[i].get()
+
+        # This function loops through the light responses
+        def body_fun(i, val):
+            A, n, light_response = val
+            image = light_response.at[i].get()
 
             # NOTE: Primary beam not supported in jaxtronomy
             # multiply with primary beam before convolution
@@ -424,24 +426,15 @@ class ImageLinearFit(ImageModel):
 
             # image *= extinction
             image = self.ImageNumerics.re_size_convolve(image, unconvolved=unconvolved)
-            A = A.at[i].set(jnp.nan_to_num(self.image2array_masked(image)))
-            return A
+            A = A.at[i+n].set(jnp.nan_to_num(self.image2array_masked(image)))
+            return A, n, light_response
 
-        A = lax.fori_loop(0, n_source, body_fun, A)
+        # response of lensed source profile
+        A, _, _ = lax.fori_loop(0, n_source, body_fun, (A, 0, source_light_response))
 
         # response of deflector light profile (or any other un-lensed extended components)
-        n = n_source
-        for i in range(0, n_lens_light):
-            image = lens_light_response[i]
+        A, _, _ = lax.fori_loop(0, n_lens_light, body_fun, (A, n_source, lens_light_response))
 
-            # NOTE: Primary beam not supported in jaxtronomy
-            # multiply with primary beam before convolution
-            # if self._pb is not None:
-            #    image *= self._pb_1d
-
-            image = self.ImageNumerics.re_size_convolve(image, unconvolved=unconvolved)
-            A = A.at[n].set(jnp.nan_to_num(self.image2array_masked(image)))
-            n += 1
         # response of point sources
         for i in range(0, n_points):
             # NOTE: Primary beam not supported in jaxtronomy

--- a/jaxtronomy/LightModel/Profiles/gaussian.py
+++ b/jaxtronomy/LightModel/Profiles/gaussian.py
@@ -209,11 +209,15 @@ class MultiGaussian(object):
         :return: list of arrays of surface brightness
         """
         f_list = jnp.zeros((len(amp), x.size), dtype=float)
-        
+
         def body_fun(i, f_list):
-            f_list = f_list.at[i].set(Gaussian.function(x, y, amp.at[i].get(), sigma.at[i].get(), center_x, center_y))
+            f_list = f_list.at[i].set(
+                Gaussian.function(
+                    x, y, amp.at[i].get(), sigma.at[i].get(), center_x, center_y
+                )
+            )
             return f_list
-        
+
         return lax.fori_loop(0, len(amp), body_fun, f_list)
 
     @staticmethod
@@ -317,11 +321,13 @@ class MultiGaussianEllipse(object):
             x, y, e1, e2, center_x, center_y
         )
         f_list = jnp.zeros((len(amp), x.size), dtype=float)
-    
+
         def body_fun(i, f_list):
-            f_list = f_list.at[i].set(Gaussian.function(x_, y_, amp.at[i].get(), sigma.at[i].get()))
+            f_list = f_list.at[i].set(
+                Gaussian.function(x_, y_, amp.at[i].get(), sigma.at[i].get())
+            )
             return f_list
-        
+
         return lax.fori_loop(0, len(amp), body_fun, f_list)
 
     @staticmethod

--- a/jaxtronomy/LightModel/Profiles/gaussian.py
+++ b/jaxtronomy/LightModel/Profiles/gaussian.py
@@ -1,4 +1,4 @@
-from jax import jit, numpy as jnp
+from jax import jit, lax, numpy as jnp
 import jaxtronomy.Util.param_util as param_util
 
 
@@ -208,10 +208,13 @@ class MultiGaussian(object):
         :param center_y: center of profile
         :return: list of arrays of surface brightness
         """
-        f_list = []
-        for i in range(len(amp)):
-            f_list.append(Gaussian.function(x, y, amp[i], sigma[i], center_x, center_y))
-        return f_list
+        f_list = jnp.zeros((len(amp), x.size), dtype=float)
+        
+        def body_fun(i, f_list):
+            f_list = f_list.at[i].set(Gaussian.function(x, y, amp.at[i].get(), sigma.at[i].get(), center_x, center_y))
+            return f_list
+        
+        return lax.fori_loop(0, len(amp), body_fun, f_list)
 
     @staticmethod
     @jit
@@ -313,12 +316,13 @@ class MultiGaussianEllipse(object):
         x_, y_ = param_util.transform_e1e2_product_average(
             x, y, e1, e2, center_x, center_y
         )
-        f_list = []
-        for i in range(len(amp)):
-            f_list.append(
-                Gaussian.function(x_, y_, amp[i], sigma[i], center_x=0, center_y=0)
-            )
-        return f_list
+        f_list = jnp.zeros((len(amp), x.size), dtype=float)
+    
+        def body_fun(i, f_list):
+            f_list = f_list.at[i].set(Gaussian.function(x_, y_, amp.at[i].get(), sigma.at[i].get()))
+            return f_list
+        
+        return lax.fori_loop(0, len(amp), body_fun, f_list)
 
     @staticmethod
     @jit

--- a/jaxtronomy/LightModel/Profiles/gaussian.py
+++ b/jaxtronomy/LightModel/Profiles/gaussian.py
@@ -208,6 +208,7 @@ class MultiGaussian(object):
         :param center_y: center of profile
         :return: list of arrays of surface brightness
         """
+        amp = jnp.asarray(amp, dtype=float)
         sigma = jnp.asarray(sigma, dtype=float)
         f_list = jnp.zeros((len(amp), x.size), dtype=float)
 
@@ -321,6 +322,7 @@ class MultiGaussianEllipse(object):
         x_, y_ = param_util.transform_e1e2_product_average(
             x, y, e1, e2, center_x, center_y
         )
+        amp = jnp.asarray(amp, dtype=float)
         sigma = jnp.asarray(sigma, dtype=float)
         f_list = jnp.zeros((len(amp), x.size), dtype=float)
 

--- a/jaxtronomy/LightModel/Profiles/gaussian.py
+++ b/jaxtronomy/LightModel/Profiles/gaussian.py
@@ -208,6 +208,7 @@ class MultiGaussian(object):
         :param center_y: center of profile
         :return: list of arrays of surface brightness
         """
+        sigma = jnp.asarray(sigma, dtype=float)
         f_list = jnp.zeros((len(amp), x.size), dtype=float)
 
         def body_fun(i, f_list):
@@ -320,6 +321,7 @@ class MultiGaussianEllipse(object):
         x_, y_ = param_util.transform_e1e2_product_average(
             x, y, e1, e2, center_x, center_y
         )
+        sigma = jnp.asarray(sigma, dtype=float)
         f_list = jnp.zeros((len(amp), x.size), dtype=float)
 
         def body_fun(i, f_list):

--- a/jaxtronomy/LightModel/Profiles/shapelets.py
+++ b/jaxtronomy/LightModel/Profiles/shapelets.py
@@ -412,12 +412,13 @@ class ShapeletSetStatic(object):
 
         n1 = 0
         n2 = 0
+        f_ = jnp.zeros((len(amp), x.size), dtype=float)
 
-        for i in range(len(amp)):
-            f_.append(jnp.nan_to_num(amp[i] * phi_x[n1] * phi_y[n2]))
-            if n1 == 0:
-                n1, n2 = n2 + 1, 0
-            else:
-                n1, n2 = n1 - 1, n2 + 1
+        def body_fun(i, val):
+            f_, n1, n2 = val
+            f_ = f_.at[i].set(amp.at[i].get() * phi_x.at[n1].get() * phi_y.at[n2].get())
+            n1, n2 = jnp.where(n1 == 0, n2 + 1, n1 - 1), jnp.where(n1 == 0, 0, n2 + 1)
+            return f_, n1, n2
 
-        return f_
+        f_ = lax.fori_loop(0, self.num_param, body_fun, (f_, n1, n2))[0]
+        return jnp.nan_to_num(f_)

--- a/jaxtronomy/LightModel/linear_basis.py
+++ b/jaxtronomy/LightModel/linear_basis.py
@@ -30,7 +30,8 @@ class LinearBasis(LightModelBase):
         :param kwargs_list: keyword argument list of light profile
         :param k: integer or tuple of integers for selecting subsets of light profiles
         """
-        response = []
+        num_param = self.num_param_linear(kwargs_list)
+        response = jnp.zeros((num_param, x.size), dtype=float)
         n = 0
         bool_list = self._bool_list(k=k)
         for i, model in enumerate(self.profile_type_list):
@@ -61,14 +62,14 @@ class LinearBasis(LightModelBase):
                     kwargs_new = kwargs_list[i].copy()
                     new = {"amp": 1}
                     kwargs_new.update(new)
-                    response += [self.func_list[i].function(x, y, **kwargs_new)]
+                    response = response.at[n].set(self.func_list[i].function(x, y, **kwargs_new))
                     n += 1
                 elif model in ["MULTI_GAUSSIAN", "MULTI_GAUSSIAN_ELLIPSE"]:
                     num = len(kwargs_list[i]["sigma"])
                     new = {"amp": np.ones(num)}
                     kwargs_new = kwargs_list[i].copy()
                     kwargs_new.update(new)
-                    response += self.func_list[i].function_split(x, y, **kwargs_new)
+                    response = response.at[n:n+num].set(self.func_list[i].function_split(x, y, **kwargs_new))
                     n += num
                 elif model in [
                     "SHAPELETS",
@@ -80,7 +81,7 @@ class LinearBasis(LightModelBase):
                     new = {"amp": np.ones(num_param)}
                     kwargs_new = kwargs_list[i].copy()
                     kwargs_new.update(new)
-                    response += self.func_list[i].function_split(x, y, **kwargs_new)
+                    response = response.at[n:n+num_param].set(self.func_list[i].function_split(x, y, **kwargs_new))
                     n += num_param
                 # elif model in ["SLIT_STARLETS", "SLIT_STARLETS_GEN2"]:
                 #     raise ValueError(
@@ -90,28 +91,17 @@ class LinearBasis(LightModelBase):
                     raise ValueError("model type %s not valid!" % model)
         return response, n
 
-    @partial(jit, static_argnums=(0, 2))
     def num_param_linear(self, kwargs_list, list_return=False):
-        """
+        """Returns the the number of linear components per model.
 
         :param kwargs_list: list of keyword arguments of the light profiles
         :param list_return: bool, if True returns list of individual number of parameters
         :return: number of linear basis set coefficients
         """
-        n_list = self.num_param_linear_list(kwargs_list)
-        if not list_return:
-            return jnp.sum(jnp.array(n_list))
-        return n_list
-
-    @partial(jit, static_argnums=(0,))
-    def num_param_linear_list(self, kwargs_list):
-        """Returns the list (in order of the light profiles) of the number of linear
-        components per model.
-
-        :param kwargs_list: list of keyword arguments of the light profiles
-        :return: number of linear basis set coefficients
-        """
-        n_list = []
+        if list_return:
+            n_list = []
+        else:
+            n = 0
         for i, model in enumerate(self.profile_type_list):
             if model in [
                 "SERSIC",
@@ -135,10 +125,16 @@ class LinearBasis(LightModelBase):
                 "LINEAR_ELLIPSE",
                 "LINE_PROFILE",
             ]:
-                n_list += [1]
+                if list_return:
+                    n_list += [1]
+                else:
+                    n += 1
             elif model in ["MULTI_GAUSSIAN", "MULTI_GAUSSIAN_ELLIPSE"]:
                 num = len(kwargs_list[i]["sigma"])
-                n_list += [num]
+                if list_return:
+                    n_list += [num]
+                else:
+                    n += num
             elif model in [
                 "SHAPELETS",
                 "SHAPELETS_POLAR",
@@ -146,7 +142,10 @@ class LinearBasis(LightModelBase):
                 "SHAPELETS_ELLIPSE",
             ]:
                 num_param = self.func_list[i].num_param
-                n_list += [num_param]
+                if list_return:
+                    n_list += [num_param]
+                else:
+                    n += num_param
             # elif model in ["SLIT_STARLETS", "SLIT_STARLETS_GEN2"]:
             #     n_scales = kwargs_list[i]["n_scales"]
             #     n_pixels = kwargs_list[i]["n_pixels"]
@@ -156,7 +155,19 @@ class LinearBasis(LightModelBase):
             #     ]  # TODO : find a way to make it the number of source pixels
             else:
                 raise ValueError("model type %s not valid!" % model)
-        return n_list
+        if list_return:
+            return n_list
+        else:
+            return n
+
+    def num_param_linear_list(self, kwargs_list):
+        """Returns the list (in order of the light profiles) of the number of linear
+        components per model.
+
+        :param kwargs_list: list of keyword arguments of the light profiles
+        :return: number of linear basis set coefficients
+        """
+        return self.num_param_linear(kwargs_list, True)
 
     @partial(jit, static_argnums=(0,))
     def update_linear(self, param, i, kwargs_list):

--- a/jaxtronomy/LightModel/linear_basis.py
+++ b/jaxtronomy/LightModel/linear_basis.py
@@ -62,14 +62,18 @@ class LinearBasis(LightModelBase):
                     kwargs_new = kwargs_list[i].copy()
                     new = {"amp": 1}
                     kwargs_new.update(new)
-                    response = response.at[n].set(self.func_list[i].function(x, y, **kwargs_new))
+                    response = response.at[n].set(
+                        self.func_list[i].function(x, y, **kwargs_new)
+                    )
                     n += 1
                 elif model in ["MULTI_GAUSSIAN", "MULTI_GAUSSIAN_ELLIPSE"]:
                     num = len(kwargs_list[i]["sigma"])
                     new = {"amp": np.ones(num)}
                     kwargs_new = kwargs_list[i].copy()
                     kwargs_new.update(new)
-                    response = response.at[n:n+num].set(self.func_list[i].function_split(x, y, **kwargs_new))
+                    response = response.at[n : n + num].set(
+                        self.func_list[i].function_split(x, y, **kwargs_new)
+                    )
                     n += num
                 elif model in [
                     "SHAPELETS",
@@ -81,7 +85,9 @@ class LinearBasis(LightModelBase):
                     new = {"amp": np.ones(num_param)}
                     kwargs_new = kwargs_list[i].copy()
                     kwargs_new.update(new)
-                    response = response.at[n:n+num_param].set(self.func_list[i].function_split(x, y, **kwargs_new))
+                    response = response.at[n : n + num_param].set(
+                        self.func_list[i].function_split(x, y, **kwargs_new)
+                    )
                     n += num_param
                 # elif model in ["SLIT_STARLETS", "SLIT_STARLETS_GEN2"]:
                 #     raise ValueError(
@@ -95,7 +101,8 @@ class LinearBasis(LightModelBase):
         """Returns the the number of linear components per model.
 
         :param kwargs_list: list of keyword arguments of the light profiles
-        :param list_return: bool, if True returns list of individual number of parameters
+        :param list_return: bool, if True returns list of individual number of
+            parameters
         :return: number of linear basis set coefficients
         """
         if list_return:

--- a/jaxtronomy/LightModel/linear_basis.py
+++ b/jaxtronomy/LightModel/linear_basis.py
@@ -161,10 +161,8 @@ class LinearBasis(LightModelBase):
             #     n_list += [
             #         num_param
             #     ]  # TODO : find a way to make it the number of source pixels
-            # NOTE: the following line of code is impossible to execute since JAXtronomy
-            # doesn't contain any light profiles not included in the above if-statements
-            # else:
-            #     raise ValueError("model type %s not valid!" % model)
+            else:
+                raise ValueError("model type %s not valid!" % model)
         if list_return:
             return n_list
         else:

--- a/jaxtronomy/LightModel/linear_basis.py
+++ b/jaxtronomy/LightModel/linear_basis.py
@@ -93,8 +93,6 @@ class LinearBasis(LightModelBase):
                 #     raise ValueError(
                 #         "'{}' model does not support function split".format(model)
                 #     )
-                else:
-                    raise ValueError("model type %s not valid!" % model)
         return response, n
 
     def num_param_linear(self, kwargs_list, list_return=False):

--- a/jaxtronomy/LightModel/linear_basis.py
+++ b/jaxtronomy/LightModel/linear_basis.py
@@ -113,6 +113,7 @@ class LinearBasis(LightModelBase):
             if model in [
                 "SERSIC",
                 "SERSIC_ELLIPSE",
+                "SERSIC_ELLIPSE_Q_PHI",
                 "CORE_SERSIC",
                 "HERNQUIST",
                 "HERNQUIST_ELLIPSE",

--- a/jaxtronomy/LightModel/linear_basis.py
+++ b/jaxtronomy/LightModel/linear_basis.py
@@ -161,8 +161,10 @@ class LinearBasis(LightModelBase):
             #     n_list += [
             #         num_param
             #     ]  # TODO : find a way to make it the number of source pixels
-            else:
-                raise ValueError("model type %s not valid!" % model)
+            # NOTE: the following line of code is impossible to execute since JAXtronomy
+            # doesn't contain any light profiles not included in the above if-statements
+            # else:
+            #     raise ValueError("model type %s not valid!" % model)
         if list_return:
             return n_list
         else:


### PR DESCRIPTION
1. When the linear solver is activated, the source light response has to be computed for each amplitude component. Previously, this was done using regular python for-loops scattered throughout the code. Since JAX unrolls for-loops during compilation, these loops can result in the kernel crashing (on both CPU and GPU) if e.g. high order Shapelets are used. This is due to the memory usage blowing up if the number of for-loop iterations is in the hundreds. This PR replaces these loops with JAX for-loops which do not result in a memory blow-up.
2. Point source responses also use python for-loops and suffer the same problem as above. However, in this case, the number of for-loop iterations typically does not exceed 4, so they are unlikely to be problematic. Therefore, these for-loops have been untouched.
3. Appending to lists is slow on GPU (and also no longer works once the for-loops have been converted to JAX versions). The `function_split` functions in LinearBasis and various LightModels have been modified to pre-allocate arrays and make in-place updates.