### PR TITLE
Implement a fully JAX'd version of PSO

### DIFF
--- a/jaxtronomy/Sampling/Samplers/pso.py
+++ b/jaxtronomy/Sampling/Samplers/pso.py
@@ -10,13 +10,13 @@ __all__ = ["ParticleSwarmOptimizer"]
 
 class ParticleSwarmOptimizer(PSO_lenstronomy):
     """Optimizer using a swarm of particles. Same as the PSO from lenstronomy, but the
-    input log likelihood function is assumed to be vectorized.
+    input log likelihood function is assumed to be parallelized across CPU cores (e.g. pmap(f)).
 
-    :param func: A function that takes a vector in the parameter space as input and
-        returns the natural logarithm of the posterior probability for that position.
-    :param low: array of the lower bound of the parameter space
-    :param high: array of the upper bound of the parameter space
-    :param particle_count: the number of particles to use.
+    The PSO algorithm in this class does not happen within JIT, since jit(pmap(f)) is generally
+    not recommended and can lead to unwanted side effects (see discussion at
+    https://github.com/jax-ml/jax/issues/2926#issuecomment-802411631). Thus, this class is unfit
+    for running PSO on GPU due to memory transfer overheads between CPU and GPU. To run PSO on GPU,
+    use the ParticleSwarmOptimizerJIT class in pso_jit.py.
     """
 
     def __init__(
@@ -28,7 +28,8 @@ class ParticleSwarmOptimizer(PSO_lenstronomy):
     ):
         """
 
-        :param func: function to call to return log likelihood. Must be a vectorized logL function.
+        :param func: function to call to return log likelihood of swarm. Must take in the position vector
+            of the entire swarm.
         :type func: python definition
         :param low: lower bound of the parameters
         :type low: numpy array
@@ -48,6 +49,10 @@ class ParticleSwarmOptimizer(PSO_lenstronomy):
         self.logL_func = func
         self.swarm = self._init_swarm()
 
+    @property
+    def global_best_fitness(self):
+        return self.global_best.fitness
+
     def _get_fitness(self, swarm):
         """Set fitness (probability) of the particles in swarm.
 
@@ -58,8 +63,8 @@ class ParticleSwarmOptimizer(PSO_lenstronomy):
         """
         position = [particle.position for particle in swarm]
 
-        position = np.array(position)
-        ln_probability = np.array(self.logL_func(position))
+        position = np.asarray(position, dtype=float)
+        ln_probability = np.asarray(self.logL_func(position), dtype=float)
 
         for i, particle in enumerate(swarm):
             particle.fitness = ln_probability[i]

--- a/jaxtronomy/Sampling/Samplers/pso.py
+++ b/jaxtronomy/Sampling/Samplers/pso.py
@@ -10,11 +10,13 @@ __all__ = ["ParticleSwarmOptimizer"]
 
 class ParticleSwarmOptimizer(PSO_lenstronomy):
     """Optimizer using a swarm of particles. Same as the PSO from lenstronomy, but the
-    input log likelihood function is assumed to be parallelized across CPU cores (e.g. pmap(f)).
+    input log likelihood function is assumed to be parallelized across CPU cores (e.g.
+    pmap(f)).
 
-    The PSO algorithm in this class does not happen within JIT, since jit(pmap(f)) is generally
-    not recommended and can lead to unwanted side effects (see discussion at
-    https://github.com/jax-ml/jax/issues/2926#issuecomment-802411631). Thus, this class is unfit
+    The PSO algorithm in this class does not happen within JIT, since jit(pmap(f)) is
+    generally not recommended and can lead to unwanted side effects (see discussion at
+    https://github.com/jax-ml/jax/issues/2926#issuecomment-802411631).
+    Thus, this class is unfit
     for running PSO on GPU due to memory transfer overheads between CPU and GPU. To run PSO on GPU,
     use the ParticleSwarmOptimizerJIT class in pso_jit.py.
     """

--- a/jaxtronomy/Sampling/Samplers/pso_jit.py
+++ b/jaxtronomy/Sampling/Samplers/pso_jit.py
@@ -98,7 +98,9 @@ class ParticleSwarmOptimizerJIT(object):
             m of the global best fitness
         :param n: stop criterion tolerance; positions of best p% of particles must be within
             n euclidean distance of the global best position
-        :param early_stop_tolerance: will terminate at the given value (should be specified as a chi^2)
+        :param early_stop_tolerance: float or None; if set, will terminate the PSO early if
+            |2 * global_best_fitness| < early_stop_tolerance. This takes priority over the
+            fitness and spatial convergence criteria.
         :param rng_seed: int, rng seed for reproducibility. If None, a random seed is used
         """
         log_likelihood_list = []
@@ -160,8 +162,8 @@ class ParticleSwarmOptimizerJIT(object):
             within m of the global best fitness
         :param n: stop criterion tolerance; positions of best p% of particles must be
             within n euclidean distance of the global best position
-        :param early_stop_tolerance: if set, will cause the PSO to terminate if |2 *
-            global_best_fitness| < early_stop_tolerance. This takes priority over the
+        :param early_stop_tolerance: float or None; if set, will terminate the PSO early if
+            |2 * global_best_fitness| < early_stop_tolerance. This takes priority over the
             fitness and spatial convergence criteria.
         :param verbose: if True, prints out the iteration number as the loop progresses
         :type verbose: boolean
@@ -350,7 +352,7 @@ class ParticleSwarmOptimizerJIT(object):
 
     @partial(jit, static_argnums=(0, 1))
     def _converged_fit(self, p, m, global_best_fitness, personal_best_fitnesses):
-        """Given the global best fitnesses and an array of personal best fitnesses of
+        """Given the global best fitness and an array of personal best fitnesses of
         the swarm, determine whether or not the average fitness of the best p% of
         particles is within m of the global best fitness.
 
@@ -362,8 +364,8 @@ class ParticleSwarmOptimizerJIT(object):
         :param global_best_fitness: float, the current best fitness of the swarm
         :param personal_best_fitnesses: 1d array of floats with size n_particles
             containing the best fitnesses for each particle in the swarm
-        :return: whether or not the average of the best p% of particles is within m of
-            the
+        :return: whether or not the average fitness of the best p% of particles is within m of
+            the global best fitness
         :rtype: bool
         """
 
@@ -384,11 +386,11 @@ class ParticleSwarmOptimizerJIT(object):
         :type p: float
         :param n: tolerance criteria for euclidean distance
         :type n: float
-        :param global_best_position: 1d array of size len(args), current best position
+        :param global_best_position: 1d array of size len(args), current best position of swarm
         :type global_best_position: array
         :param swarm_fitnesses: 1d array of floats with size n_particles containing the
-        :return: whether or not the average of the best p% of particles is within m of
-            the
+        :return: whether or not the best p% of particles is within n euclidean distance of
+            the global best position
         :rtype: bool
         """
 

--- a/jaxtronomy/Sampling/Samplers/pso_jit.py
+++ b/jaxtronomy/Sampling/Samplers/pso_jit.py
@@ -3,7 +3,6 @@ from jax import jit, lax, numpy as jnp
 import numpy as np
 from functools import partial
 
-
 __all__ = ["ParticleSwarmOptimizerJIT"]
 
 
@@ -17,7 +16,11 @@ class ParticleSwarmOptimizerJIT(object):
     """
 
     def __init__(
-        self, func, low, high, particle_count=25,
+        self,
+        func,
+        low,
+        high,
+        particle_count=25,
     ):
         """
 
@@ -39,7 +42,6 @@ class ParticleSwarmOptimizerJIT(object):
 
         self.set_global_best(jnp.zeros(self.param_count), None, -jnp.inf)
 
-
     def _init_swarm(self):
         """Initiate the swarm.
 
@@ -48,9 +50,7 @@ class ParticleSwarmOptimizerJIT(object):
         swarm_positions = np.zeros((self.particleCount, self.param_count))
         for i in range(self.particleCount):
             swarm_positions[i] = np.random.uniform(
-                self.low,
-                self.high,
-                size=self.param_count
+                self.low, self.high, size=self.param_count
             )
 
         swarm_positions = jnp.array(swarm_positions, dtype=float)
@@ -112,14 +112,24 @@ class ParticleSwarmOptimizerJIT(object):
 
         print("starting PSO optimization")
         global_best_position, global_best_fitness = self.run_iterations(
-            init_swarm, self.global_best_position, self.global_best_fitness, max_iter, c1, c2, p, m, n, early_stop_tolerance, rng_seed, verbose
+            init_swarm,
+            self.global_best_position,
+            self.global_best_fitness,
+            max_iter,
+            c1,
+            c2,
+            p,
+            m,
+            n,
+            early_stop_tolerance,
+            rng_seed,
+            verbose,
         )
         self.set_global_best(global_best_position, None, global_best_fitness)
 
         return np.array(global_best_position), [log_likelihood_list, pos_list, vel_list]
 
-
-    @partial(jit, static_argnums=(0,7,12))
+    @partial(jit, static_argnums=(0, 7, 12))
     def run_iterations(
         self,
         init_swarm,
@@ -138,19 +148,21 @@ class ParticleSwarmOptimizerJIT(object):
         """Launches the PSO. Yields the complete swarm per iteration.
 
         :param max_iter: maximum iterations
-        :param global_best_position: 1d array of size len(args); the initial values for the best particle position
-        :param global_best_fitness: float; the initial value for the best particle fitness
+        :param global_best_position: 1d array of size len(args); the initial values for
+            the best particle position
+        :param global_best_fitness: float; the initial value for the best particle
+            fitness
         :param c1: cognitive weight
         :param c2: social weight
-        :param p: float between 0 and 1, determines the percentage of particles to use to
-            compute swarm fit and position convergence
-        :param m: stop criterion tolerance; average fitness of best p% particles must be within
-            m of the global best fitness
-        :param n: stop criterion tolerance; positions of best p% of particles must be within
-            n euclidean distance of the global best position
-        :param early_stop_tolerance: if set, will cause the PSO to terminate if
-            |2 * global_best_fitness| < early_stop_tolerance. This takes priority over
-            the fitness and spatial convergence criteria.
+        :param p: float between 0 and 1, determines the percentage of particles to use
+            to compute swarm fit and position convergence
+        :param m: stop criterion tolerance; average fitness of best p% particles must be
+            within m of the global best fitness
+        :param n: stop criterion tolerance; positions of best p% of particles must be
+            within n euclidean distance of the global best position
+        :param early_stop_tolerance: if set, will cause the PSO to terminate if |2 *
+            global_best_fitness| < early_stop_tolerance. This takes priority over the
+            fitness and spatial convergence criteria.
         :param verbose: if True, prints out the iteration number as the loop progresses
         :type verbose: boolean
         """
@@ -189,18 +201,18 @@ class ParticleSwarmOptimizerJIT(object):
                 key,
             ) = carry
 
-
             if early_stop_tolerance is not None:
-                stop_early = self._acceptable_convergence(early_stop_tolerance, global_best_fitness)
+                stop_early = self._acceptable_convergence(
+                    early_stop_tolerance, global_best_fitness
+                )
             else:
                 stop_early = False
-
 
             fit = self._converged_fit(
                 p=p,
                 m=m,
                 global_best_fitness=global_best_fitness,
-                personal_best_fitnesses=personal_best_fitnesses
+                personal_best_fitnesses=personal_best_fitnesses,
             )
 
             space = self._converged_space(
@@ -208,7 +220,7 @@ class ParticleSwarmOptimizerJIT(object):
                 n=n,
                 global_best_position=global_best_position,
                 swarm_fitnesses=swarm_fitnesses,
-                swarm_positions=swarm_positions
+                swarm_positions=swarm_positions,
             )
             converged = fit & space
 
@@ -242,34 +254,63 @@ class ParticleSwarmOptimizerJIT(object):
             best_particle_position = swarm_positions.at[best_particle_index].get()
 
             # update the global best
-            global_best_position = jnp.where(best_particle_fitness > global_best_fitness, best_particle_position, global_best_position)
-            global_best_fitness = jnp.where(best_particle_fitness> global_best_fitness, best_particle_fitness, global_best_fitness)
+            global_best_position = jnp.where(
+                best_particle_fitness > global_best_fitness,
+                best_particle_position,
+                global_best_position,
+            )
+            global_best_fitness = jnp.where(
+                best_particle_fitness > global_best_fitness,
+                best_particle_fitness,
+                global_best_fitness,
+            )
 
             # update all personal bests
-            personal_best_positions = jnp.where(swarm_fitnesses > personal_best_fitnesses, swarm_positions.T, personal_best_positions.T).T
-            personal_best_fitnesses = jnp.where(swarm_fitnesses > personal_best_fitnesses, swarm_fitnesses, personal_best_fitnesses)
+            personal_best_positions = jnp.where(
+                swarm_fitnesses > personal_best_fitnesses,
+                swarm_positions.T,
+                personal_best_positions.T,
+            ).T
+            personal_best_fitnesses = jnp.where(
+                swarm_fitnesses > personal_best_fitnesses,
+                swarm_fitnesses,
+                personal_best_fitnesses,
+            )
 
             # each particle takes a random step
             key, subkey = jax.random.split(key)
-            w = 0.5 + jax.random.uniform(key=subkey, minval=0, maxval=1, shape=(self.particleCount, self.param_count)) / 2
+            w = (
+                0.5
+                + jax.random.uniform(
+                    key=subkey,
+                    minval=0,
+                    maxval=1,
+                    shape=(self.particleCount, self.param_count),
+                )
+                / 2
+            )
 
             part_vel = jnp.multiply(w, swarm_velocities)
             key, subkey = jax.random.split(key)
-            cog_vel = (
-                c1
-                * jnp.multiply(
-                    jax.random.uniform(key=subkey, minval=0, maxval=1, shape=(self.particleCount, self.param_count)),
-                    (personal_best_positions - swarm_positions)
-                )
+            cog_vel = c1 * jnp.multiply(
+                jax.random.uniform(
+                    key=subkey,
+                    minval=0,
+                    maxval=1,
+                    shape=(self.particleCount, self.param_count),
+                ),
+                (personal_best_positions - swarm_positions),
             )
 
             key, subkey = jax.random.split(key)
-            soc_vel = (
-                c2
-                * jnp.multiply(
-                    jax.random.uniform(key=subkey, minval=0, maxval=1, shape=(self.particleCount, self.param_count)),
-                    (global_best_position - swarm_positions)
-                )
+            soc_vel = c2 * jnp.multiply(
+                jax.random.uniform(
+                    key=subkey,
+                    minval=0,
+                    maxval=1,
+                    shape=(self.particleCount, self.param_count),
+                ),
+                (global_best_position - swarm_positions),
             )
 
             swarm_velocities = part_vel + cog_vel + soc_vel
@@ -277,7 +318,7 @@ class ParticleSwarmOptimizerJIT(object):
             swarm_fitnesses = self._get_fitness(swarm_positions)
 
             return (
-                i+1,
+                i + 1,
                 global_best_position,
                 global_best_fitness,
                 swarm_positions,
@@ -294,13 +335,12 @@ class ParticleSwarmOptimizerJIT(object):
         # returns the global best position and global best fitness
         return carry[1], carry[2]
 
-
     @partial(jit, static_argnums=0)
     def _get_fitness(self, swarm_positions):
         """Set fitness (probability) of the particles in swarm.
 
-        :param swarm_positions: 2d array of shape (n_particles, len(args)) containing the
-            position vector of each particle in the swarm
+        :param swarm_positions: 2d array of shape (n_particles, len(args)) containing
+            the position vector of each particle in the swarm
         :type swarm_positions: array
         :return: 1d array of fitnesses of each particle in the swarm
         :rtype: array
@@ -310,19 +350,20 @@ class ParticleSwarmOptimizerJIT(object):
 
     @partial(jit, static_argnums=(0, 1))
     def _converged_fit(self, p, m, global_best_fitness, personal_best_fitnesses):
-        """Given the global best fitnesses and an array of personal best fitnesses of the swarm,
-        determine whether or not the average fitness of the best p% of particles is within m
-        of the global best fitness.
+        """Given the global best fitnesses and an array of personal best fitnesses of
+        the swarm, determine whether or not the average fitness of the best p% of
+        particles is within m of the global best fitness.
 
-        :param p: float between 0 and 1, determines what percent of particles to
-            look at to compute convergence
+        :param p: float between 0 and 1, determines what percent of particles to look at
+            to compute convergence
         :type p: float
         :param m: tolerance criteria for fitness
         :type m: float
         :param global_best_fitness: float, the current best fitness of the swarm
-        :param personal_best_fitnesses: 1d array of floats with size n_particles containing the
-            best fitnesses for each particle in the swarm
-        :return: whether or not the average of the best p% of particles is within m of the
+        :param personal_best_fitnesses: 1d array of floats with size n_particles
+            containing the best fitnesses for each particle in the swarm
+        :return: whether or not the average of the best p% of particles is within m of
+            the
         :rtype: bool
         """
 
@@ -330,27 +371,31 @@ class ParticleSwarmOptimizerJIT(object):
         mean_fit = jnp.mean(best_sort[1 : int(self.particleCount * p)])
         return jnp.abs(global_best_fitness - mean_fit) < m
 
-
     @partial(jit, static_argnums=(0, 1))
-    def _converged_space(self, p, n, global_best_position, swarm_fitnesses, swarm_positions):
-        """Given the global best position, swarm fitnesses, and swarm positions, determine
-        whether or not all of the positions of the best p% of particles is within n
-        euclidean-distance of the global best position.
+    def _converged_space(
+        self, p, n, global_best_position, swarm_fitnesses, swarm_positions
+    ):
+        """Given the global best position, swarm fitnesses, and swarm positions,
+        determine whether or not all of the positions of the best p% of particles is
+        within n euclidean-distance of the global best position.
 
-        :param p: float between 0 and 1, determines what percent of particles to
-            look at to compute convergence
+        :param p: float between 0 and 1, determines what percent of particles to look at
+            to compute convergence
         :type p: float
         :param n: tolerance criteria for euclidean distance
         :type n: float
         :param global_best_position: 1d array of size len(args), current best position
         :type global_best_position: array
         :param swarm_fitnesses: 1d array of floats with size n_particles containing the
-        :return: whether or not the average of the best p% of particles is within m of the
+        :return: whether or not the average of the best p% of particles is within m of
+            the
         :rtype: bool
         """
 
         sort_by_fitness_indices = jnp.argsort(swarm_fitnesses)
-        sorted_positions = swarm_positions[sort_by_fitness_indices][0 : int(self.particleCount * p)]
+        sorted_positions = swarm_positions[sort_by_fitness_indices][
+            0 : int(self.particleCount * p)
+        ]
         diffs = global_best_position - sorted_positions
         max_norm = jnp.max(jnp.linalg.norm(diffs, axis=1))
         return jnp.abs(max_norm) < n

--- a/jaxtronomy/Sampling/Samplers/pso_jit.py
+++ b/jaxtronomy/Sampling/Samplers/pso_jit.py
@@ -162,9 +162,9 @@ class ParticleSwarmOptimizerJIT(object):
             within m of the global best fitness
         :param n: stop criterion tolerance; positions of best p% of particles must be
             within n euclidean distance of the global best position
-        :param early_stop_tolerance: float or None; if set, will terminate the PSO early if
-            |2 * global_best_fitness| < early_stop_tolerance. This takes priority over the
-            fitness and spatial convergence criteria.
+        :param early_stop_tolerance: float or None; if set, will terminate the PSO early
+            if |2 * global_best_fitness| < early_stop_tolerance. This takes priority
+            over the fitness and spatial convergence criteria.
         :param verbose: if True, prints out the iteration number as the loop progresses
         :type verbose: boolean
         """
@@ -352,9 +352,9 @@ class ParticleSwarmOptimizerJIT(object):
 
     @partial(jit, static_argnums=(0, 1))
     def _converged_fit(self, p, m, global_best_fitness, personal_best_fitnesses):
-        """Given the global best fitness and an array of personal best fitnesses of
-        the swarm, determine whether or not the average fitness of the best p% of
-        particles is within m of the global best fitness.
+        """Given the global best fitness and an array of personal best fitnesses of the
+        swarm, determine whether or not the average fitness of the best p% of particles
+        is within m of the global best fitness.
 
         :param p: float between 0 and 1, determines what percent of particles to look at
             to compute convergence
@@ -364,8 +364,8 @@ class ParticleSwarmOptimizerJIT(object):
         :param global_best_fitness: float, the current best fitness of the swarm
         :param personal_best_fitnesses: 1d array of floats with size n_particles
             containing the best fitnesses for each particle in the swarm
-        :return: whether or not the average fitness of the best p% of particles is within m of
-            the global best fitness
+        :return: whether or not the average fitness of the best p% of particles is
+            within m of the global best fitness
         :rtype: bool
         """
 
@@ -386,11 +386,12 @@ class ParticleSwarmOptimizerJIT(object):
         :type p: float
         :param n: tolerance criteria for euclidean distance
         :type n: float
-        :param global_best_position: 1d array of size len(args), current best position of swarm
+        :param global_best_position: 1d array of size len(args), current best position
+            of swarm
         :type global_best_position: array
         :param swarm_fitnesses: 1d array of floats with size n_particles containing the
-        :return: whether or not the best p% of particles is within n euclidean distance of
-            the global best position
+        :return: whether or not the best p% of particles is within n euclidean distance
+            of the global best position
         :rtype: bool
         """
 

--- a/jaxtronomy/Sampling/Samplers/pso_jit.py
+++ b/jaxtronomy/Sampling/Samplers/pso_jit.py
@@ -1,0 +1,369 @@
+import jax
+from jax import jit, lax, numpy as jnp
+import numpy as np
+from functools import partial
+
+
+__all__ = ["ParticleSwarmOptimizerJIT"]
+
+
+class ParticleSwarmOptimizerJIT(object):
+    """Optimizer using a swarm of particles. Same as the PSO from lenstronomy, but the
+    entire computation happens within JIT. This class is intended to be used for GPU so
+    that there are no memory transfer overheads between GPU and CPU since the entire
+    computation happens on GPU.
+
+    The input log likelihood function is assumed to be vectorized.
+    """
+
+    def __init__(
+        self, func, low, high, particle_count=25,
+    ):
+        """
+
+        :param func: function to call to return log likelihood of swarm. Must accept
+            as argument the position vector of the entire swarm.
+        :type func: python definition
+        :param low: lower bound of the parameters
+        :type low: numpy array
+        :param high: upper bound of the parameters
+        :type high: numpy array
+        :param particle_count: number of particles in each iteration of the PSO
+        :type particle_count: int
+        """
+        self.low = np.array([l for l in low])
+        self.high = np.array([h for h in high])
+        self.particleCount = particle_count
+        self.param_count = len(self.low)
+        self.logL_func = func
+
+        self.set_global_best(jnp.zeros(self.param_count), None, -jnp.inf)
+
+
+    def _init_swarm(self):
+        """Initiate the swarm.
+
+        :return: `None`
+        """
+        swarm_positions = np.zeros((self.particleCount, self.param_count))
+        for i in range(self.particleCount):
+            swarm_positions[i] = np.random.uniform(
+                self.low,
+                self.high,
+                size=self.param_count
+            )
+
+        swarm_positions = jnp.array(swarm_positions, dtype=float)
+        swarm_velocities = jnp.zeros_like(swarm_positions)
+        swarm_fitnesses = self._get_fitness(swarm_positions)
+
+        return swarm_positions, swarm_velocities, swarm_fitnesses
+
+    def set_global_best(self, position, velocity, fitness):
+        """Set the global best particle.
+
+        :param position: position of the new global best
+        :type position: `list` or `ndarray`
+        :param velocity: unused, kept to maintain identical API as lenstronomy
+        :param fitness: fitness of the new global best
+        :type fitness: `float`
+        :return: `None`
+        """
+        self.global_best_position = jnp.asarray(position, dtype=float)
+        self.global_best_fitness = fitness
+
+    # Top level function - should not be jitted
+    def optimize(
+        self,
+        max_iter=1000,
+        verbose=True,
+        c1=1.193,
+        c2=1.193,
+        p=0.7,
+        m=1e-3,
+        n=1e-2,
+        early_stop_tolerance=None,
+        rng_seed=None,
+    ):
+        """Run the optimization and return a full list of optimization outputs.
+        NOTE: Currently does not return the global best logL, velocity, and position histories.
+
+        :param max_iter: maximum iterations
+        :param verbose: if `True`, print a message every 10 iterations
+        :param c1: cognitive weight
+        :param c2: social weight
+        :param p: float between 0 and 1, determines the percentage of particles to use to
+            compute swarm fit and position convergence
+        :param m: stop criterion tolerance; average fitness of best p% particles must be within
+            m of the global best fitness
+        :param n: stop criterion tolerance; positions of best p% of particles must be within
+            n euclidean distance of the global best position
+        :param early_stop_tolerance: will terminate at the given value (should be specified as a chi^2)
+        :param rng_seed: int, rng seed for reproducibility. If None, a random seed is used
+        """
+        log_likelihood_list = []
+        vel_list = []
+        pos_list = []
+
+        if rng_seed is None:
+            rng_seed = int(np.random.uniform(0, 1) * 1000000)
+
+        init_swarm = self._init_swarm()
+
+        print("starting PSO optimization")
+        global_best_position, global_best_fitness = self.run_iterations(
+            init_swarm, self.global_best_position, self.global_best_fitness, max_iter, c1, c2, p, m, n, early_stop_tolerance, rng_seed, verbose
+        )
+        self.set_global_best(global_best_position, None, global_best_fitness)
+
+        return np.array(global_best_position), [log_likelihood_list, pos_list, vel_list]
+
+
+    @partial(jit, static_argnums=(0,7,12))
+    def run_iterations(
+        self,
+        init_swarm,
+        global_best_position,
+        global_best_fitness,
+        max_iter=1000,
+        c1=1.193,
+        c2=1.193,
+        p=0.7,
+        m=1e-3,
+        n=1e-2,
+        early_stop_tolerance=None,
+        rng_seed=0,
+        verbose=True,
+    ):
+        """Launches the PSO. Yields the complete swarm per iteration.
+
+        :param max_iter: maximum iterations
+        :param global_best_position: 1d array of size len(args); the initial values for the best particle position
+        :param global_best_fitness: float; the initial value for the best particle fitness
+        :param c1: cognitive weight
+        :param c2: social weight
+        :param p: float between 0 and 1, determines the percentage of particles to use to
+            compute swarm fit and position convergence
+        :param m: stop criterion tolerance; average fitness of best p% particles must be within
+            m of the global best fitness
+        :param n: stop criterion tolerance; positions of best p% of particles must be within
+            n euclidean distance of the global best position
+        :param early_stop_tolerance: if set, will cause the PSO to terminate if
+            |2 * global_best_fitness| < early_stop_tolerance. This takes priority over
+            the fitness and spatial convergence criteria.
+        :param verbose: if True, prints out the iteration number as the loop progresses
+        :type verbose: boolean
+        """
+        key = jax.random.PRNGKey(rng_seed)
+
+        swarm_positions, swarm_velocities, swarm_fitnesses = init_swarm
+
+        # intialize personal bests (these will be updated at the start of every iteration in the loop)
+        personal_best_positions = jnp.zeros((self.particleCount, self.param_count))
+        personal_best_fitnesses = -jnp.ones(self.particleCount) * jnp.inf
+
+        init_carry = (
+            0,
+            global_best_position,
+            global_best_fitness,
+            swarm_positions,
+            swarm_velocities,
+            swarm_fitnesses,
+            personal_best_positions,
+            personal_best_fitnesses,
+            key,
+        )
+
+        # define function to be computed at the start of every iteration
+        # determines whether or not to continue the iterations
+        def continuing_criteria(carry):
+            (
+                i,
+                global_best_position,
+                global_best_fitness,
+                swarm_positions,
+                swarm_velocities,
+                swarm_fitnesses,
+                personal_best_positions,
+                personal_best_fitnesses,
+                key,
+            ) = carry
+
+
+            if early_stop_tolerance is not None:
+                stop_early = self._acceptable_convergence(early_stop_tolerance, global_best_fitness)
+            else:
+                stop_early = False
+
+
+            fit = self._converged_fit(
+                p=p,
+                m=m,
+                global_best_fitness=global_best_fitness,
+                personal_best_fitnesses=personal_best_fitnesses
+            )
+
+            space = self._converged_space(
+                p=p,
+                n=n,
+                global_best_position=global_best_position,
+                swarm_fitnesses=swarm_fitnesses,
+                swarm_positions=swarm_positions
+            )
+            converged = fit & space
+
+            # continue if not converged yet and havent reached max iterations
+            cont = jnp.logical_not(converged) & (i < max_iter)
+
+            # if stop_early is True, then don't continue
+            cont = jnp.where(stop_early, False, cont)
+            return cont
+
+        # define function to be iterated over
+        def update_swarm(carry):
+            (
+                i,
+                global_best_position,
+                global_best_fitness,
+                swarm_positions,
+                swarm_velocities,
+                swarm_fitnesses,
+                personal_best_positions,
+                personal_best_fitnesses,
+                key,
+            ) = carry
+
+            if verbose:
+                jax.debug.print("iteration {i}", i=i)
+
+            # find the current best particle
+            best_particle_index = jnp.argmax(swarm_fitnesses)
+            best_particle_fitness = swarm_fitnesses.at[best_particle_index].get()
+            best_particle_position = swarm_positions.at[best_particle_index].get()
+
+            # update the global best
+            global_best_position = jnp.where(best_particle_fitness > global_best_fitness, best_particle_position, global_best_position)
+            global_best_fitness = jnp.where(best_particle_fitness> global_best_fitness, best_particle_fitness, global_best_fitness)
+
+            # update all personal bests
+            personal_best_positions = jnp.where(swarm_fitnesses > personal_best_fitnesses, swarm_positions.T, personal_best_positions.T).T
+            personal_best_fitnesses = jnp.where(swarm_fitnesses > personal_best_fitnesses, swarm_fitnesses, personal_best_fitnesses)
+
+            # each particle takes a random step
+            key, subkey = jax.random.split(key)
+            w = 0.5 + jax.random.uniform(key=subkey, minval=0, maxval=1, shape=(self.particleCount, self.param_count)) / 2
+
+            part_vel = jnp.multiply(w, swarm_velocities)
+            key, subkey = jax.random.split(key)
+            cog_vel = (
+                c1
+                * jnp.multiply(
+                    jax.random.uniform(key=subkey, minval=0, maxval=1, shape=(self.particleCount, self.param_count)),
+                    (personal_best_positions - swarm_positions)
+                )
+            )
+
+            key, subkey = jax.random.split(key)
+            soc_vel = (
+                c2
+                * jnp.multiply(
+                    jax.random.uniform(key=subkey, minval=0, maxval=1, shape=(self.particleCount, self.param_count)),
+                    (global_best_position - swarm_positions)
+                )
+            )
+
+            swarm_velocities = part_vel + cog_vel + soc_vel
+            swarm_positions += swarm_velocities
+            swarm_fitnesses = self._get_fitness(swarm_positions)
+
+            return (
+                i+1,
+                global_best_position,
+                global_best_fitness,
+                swarm_positions,
+                swarm_velocities,
+                swarm_fitnesses,
+                personal_best_positions,
+                personal_best_fitnesses,
+                key,
+            )
+
+        # run the loop
+        carry = lax.while_loop(continuing_criteria, update_swarm, init_carry)
+
+        # returns the global best position and global best fitness
+        return carry[1], carry[2]
+
+
+    @partial(jit, static_argnums=0)
+    def _get_fitness(self, swarm_positions):
+        """Set fitness (probability) of the particles in swarm.
+
+        :param swarm_positions: 2d array of shape (n_particles, len(args)) containing the
+            position vector of each particle in the swarm
+        :type swarm_positions: array
+        :return: 1d array of fitnesses of each particle in the swarm
+        :rtype: array
+        """
+        ln_probability = self.logL_func(swarm_positions)
+        return ln_probability
+
+    @partial(jit, static_argnums=(0, 1))
+    def _converged_fit(self, p, m, global_best_fitness, personal_best_fitnesses):
+        """Given the global best fitnesses and an array of personal best fitnesses of the swarm,
+        determine whether or not the average fitness of the best p% of particles is within m
+        of the global best fitness.
+
+        :param p: float between 0 and 1, determines what percent of particles to
+            look at to compute convergence
+        :type p: float
+        :param m: tolerance criteria for fitness
+        :type m: float
+        :param global_best_fitness: float, the current best fitness of the swarm
+        :param personal_best_fitnesses: 1d array of floats with size n_particles containing the
+            best fitnesses for each particle in the swarm
+        :return: whether or not the average of the best p% of particles is within m of the
+        :rtype: bool
+        """
+
+        best_sort = jnp.sort(personal_best_fitnesses)[::-1]
+        mean_fit = jnp.mean(best_sort[1 : int(self.particleCount * p)])
+        return jnp.abs(global_best_fitness - mean_fit) < m
+
+
+    @partial(jit, static_argnums=(0, 1))
+    def _converged_space(self, p, n, global_best_position, swarm_fitnesses, swarm_positions):
+        """Given the global best position, swarm fitnesses, and swarm positions, determine
+        whether or not all of the positions of the best p% of particles is within n
+        euclidean-distance of the global best position.
+
+        :param p: float between 0 and 1, determines what percent of particles to
+            look at to compute convergence
+        :type p: float
+        :param n: tolerance criteria for euclidean distance
+        :type n: float
+        :param global_best_position: 1d array of size len(args), current best position
+        :type global_best_position: array
+        :param swarm_fitnesses: 1d array of floats with size n_particles containing the
+        :return: whether or not the average of the best p% of particles is within m of the
+        :rtype: bool
+        """
+
+        sort_by_fitness_indices = jnp.argsort(swarm_fitnesses)
+        sorted_positions = swarm_positions[sort_by_fitness_indices][0 : int(self.particleCount * p)]
+        diffs = global_best_position - sorted_positions
+        max_norm = jnp.max(jnp.linalg.norm(diffs, axis=1))
+        return jnp.abs(max_norm) < n
+
+    @partial(jit, static_argnums=0)
+    def _acceptable_convergence(self, chi_square_tolerance, global_best_fitness):
+        """Checks whether the chi squared is within the chi squared tolerance.
+
+        :param chi_square_tolerance: float, chi square tolerance
+        :param global_best_fitness: float, best fitness of the swarm
+        :return: whether the chi squared is within the chi squared tolerance
+        :rtype: bool
+        """
+
+        chi_square = -2 * global_best_fitness
+        return chi_square < chi_square_tolerance

--- a/jaxtronomy/Sampling/sampler.py
+++ b/jaxtronomy/Sampling/sampler.py
@@ -42,9 +42,9 @@ class Sampler(Sampler_lenstronomy):
             starting particles
         :param threadCount: number of threads in the computation, only relevant for CPU
             parallelization
-        :param vectorization_batch_size: int, only relevant for GPU, determines number of particles
-            computed simultaneously. None defaults to one particle at a time and 0 means to compute
-            all particles simultaneously. 
+        :param vectorization_batch_size: int, only relevant for GPU, determines number
+            of particles computed simultaneously. None defaults to one particle at a
+            time and 0 means to compute all particles simultaneously.
         :param init_pos: numpy array, position of the initial best guess model
         :param mpi: bool, if True, makes instance of MPIPool to allow for MPI execution
             (must be False in JAXtronomy)
@@ -74,11 +74,14 @@ class Sampler(Sampler_lenstronomy):
                 )
                 n_particles = new_n_particles
             PSO_class = ParticleSwarmOptimizer
-        else: # For GPU
+        else:  # For GPU
             PSO_class = ParticleSwarmOptimizerJIT
 
         logL_func = prepare_logL_func(
-            backend=backend, logL_func=self.chain.logL, threadCount=threadCount, vectorization_batch_size=vectorization_batch_size
+            backend=backend,
+            logL_func=self.chain.logL,
+            threadCount=threadCount,
+            vectorization_batch_size=vectorization_batch_size,
         )
 
         if lower_start is None or upper_start is None:
@@ -154,7 +157,7 @@ class Sampler(Sampler_lenstronomy):
         :type threadCount: integer
         :param vectorization_batch_size: int, only relevant for GPU, determines number of particles
             computed simultaneously. None defaults to one particle at a time and 0 means to compute
-            all particles simultaneously. 
+            all particles simultaneously.
         :type vectorization_batch_size: integer
         :param initpos: initial walker position to start sampling (optional)
         :type initpos: numpy array of size num param x num walkser
@@ -194,7 +197,10 @@ class Sampler(Sampler_lenstronomy):
                 n_walkers = new_n_walkers
 
         logL_func = prepare_logL_func(
-            backend=backend, logL_func=self.chain.logL, threadCount=threadCount, vectorization_batch_size=vectorization_batch_size
+            backend=backend,
+            logL_func=self.chain.logL,
+            threadCount=threadCount,
+            vectorization_batch_size=vectorization_batch_size,
         )
 
         import emcee
@@ -237,9 +243,9 @@ def prepare_logL_func(backend, logL_func, threadCount, vectorization_batch_size)
         likelihood.
     :param threadCount: number of threads in the computation, only relevant for CPU
         parallelization
-    :param vectorization_batch_size: int, only relevant for GPU, determines number of particles
-        computed simultaneously. None defaults to one particle at a time and 0 means to compute
-        all particles simultaneously. 
+    :param vectorization_batch_size: int, only relevant for GPU, determines number of
+        particles computed simultaneously. None defaults to one particle at a time and 0
+        means to compute all particles simultaneously.
     :returns: a callable function that takes a set of position vectors and returns a set
         of log likelihoods.
     """

--- a/jaxtronomy/Sampling/sampler.py
+++ b/jaxtronomy/Sampling/sampler.py
@@ -15,8 +15,10 @@ __all__ = ["Sampler"]
 
 
 class Sampler(Sampler_lenstronomy):
-    """Inherits samplers from lenstronomy, but modifies the PSO and mcmc to parallelize
-    computations across hardware devices."""
+    """Inherits samplers from lenstronomy, but modifies the PSO and emcee to parallelize
+    computations if using CPU, and vectorize computations if using GPU. The device
+    given by jax.default_device() will be used for computations.
+    """
 
     def pso(
         self,
@@ -24,9 +26,9 @@ class Sampler(Sampler_lenstronomy):
         n_iterations,
         lower_start=None,
         upper_start=None,
+        init_pos=None,
         threadCount=1,
         vectorization_batch_size=None,
-        init_pos=None,
         mpi=False,
         print_key="PSO",
         verbose=True,
@@ -40,12 +42,12 @@ class Sampler(Sampler_lenstronomy):
             starting particles
         :param upper_start: numpy array, upper end parameter of the values of the
             starting particles
+        :param init_pos: numpy array, position of the initial best guess model
         :param threadCount: number of threads in the computation, only relevant for CPU
             parallelization
         :param vectorization_batch_size: int, only relevant for GPU, determines number
             of particles computed simultaneously. None defaults to one particle at a
             time and 0 means to compute all particles simultaneously.
-        :param init_pos: numpy array, position of the initial best guess model
         :param mpi: bool, if True, makes instance of MPIPool to allow for MPI execution
             (must be False in JAXtronomy)
         :param print_key: string, prints the process name in the progress bar (optional)
@@ -57,6 +59,8 @@ class Sampler(Sampler_lenstronomy):
             raise ValueError(
                 "mpi must be False in JAXtronomy since parallelization is done through JAX"
             )
+
+        PSO_class = ParticleSwarmOptimizerJIT
 
         backend = jax.default_backend()
         if backend == "cpu":
@@ -73,9 +77,8 @@ class Sampler(Sampler_lenstronomy):
                     f"n_particles will automatically be set to {new_n_particles}."
                 )
                 n_particles = new_n_particles
+            # Use non-jit version of PSO if parallelizing across cpu cores
             PSO_class = ParticleSwarmOptimizer
-        else:  # For GPU
-            PSO_class = ParticleSwarmOptimizerJIT
 
         logL_func = prepare_logL_func(
             backend=backend,

--- a/jaxtronomy/Sampling/sampler.py
+++ b/jaxtronomy/Sampling/sampler.py
@@ -2,12 +2,13 @@ import time
 
 import numpy as np
 from jaxtronomy.Sampling.Samplers.pso import ParticleSwarmOptimizer
+from jaxtronomy.Sampling.Samplers.pso_jit import ParticleSwarmOptimizerJIT
 from lenstronomy.Sampling.sampler import Sampler as Sampler_lenstronomy
 from lenstronomy.Util import sampling_util
 
 from functools import partial
 import jax
-from jax import lax
+from jax import jit, lax
 import warnings
 
 __all__ = ["Sampler"]
@@ -24,6 +25,7 @@ class Sampler(Sampler_lenstronomy):
         lower_start=None,
         upper_start=None,
         threadCount=1,
+        vectorization_batch_size=None,
         init_pos=None,
         mpi=False,
         print_key="PSO",
@@ -40,6 +42,9 @@ class Sampler(Sampler_lenstronomy):
             starting particles
         :param threadCount: number of threads in the computation, only relevant for CPU
             parallelization
+        :param vectorization_batch_size: int, only relevant for GPU, determines number of particles
+            computed simultaneously. None defaults to one particle at a time and 0 means to compute
+            all particles simultaneously. 
         :param init_pos: numpy array, position of the initial best guess model
         :param mpi: bool, if True, makes instance of MPIPool to allow for MPI execution
             (must be False in JAXtronomy)
@@ -48,11 +53,6 @@ class Sampler(Sampler_lenstronomy):
         :return: kwargs_result (of best fit), [lnlikelihood of samples, positions of
             samples, velocity of samples])
         """
-        if threadCount > len(jax.devices()):
-            raise ValueError(
-                f"Supplied threadCount {threadCount} is greater than {len(jax.devices())}, the number of devices detectable by JAX.\n"
-                f"To ensure that the correct number of devices is recognized by JAX, an environment variable must be set; see JAX or JAXtronomy documentation."
-            )
         if mpi:
             raise ValueError(
                 "mpi must be False in JAXtronomy since parallelization is done through JAX"
@@ -60,6 +60,12 @@ class Sampler(Sampler_lenstronomy):
 
         backend = jax.default_backend()
         if backend == "cpu":
+            if threadCount > len(jax.devices()):
+                raise ValueError(
+                    f"Supplied threadCount {threadCount} is greater than {len(jax.devices())}, the number of CPU devices detectable by JAX.\n"
+                    f"To ensure that the correct number of devices is recognized by JAX, an environment variable must be set; see JAX or JAXtronomy documentation."
+                )
+
             if n_particles % threadCount != 0:
                 new_n_particles = int(((n_particles // threadCount) + 1) * threadCount)
                 warnings.warn(
@@ -67,9 +73,12 @@ class Sampler(Sampler_lenstronomy):
                     f"n_particles will automatically be set to {new_n_particles}."
                 )
                 n_particles = new_n_particles
+            PSO_class = ParticleSwarmOptimizer
+        else: # For GPU
+            PSO_class = ParticleSwarmOptimizerJIT
 
         logL_func = prepare_logL_func(
-            backend=backend, logL_func=self.chain.logL, threadCount=threadCount
+            backend=backend, logL_func=self.chain.logL, threadCount=threadCount, vectorization_batch_size=vectorization_batch_size
         )
 
         if lower_start is None or upper_start is None:
@@ -81,7 +90,7 @@ class Sampler(Sampler_lenstronomy):
             lower_start = np.maximum(lower_start, self.lower_limit)
             upper_start = np.minimum(upper_start, self.upper_limit)
 
-        pso = ParticleSwarmOptimizer(logL_func, lower_start, upper_start, n_particles)
+        pso = PSO_class(logL_func, lower_start, upper_start, n_particles)
 
         if init_pos is None:
             init_pos = (upper_start - lower_start) / 2 + lower_start
@@ -97,12 +106,12 @@ class Sampler(Sampler_lenstronomy):
         kwargs_return = self.chain.param.args2kwargs(result)
         if verbose:
             print(
-                pso.global_best.fitness
+                pso.global_best_fitness
                 * 2
                 / (max(self.chain.effective_num_data_points(**kwargs_return), 1)),
                 "reduced X^2 of best position",
             )
-            print(pso.global_best.fitness, "log likelihood")
+            print(pso.global_best_fitness, "log likelihood")
             self._print_result(result=result)
             time_end = time.time()
             print(time_end - time_start, "time used for ", print_key)
@@ -119,6 +128,7 @@ class Sampler(Sampler_lenstronomy):
         mpi=False,
         progress=False,
         threadCount=1,
+        vectorization_batch_size=None,
         initpos=None,
         backend_filename=None,
         start_from_backend=False,
@@ -142,6 +152,10 @@ class Sampler(Sampler_lenstronomy):
         :type progress: bool
         :param threadCount: number of threads used for computation, only relevant for CPU parallelization
         :type threadCount: integer
+        :param vectorization_batch_size: int, only relevant for GPU, determines number of particles
+            computed simultaneously. None defaults to one particle at a time and 0 means to compute
+            all particles simultaneously. 
+        :type vectorization_batch_size: integer
         :param initpos: initial walker position to start sampling (optional)
         :type initpos: numpy array of size num param x num walkser
         :param backend_filename: name of the HDF5 file where sampling state is saved (through emcee backend engine)
@@ -156,11 +170,6 @@ class Sampler(Sampler_lenstronomy):
             raise ValueError(
                 "mpi must be False in JAXtronomy, since parallelization is done through JAX"
             )
-        if threadCount > len(jax.devices()):
-            raise ValueError(
-                f"Supplied threadCount {threadCount} is greater than {len(jax.devices())}, the number of devices detectable by JAX.\n"
-                f"To ensure that the correct number of devices is recognized by JAX, an environment variable must be set; see JAX or JAXtronomy documentation."
-            )
         if start_from_backend:
             raise ValueError("start_from_backend must be False in JAXtronomy")
         if backend_filename is not None:
@@ -168,6 +177,12 @@ class Sampler(Sampler_lenstronomy):
 
         backend = jax.default_backend()
         if backend == "cpu":
+            if threadCount > len(jax.devices()):
+                raise ValueError(
+                    f"Supplied threadCount {threadCount} is greater than {len(jax.devices())}, the number of CPU devices detectable by JAX.\n"
+                    f"To ensure that the correct number of devices is recognized by JAX, an environment variable must be set; see JAX or JAXtronomy documentation."
+                )
+
             if n_walkers % (2 * threadCount) != 0:
                 new_n_walkers = int(
                     ((n_walkers // (2 * threadCount)) + 1) * (2 * threadCount)
@@ -179,7 +194,7 @@ class Sampler(Sampler_lenstronomy):
                 n_walkers = new_n_walkers
 
         logL_func = prepare_logL_func(
-            backend=backend, logL_func=self.chain.logL, threadCount=threadCount
+            backend=backend, logL_func=self.chain.logL, threadCount=threadCount, vectorization_batch_size=vectorization_batch_size
         )
 
         import emcee
@@ -212,7 +227,7 @@ class Sampler(Sampler_lenstronomy):
         return flat_samples, dist
 
 
-def prepare_logL_func(backend, logL_func, threadCount):
+def prepare_logL_func(backend, logL_func, threadCount, vectorization_batch_size):
     """Parallelizes the logL function for CPU backend, and vectorizes the logL function
     for GPU backend. Only the first threadCount cores will be used for CPU
     parallelization. TPU support has not been implemented.
@@ -222,6 +237,9 @@ def prepare_logL_func(backend, logL_func, threadCount):
         likelihood.
     :param threadCount: number of threads in the computation, only relevant for CPU
         parallelization
+    :param vectorization_batch_size: int, only relevant for GPU, determines number of particles
+        computed simultaneously. None defaults to one particle at a time and 0 means to compute
+        all particles simultaneously. 
     :returns: a callable function that takes a set of position vectors and returns a set
         of log likelihoods.
     """
@@ -232,18 +250,19 @@ def prepare_logL_func(backend, logL_func, threadCount):
         pmapped_func = jax.pmap(mapped_func, devices=devices)
 
         def new_logL_func(args):
-            args = np.array(args)
+            args = np.asarray(args, dtype=float)
             old_shape = args.shape
             new_shape = (threadCount, int(old_shape[0] / threadCount), old_shape[-1])
             result = pmapped_func(args.reshape(new_shape))
-            return np.array(result).flatten()
+            return np.asarray(result, dtype=float).flatten()
 
     elif backend == "gpu":
-        vmapped_func = jax.jit(jax.vmap(logL_func))
 
+        vmapped_func = partial(lax.map, logL_func, batch_size=vectorization_batch_size)
+
+        @jit
         def new_logL_func(args):
-            result = vmapped_func(args)
-            return np.array(result).flatten()
+            return vmapped_func(args).flatten()
 
     else:
         raise ValueError("backend must be either 'cpu' or 'gpu'")

--- a/jaxtronomy/Sampling/sampler.py
+++ b/jaxtronomy/Sampling/sampler.py
@@ -16,8 +16,9 @@ __all__ = ["Sampler"]
 
 class Sampler(Sampler_lenstronomy):
     """Inherits samplers from lenstronomy, but modifies the PSO and emcee to parallelize
-    computations if using CPU, and vectorize computations if using GPU. The device
-    given by jax.default_device() will be used for computations.
+    computations if using CPU, and vectorize computations if using GPU.
+
+    The device given by jax.default_device() will be used for computations.
     """
 
     def pso(

--- a/jaxtronomy/Workflow/fitting_sequence.py
+++ b/jaxtronomy/Workflow/fitting_sequence.py
@@ -14,6 +14,7 @@ from lenstronomy.Sampling.Samplers.nautilus_sampler import NautilusSampler
 from lenstronomy.Sampling.Samplers.cobaya_sampler import CobayaSampler
 
 import copy
+import jax
 import numpy as np
 import lenstronomy.Util.analysis_util as analysis_util
 
@@ -99,6 +100,10 @@ class FittingSequence(object):
         """
         chain_list = []
         for i, fitting in enumerate(fitting_list):
+            # clear the cache of compiled functions before each iteration to free up memory
+            # since a new Likelihood class is created each time, functions will have to be recompiled anyways
+            jax.clear_caches()
+
             fitting_type = fitting[0]
             kwargs = fitting[1]
 
@@ -359,6 +364,7 @@ class FittingSequence(object):
         n_walkers=None,
         sigma_scale=1,
         threadCount=1,
+        vectorization_batch_size=None,
         init_samples=None,
         re_use_samples=True,
         sampler_type="emcee",
@@ -442,6 +448,7 @@ class FittingSequence(object):
                 sigma_start,
                 mpi=self._mpi,
                 threadCount=threadCount,
+                vectorization_batch_size=vectorization_batch_size,
                 progress=progress,
                 initpos=initpos,
                 backend_filename=backend_filename,
@@ -518,6 +525,7 @@ class FittingSequence(object):
         sigma_scale=1,
         print_key="PSO",
         threadCount=1,
+        vectorization_batch_size=None,
     ):
         """Particle Swarm Optimization.
 
@@ -557,6 +565,7 @@ class FittingSequence(object):
             upper_start,
             init_pos=init_pos,
             threadCount=threadCount,
+            vectorization_batch_size=vectorization_batch_size,
             mpi=self._mpi,
             print_key=print_key,
             verbose=self._verbose,

--- a/test/test_Sampling/test_Samplers/test_pso.py
+++ b/test/test_Sampling/test_Samplers/test_pso.py
@@ -46,6 +46,9 @@ class TestPSOJIT(object):
         final_result, _ = self.pso.optimize(max_iter=200)
         npt.assert_array_almost_equal(final_result, [0.6], decimal=5)
 
+        final_result, _ = self.pso.optimize(max_iter=200, early_stop_tolerance=1e-5)
+        npt.assert_array_almost_equal(final_result, [0.6], decimal=5)
+
 
 if __name__ == "__main__":
     pytest.main()

--- a/test/test_Sampling/test_Samplers/test_pso.py
+++ b/test/test_Sampling/test_Samplers/test_pso.py
@@ -9,14 +9,16 @@ import pytest
 from jaxtronomy.Sampling.Samplers.pso import ParticleSwarmOptimizer
 from jaxtronomy.Sampling.Samplers.pso_jit import ParticleSwarmOptimizerJIT
 
+
 @jit
 @vmap
 def logL(x):
     # Minimum at x = 0.6
     return -jnp.sum((x - 0.6) ** 2)
 
+
 class TestPSO(object):
-    """Tests the PSO class with a simple logL function"""
+    """Tests the PSO class with a simple logL function."""
 
     def setup_method(self):
         args_lower = np.array([0.0])
@@ -29,8 +31,9 @@ class TestPSO(object):
         final_result, _ = self.pso.optimize(max_iter=200)
         npt.assert_array_almost_equal(final_result, [0.6], decimal=5)
 
+
 class TestPSOJIT(object):
-    """Tests the PSO JIT class with a simple logL function"""
+    """Tests the PSO JIT class with a simple logL function."""
 
     def setup_method(self):
         args_lower = np.array([0.0])
@@ -42,7 +45,6 @@ class TestPSOJIT(object):
         # Tests to see if the PSO gets close to the true answer
         final_result, _ = self.pso.optimize(max_iter=200)
         npt.assert_array_almost_equal(final_result, [0.6], decimal=5)
-
 
 
 if __name__ == "__main__":

--- a/test/test_Sampling/test_Samplers/test_pso.py
+++ b/test/test_Sampling/test_Samplers/test_pso.py
@@ -24,12 +24,12 @@ class TestPSO(object):
         args_lower = np.array([0.0])
         args_upper = np.array([10.1])
         args = (args_lower, args_upper)
-        self.pso = ParticleSwarmOptimizer(logL, *args, particle_count=100)
+        self.pso = ParticleSwarmOptimizer(logL, *args, particle_count=10)
 
     def test_run(self):
         # Tests to see if the PSO gets close to the true answer
-        final_result, _ = self.pso.optimize(max_iter=200)
-        npt.assert_array_almost_equal(final_result, [0.6], decimal=5)
+        final_result, _ = self.pso.optimize(max_iter=100)
+        npt.assert_array_almost_equal(final_result, [0.6], decimal=4)
 
 
 class TestPSOJIT(object):
@@ -39,15 +39,15 @@ class TestPSOJIT(object):
         args_lower = np.array([0.0])
         args_upper = np.array([10.1])
         args = (args_lower, args_upper)
-        self.pso = ParticleSwarmOptimizerJIT(logL, *args, particle_count=100)
+        self.pso = ParticleSwarmOptimizerJIT(logL, *args, particle_count=10)
 
     def test_run(self):
         # Tests to see if the PSO gets close to the true answer
-        final_result, _ = self.pso.optimize(max_iter=200)
-        npt.assert_array_almost_equal(final_result, [0.6], decimal=5)
+        final_result, _ = self.pso.optimize(max_iter=100)
+        npt.assert_array_almost_equal(final_result, [0.6], decimal=4)
 
-        final_result, _ = self.pso.optimize(max_iter=200, early_stop_tolerance=1e-5)
-        npt.assert_array_almost_equal(final_result, [0.6], decimal=5)
+        final_result, _ = self.pso.optimize(max_iter=100, early_stop_tolerance=1e-5)
+        npt.assert_array_almost_equal(final_result, [0.6], decimal=4)
 
 
 if __name__ == "__main__":

--- a/test/test_Sampling/test_Samplers/test_pso.py
+++ b/test/test_Sampling/test_Samplers/test_pso.py
@@ -1,0 +1,49 @@
+__author__ = "ahuang314"
+
+from functools import partial
+from jax import jit, lax, numpy as jnp, vmap
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from jaxtronomy.Sampling.Samplers.pso import ParticleSwarmOptimizer
+from jaxtronomy.Sampling.Samplers.pso_jit import ParticleSwarmOptimizerJIT
+
+@jit
+@vmap
+def logL(x):
+    # Minimum at x = 0.6
+    return -jnp.sum((x - 0.6) ** 2)
+
+class TestPSO(object):
+    """Tests the PSO class with a simple logL function"""
+
+    def setup_method(self):
+        args_lower = np.array([0.0])
+        args_upper = np.array([10.1])
+        args = (args_lower, args_upper)
+        self.pso = ParticleSwarmOptimizer(logL, *args, particle_count=100)
+
+    def test_run(self):
+        # Tests to see if the PSO gets close to the true answer
+        final_result, _ = self.pso.optimize(max_iter=200)
+        npt.assert_array_almost_equal(final_result, [0.6], decimal=5)
+
+class TestPSOJIT(object):
+    """Tests the PSO JIT class with a simple logL function"""
+
+    def setup_method(self):
+        args_lower = np.array([0.0])
+        args_upper = np.array([10.1])
+        args = (args_lower, args_upper)
+        self.pso = ParticleSwarmOptimizerJIT(logL, *args, particle_count=100)
+
+    def test_run(self):
+        # Tests to see if the PSO gets close to the true answer
+        final_result, _ = self.pso.optimize(max_iter=200)
+        npt.assert_array_almost_equal(final_result, [0.6], decimal=5)
+
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/test/test_Sampling/test_sampler.py
+++ b/test/test_Sampling/test_sampler.py
@@ -236,13 +236,14 @@ class TestSampler(object):
             "fake_backend",
             self.Likelihood.logL,
             threadCount=1,
+            vectorization_batch_size=0,
         )
 
         def logL_func(args):
             return args**2 - 4
 
         new_logL_func = prepare_logL_func(
-            backend="gpu", logL_func=logL_func, threadCount=1
+            backend="gpu", logL_func=logL_func, threadCount=None, vectorization_batch_size=0
         )
 
         x = np.array([[1, 2], [3, 4]])
@@ -251,7 +252,7 @@ class TestSampler(object):
         npt.assert_allclose(expected, logL, atol=1e-16, rtol=1e-16)
 
         new_logL_func = prepare_logL_func(
-            backend="cpu", logL_func=logL_func, threadCount=1
+            backend="cpu", logL_func=logL_func, threadCount=1, vectorization_batch_size=None
         )
         logL = new_logL_func(x)
         npt.assert_allclose(expected, logL, atol=1e-16, rtol=1e-16)

--- a/test/test_Sampling/test_sampler.py
+++ b/test/test_Sampling/test_sampler.py
@@ -243,7 +243,10 @@ class TestSampler(object):
             return args**2 - 4
 
         new_logL_func = prepare_logL_func(
-            backend="gpu", logL_func=logL_func, threadCount=None, vectorization_batch_size=0
+            backend="gpu",
+            logL_func=logL_func,
+            threadCount=None,
+            vectorization_batch_size=0,
         )
 
         x = np.array([[1, 2], [3, 4]])
@@ -252,7 +255,10 @@ class TestSampler(object):
         npt.assert_allclose(expected, logL, atol=1e-16, rtol=1e-16)
 
         new_logL_func = prepare_logL_func(
-            backend="cpu", logL_func=logL_func, threadCount=1, vectorization_batch_size=None
+            backend="cpu",
+            logL_func=logL_func,
+            threadCount=1,
+            vectorization_batch_size=None,
         )
         logL = new_logL_func(x)
         npt.assert_allclose(expected, logL, atol=1e-16, rtol=1e-16)


### PR DESCRIPTION
1. In order to eliminate memory transfer overheads between GPU and CPU, this PR implements a fully JAX'd version of PSO so that the entire algorithm can be executed on GPU. A fully JAX'd version of MCMC also needs to be implemented in a future PR.
2. Previously, the vectorization batch size when performing PSO/MCMC on GPU was automatically set to vectorize across all particles/walkers. The user can now specify the vectorization batch size separately for different fits in the fitting sequence. For complicated lensed systems, the computational power of the GPU can be saturated for batch sizes as low as 5, and further increasing the batch size results in significantly higher memory usage with no benefit to execution speed (in fact it can result in slower execution).
3. Since the Likelihood class is re-initialized after each iteration of the fitting sequence, all functions are recompiled. This PR clears the cache after each iteration so that memory usage does not build up from adding more and more compiled functions.