### PR TITLE
add MGE, fix tnfw autodiff

### DIFF
--- a/jaxtronomy/LensModel/Profiles/tnfw.py
+++ b/jaxtronomy/LensModel/Profiles/tnfw.py
@@ -296,13 +296,9 @@ class TNFW(LensProfileBase):
 
         x = jnp.maximum(x, TNFW._s)
         safe_value = jnp.sqrt(jnp.abs(1 - x**2))
-        result = jnp.where(
-            x > 1, jnp.arctan(safe_value) / safe_value, x
-        )
+        result = jnp.where(x > 1, jnp.arctan(safe_value) / safe_value, x)
         safe_value = jnp.where(x > 1, 0.5, safe_value)
-        result = jnp.where(
-            x < 1, jnp.arctanh(safe_value) / safe_value, result
-        )
+        result = jnp.where(x < 1, jnp.arctanh(safe_value) / safe_value, result)
         return result
 
     @staticmethod

--- a/jaxtronomy/LensModel/Profiles/tnfw.py
+++ b/jaxtronomy/LensModel/Profiles/tnfw.py
@@ -295,11 +295,13 @@ class TNFW(LensProfileBase):
         """
 
         x = jnp.maximum(x, TNFW._s)
+        safe_value = jnp.sqrt(jnp.abs(1 - x**2))
         result = jnp.where(
-            x < 1, (1 - x**2) ** -0.5 * jnp.arctanh((1 - x**2) ** 0.5), x
+            x > 1, jnp.arctan(safe_value) / safe_value, x
         )
+        safe_value = jnp.where(x > 1, 0.5, safe_value)
         result = jnp.where(
-            x > 1, (x**2 - 1) ** -0.5 * jnp.arctan((x**2 - 1) ** 0.5), result
+            x < 1, jnp.arctanh(safe_value) / safe_value, result
         )
         return result
 
@@ -352,8 +354,10 @@ class TNFW(LensProfileBase):
     @jit
     def _cos_function(x):
         out = jnp.ones_like(x)
-        out = jnp.where(x < 1, -jnp.arccosh(1 / x) ** 2, out)
-        out = jnp.where(x >= 1, jnp.arccos(1 / x) ** 2, out)
+        safe_value = jnp.where(x < 1, x, 1)
+        out = jnp.where(x < 1, -jnp.arccosh(1 / safe_value) ** 2, out)
+        safe_value = jnp.where(x >= 1, x, 1)
+        out = jnp.where(x >= 1, jnp.arccos(1 / safe_value) ** 2, out)
 
         return out
 

--- a/jaxtronomy/LightModel/Profiles/mge_ellipse.py
+++ b/jaxtronomy/LightModel/Profiles/mge_ellipse.py
@@ -1,0 +1,154 @@
+from functools import partial
+from jax import jit
+
+from jaxtronomy.LightModel.Profiles.mge_set import MGESet
+from jaxtronomy.Util import param_util
+
+
+class MGEEllipse(object):
+    """Multi Gaussian Sets with elliptical axis ratios."""
+
+    param_names = [
+        "amp",
+        "sigma_min",
+        "sigma_width",
+        "e1",
+        "e2",
+        "center_x",
+        "center_y",
+    ]
+    lower_limit_default = {
+        "amp": 0,
+        "sigma_min": 0.0001,
+        "sigma_width": 0.001,
+        "e1": -0.6,
+        "e2": -0.6,
+        "center_x": -100,
+        "center_y": -100,
+    }
+    upper_limit_default = {
+        "amp": 1000,
+        "sigma_min": 50,
+        "sigma_width": 1000,
+        "e1": 0.6,
+        "e2": 0.6,
+        "center_x": 100,
+        "center_y": 100,
+    }
+
+    def __init__(self, n_comp):
+        """
+
+        :param n_comp: number of Gaussian component
+        :type n_comp: int > 1
+        """
+
+        self._mge_set = MGESet(n_comp=n_comp)
+
+    @property
+    def num_linear(self):
+        """Number of linear parameters.
+
+        :return:
+        """
+        return self._mge_set.num_linear
+
+    @partial(jit, static_argnums=0)
+    def function(
+        self, x, y, amp, sigma_min, sigma_width, e1, e2, center_x=0, center_y=0
+    ):
+        """
+
+        :param x: x-coordinates
+        :param y: y-coordinates
+        :param amp: array of amplitudes in pre-defined order of shapelet basis functions
+        :param sigma_min: minimum Gaussian sigma (sigmas being logarithmically scalled between min and max)
+        :param sigma_width: sigma_min + sigma_width is maximum Gaussian sigma
+        :param e1: eccentricity component 1
+        :param e2: eccentricity component 2
+        :param center_x: MGE center x
+        :param center_y: MGE center y
+        :return: surface brightness
+        """
+        x_, y_ = param_util.transform_e1e2_product_average(
+            x, y, e1, e2, center_x=center_x, center_y=center_y
+        )
+        return self._mge_set.function(
+            x_,
+            y_,
+            amp,
+            sigma_min=sigma_min,
+            sigma_width=sigma_width,
+            center_x=0,
+            center_y=0,
+        )
+
+    @partial(jit, static_argnums=0)
+    def function_split(
+        self, x, y, amp, sigma_min, sigma_width, e1, e2, center_x=0, center_y=0
+    ):
+        """Slits surface brightness into individual Gaussian components.
+
+        :param x: x-coordinates
+        :param y: y-coordinates
+        :param amp: array of amplitudes in pre-defined order of shapelet basis functions
+        :param sigma_min: minimum Gaussian sigma (sigmas being logarithmically scalled
+            between min and max)
+        :param sigma_width: sigma_min + sigma_width is maximum Gaussian sigma
+        :param e1: eccentricity component 1
+        :param e2: eccentricity component 2
+        :param center_x: MGE center x
+        :param center_y: MGE center y
+        :return: surface brightness split in different components
+        """
+        x_, y_ = param_util.transform_e1e2_product_average(
+            x, y, e1, e2, center_x=center_x, center_y=center_y
+        )
+        return self._mge_set.function_split(
+            x_,
+            y_,
+            amp,
+            sigma_min=sigma_min,
+            sigma_width=sigma_width,
+            center_x=0,
+            center_y=0,
+        )
+
+    @partial(jit, static_argnums=0)
+    def total_flux(self, amp, sigma_min, sigma_width, e1, e2, center_x=0, center_y=0):
+        """Total integrated flux of profile.
+
+        :param amp: list of amplitudes of individual Gaussian profiles
+        :param sigma_min: minimum Gaussian sigma (sigmas being logarithmically scalled
+            between min and max)
+        :param sigma_width: sigma_min + sigma_width is maximum Gaussian sigma
+        :param e1: eccentricity component 1
+        :param e2: eccentricity component 2
+        :param center_x: center of profile
+        :param center_y: center of profile
+        :return: total flux
+        """
+        return self._mge_set.total_flux(
+            amp,
+            sigma_min=sigma_min,
+            sigma_width=sigma_width,
+            center_x=center_x,
+            center_y=center_y,
+        )
+
+    @partial(jit, static_argnums=0)
+    def light_3d(self, r, amp, sigma_min, sigma_width, e1, e2):
+        """3D brightness per angular volume element.
+
+        :param r: 3d distance from center of profile
+        :param amp: list of amplitudes of individual Gaussian profiles
+        :param sigma_min: minimum Gaussian sigma (sigmas being logarithmically scalled
+            between min and max)
+        :param sigma_width: sigma_min + sigma_width is maximum Gaussian sigma
+        :param e1: eccentricity component 1
+        :param e2: eccentricity component 2
+        :return: 3D brightness per angular volume element
+        """
+        return self._mge_set.light_3d(
+            r, amp, sigma_min=sigma_min, sigma_width=sigma_width
+        )

--- a/jaxtronomy/LightModel/Profiles/mge_set.py
+++ b/jaxtronomy/LightModel/Profiles/mge_set.py
@@ -1,0 +1,145 @@
+from functools import partial
+from jax import jit, lax, numpy as jnp
+
+from jaxtronomy.LightModel.Profiles.gaussian import Gaussian
+
+
+class MGESet(object):
+    """Class for Multi Gaussian lens light (2d projected light/mass distribution as a
+    set of Gaussians in logarithmic spacing.
+
+    profile name in LightModel module: 'MGE_SET
+    """
+
+    param_names = ["amp", "sigma_min", "sigma_width", "center_x", "center_y"]
+    lower_limit_default = {
+        "amp": 0,
+        "sigma_min": 0.0001,
+        "sigma_width": 0.001,
+        "center_x": -100,
+        "center_y": -100,
+    }
+    upper_limit_default = {
+        "amp": 1000,
+        "sigma_min": 50,
+        "sigma_width": 1000,
+        "center_x": 100,
+        "center_y": 100,
+    }
+
+    def __init__(self, n_comp):
+        """
+
+        :param n_comp: number of Gaussian component
+        :type n_comp: int > 1
+        """
+        self._ncomp = int(n_comp)
+        assert self._ncomp > 1
+
+    @property
+    def num_linear(self):
+        """Number of linear parameters.
+
+        :return:
+        """
+        return self._ncomp
+
+    @partial(jit, static_argnums=0)
+    def _sigma(self, sigma_min, sigma_width):
+        """Logarithmically scaled sigmas.
+
+        :param sigma_min: minimum Gaussian sigma (sigmas being logarithmically scalled
+            between min and max)
+        :param sigma_width: sigma_min + sigma_width is maximum Gaussian sigma
+        :return: array of sigmas for Multi-Gaussian components
+        """
+        sigmas = jnp.logspace(
+            start=jnp.log10(sigma_min),
+            stop=jnp.log10(sigma_min + sigma_width),
+            num=self._ncomp,
+            endpoint=True,
+        )
+        return sigmas
+
+    @partial(jit, static_argnums=0)
+    def function(self, x, y, amp, sigma_min, sigma_width, center_x=0, center_y=0):
+        """Surface brightness per angular unit.
+
+        :param x: coordinate on the sky
+        :param y: coordinate on the sky
+        :param amp: list of amplitudes of individual Gaussian profiles
+        :param sigma_min: minimum Gaussian sigma (sigmas being logarithmically scalled
+            between min and max)
+        :param sigma_width: sigma_min + sigma_width is maximum Gaussian sigma
+        :param center_x: center of profile
+        :param center_y: center of profile
+        :return: surface brightness at (x, y)
+        """
+        sigma = self._sigma(sigma_min=sigma_min, sigma_width=sigma_width)
+        f_ = jnp.zeros_like(x, dtype=float)
+        for i in range(len(amp)):
+            f_ += Gaussian.function(x, y, amp[i], sigma[i], center_x, center_y)
+        return f_
+
+    @partial(jit, static_argnums=0)
+    def total_flux(self, amp, sigma_min, sigma_width, center_x=0, center_y=0):
+        """Total integrated flux of profile.
+
+        :param amp: list of amplitudes of individual Gaussian profiles
+        :param sigma_min: minimum Gaussian sigma (sigmas being logarithmically scalled
+            between min and max)
+        :param sigma_width: sigma_min + sigma_width is maximum Gaussian sigma
+        :param center_x: center of profile
+        :param center_y: center of profile
+        :return: total flux
+        """
+        sigma = self._sigma(sigma_min=sigma_min, sigma_width=sigma_width)
+        flux = 0
+        for i in range(len(amp)):
+            flux += Gaussian.total_flux(amp[i], sigma[i], center_x, center_y)
+        return flux
+
+    @partial(jit, static_argnums=0)
+    def function_split(self, x, y, amp, sigma_min, sigma_width, center_x=0, center_y=0):
+        """Split surface brightness in individual components.
+
+        :param x: coordinate on the sky
+        :param y: coordinate on the sky
+        :param amp: list of amplitudes of individual Gaussian profiles
+        :param sigma_min: minimum Gaussian sigma (sigmas being logarithmically scalled
+            between min and max)
+        :param sigma_width: sigma_min + sigma_width is maximum Gaussian sigma
+        :param center_x: center of profile
+        :param center_y: center of profile
+        :return: list of arrays of surface brightness
+        """
+        amp = jnp.asarray(amp, dtype=float)
+        sigma = self._sigma(sigma_min=sigma_min, sigma_width=sigma_width)
+        f_list = jnp.zeros((len(amp), x.size), dtype=float)
+
+        def body_fun(i, f_list):
+            f_list = f_list.at[i].set(
+                Gaussian.function(
+                    x, y, amp.at[i].get(), sigma.at[i].get(), center_x, center_y
+                )
+            )
+            return f_list
+
+        return lax.fori_loop(0, len(amp), body_fun, f_list)
+
+    @partial(jit, static_argnums=0)
+    def light_3d(self, r, amp, sigma_min, sigma_width):
+        """3D brightness per angular volume element.
+
+        :param r: 3d distance from center of profile
+        :param amp: list of amplitudes of individual Gaussian profiles
+        :param sigma_min: minimum Gaussian sigma (sigmas being logarithmically scalled
+            between min and max)
+        :param sigma_width: sigma_min + sigma_width is maximum Gaussian sigma
+        :return: 3D brightness per angular volume element
+        """
+        sigma = self._sigma(sigma_min=sigma_min, sigma_width=sigma_width)
+        f_ = jnp.zeros_like(r, dtype=float)
+        for i in range(len(amp)):
+            f_ += Gaussian.light_3d(r, amp[i], sigma[i])
+        return f_

--- a/jaxtronomy/LightModel/light_model_base.py
+++ b/jaxtronomy/LightModel/light_model_base.py
@@ -16,44 +16,14 @@ _JAXXED_MODELS = [
     "CORE_SERSIC",
     "GAUSSIAN",
     "GAUSSIAN_ELLIPSE",
+    "MGE_SET",
+    "MGE_SET_ELLIPSE",
     "MULTI_GAUSSIAN",
     "MULTI_GAUSSIAN_ELLIPSE",
     "SERSIC",
     "SERSIC_ELLIPSE",
     "SERSIC_ELLIPSE_Q_PHI",
     "SHAPELETS",
-]
-
-_MODELS_SUPPORTED = [
-    "GAUSSIAN",
-    "GAUSSIAN_ELLIPSE",
-    "ELLIPSOID",
-    "MULTI_GAUSSIAN",
-    "MULTI_GAUSSIAN_ELLIPSE",
-    "SERSIC",
-    "SERSIC_ELLIPSE",
-    "SERSIC_ELLIPSE_Q_PHI",
-    "CORE_SERSIC",
-    "SHAPELETS",
-    "SHAPELETS_POLAR",
-    "SHAPELETS_POLAR_EXP",
-    "SHAPELETS_ELLIPSE",
-    "HERNQUIST",
-    "HERNQUIST_ELLIPSE",
-    "PJAFFE",
-    "PJAFFE_ELLIPSE",
-    "UNIFORM",
-    "POWER_LAW",
-    "NIE",
-    "CHAMELEON",
-    "DOUBLE_CHAMELEON",
-    "TRIPLE_CHAMELEON",
-    "INTERPOL",
-    "SLIT_STARLETS",
-    "SLIT_STARLETS_GEN2",
-    "LINEAR",
-    "LINEAR_ELLIPSE",
-    "LINE_PROFILE",
 ]
 
 
@@ -88,6 +58,14 @@ class LightModelBase(object):
             #     from lenstronomy.LightModel.Profiles.ellipsoid import Ellipsoid
 
             #     self.func_list.append(Ellipsoid(**profile_kwargs))
+            elif profile_type == "MGE_SET":
+                from jaxtronomy.LightModel.Profiles.mge_set import MGESet
+
+                self.func_list.append(MGESet(**profile_kwargs))
+            elif profile_type == "MGE_SET_ELLIPSE":
+                from jaxtronomy.LightModel.Profiles.mge_ellipse import MGEEllipse
+
+                self.func_list.append(MGEEllipse(**profile_kwargs))
             elif profile_type == "MULTI_GAUSSIAN":
                 from jaxtronomy.LightModel.Profiles.gaussian import MultiGaussian
 
@@ -317,16 +295,27 @@ class LightModelBase(object):
                 if model in [
                     "SERSIC",
                     "SERSIC_ELLIPSE",
+                    "SERSIC_ELLIPSE_FLEXION",
                     "INTERPOL",
                     "GAUSSIAN",
                     "GAUSSIAN_ELLIPSE",
                     "MULTI_GAUSSIAN",
                     "MULTI_GAUSSIAN_ELLIPSE",
+                    "MGE_SET",
+                    "MGE_SET_ELLIPSE",
                     "LINE_PROFILE",
+                    "HERNQUIST",
+                    "HERNQUIST_ELLIPSE",
+                    "PL_SERSIC",
                 ]:
                     kwargs_new = kwargs_list_standard[i].copy()
                     if norm is True:
-                        if model in ["MULTI_GAUSSIAN", "MULTI_GAUSSIAN_ELLIPSE"]:
+                        if model in [
+                            "MULTI_GAUSSIAN",
+                            "MULTI_GAUSSIAN_ELLIPSE",
+                            "MGE_SET",
+                            "MGE_SET_ELLIPSE",
+                        ]:
                             new_amp = jnp.array(kwargs_new["amp"])
                             new = {"amp": new_amp / jnp.sum(new_amp)}
                         else:

--- a/jaxtronomy/LightModel/linear_basis.py
+++ b/jaxtronomy/LightModel/linear_basis.py
@@ -5,7 +5,6 @@ __author__ = "sibirrer"
 
 from functools import partial
 from jax import jit, lax, numpy as jnp
-import numpy as np
 from jaxtronomy.LightModel.light_model_base import LightModelBase
 
 __all__ = ["LinearBasis"]
@@ -68,10 +67,19 @@ class LinearBasis(LightModelBase):
                     n += 1
                 elif model in ["MULTI_GAUSSIAN", "MULTI_GAUSSIAN_ELLIPSE"]:
                     num = len(kwargs_list[i]["sigma"])
-                    new = {"amp": np.ones(num)}
+                    new = {"amp": jnp.ones(num)}
                     kwargs_new = kwargs_list[i].copy()
                     kwargs_new.update(new)
                     response = response.at[n : n + num].set(
+                        self.func_list[i].function_split(x, y, **kwargs_new)
+                    )
+                    n += num
+                elif model in ["MGE_SET", "MGE_SET_ELLIPSE"]:
+                    num = self.func_list[i].num_linear
+                    new = {"amp": jnp.ones(num, dtype=float)}
+                    kwargs_new = kwargs_list[i].copy()
+                    kwargs_new.update(new)
+                    response = response.at[n: n + num].set(
                         self.func_list[i].function_split(x, y, **kwargs_new)
                     )
                     n += num
@@ -81,14 +89,14 @@ class LinearBasis(LightModelBase):
                     "SHAPELETS_POLAR_EXP",
                     "SHAPELETS_ELLIPSE",
                 ]:
-                    num_param = self.func_list[i].num_param
-                    new = {"amp": np.ones(num_param)}
+                    num = self.func_list[i].num_param
+                    new = {"amp": jnp.ones(num, dtype=float)}
                     kwargs_new = kwargs_list[i].copy()
                     kwargs_new.update(new)
-                    response = response.at[n : n + num_param].set(
+                    response = response.at[n : n + num].set(
                         self.func_list[i].function_split(x, y, **kwargs_new)
                     )
-                    n += num_param
+                    n += num
                 # elif model in ["SLIT_STARLETS", "SLIT_STARLETS_GEN2"]:
                 #     raise ValueError(
                 #         "'{}' model does not support function split".format(model)
@@ -137,6 +145,12 @@ class LinearBasis(LightModelBase):
                     n += 1
             elif model in ["MULTI_GAUSSIAN", "MULTI_GAUSSIAN_ELLIPSE"]:
                 num = len(kwargs_list[i]["sigma"])
+                if list_return:
+                    n_list += [num]
+                else:
+                    n += num
+            elif model in ["MGE_SET", "MGE_SET_ELLIPSE"]:
+                num = self.func_list[i].num_linear
                 if list_return:
                     n_list += [num]
                 else:
@@ -216,6 +230,10 @@ class LinearBasis(LightModelBase):
                 num_param = len(kwargs_list[k]["sigma"])
                 kwargs_list[k]["amp"] = lax.dynamic_slice(param, [i], (num_param,))
                 i += num_param
+            elif model in ["MGE_SET", "MGE_SET_ELLIPSE"]:
+                num_param = self.func_list[k].num_linear
+                kwargs_list[k]["amp"] = lax.dynamic_slice(param, [i], (num_param,))
+                i += num_param
             elif model in [
                 "SHAPELETS",
                 "SHAPELETS_POLAR",
@@ -283,19 +301,25 @@ class LinearBasis(LightModelBase):
         for k, model in enumerate(self.profile_type_list):
             if "amp" in kwargs_list[k]:
                 if model in [
-                    "SERSIC",
-                    "SERSIC_ELLIPSE",
+                    "MULTI_GAUSSIAN",
+                    "MULTI_GAUSSIAN_ELLIPSE",
+                    "MGE_SET",
+                    "MGE_SET_ELLIPSE",
+                    "CHAMELEON",
                     "CORE_SERSIC",
-                    "HERNQUIST",
-                    "PJAFFE",
-                    "PJAFFE_ELLIPSE",
-                    "HERNQUIST_ELLIPSE",
+                    "DOUBLE_CHAMELEON",
                     "GAUSSIAN",
                     "GAUSSIAN_ELLIPSE",
-                    "POWER_LAW",
+                    "HERNQUIST",
+                    "HERNQUIST_ELLIPSE",
                     "NIE",
-                    "CHAMELEON",
-                    "DOUBLE_CHAMELEON",
+                    "PJAFFE",
+                    "PJAFFE_ELLIPSE",
+                    "PL_SERSIC",
+                    "POWER_LAW",
+                    "SERSIC",
+                    "SERSIC_ELLIPSE",
+                    "SERSIC_ELLIPSE_FLEXION",
                 ]:
                     pos_bool = jnp.where(kwargs_list[k]["amp"] < 0, False, pos_bool)
         return pos_bool

--- a/jaxtronomy/LightModel/linear_basis.py
+++ b/jaxtronomy/LightModel/linear_basis.py
@@ -79,7 +79,7 @@ class LinearBasis(LightModelBase):
                     new = {"amp": jnp.ones(num, dtype=float)}
                     kwargs_new = kwargs_list[i].copy()
                     kwargs_new.update(new)
-                    response = response.at[n: n + num].set(
+                    response = response.at[n : n + num].set(
                         self.func_list[i].function_split(x, y, **kwargs_new)
                     )
                     n += num

--- a/test/test_LightModel/test_Profiles/test_mge.py
+++ b/test/test_LightModel/test_Profiles/test_mge.py
@@ -22,63 +22,88 @@ class TestMGESet(object):
     def test_function(self):
         x = np.array([1.0])
         y = np.array([2.0])
-        values_ref = self.profile_ref.function(x, y, self.amp, self.sigma_min, self.sigma_width)
+        values_ref = self.profile_ref.function(
+            x, y, self.amp, self.sigma_min, self.sigma_width
+        )
         values = self.profile.function(x, y, self.amp, self.sigma_min, self.sigma_width)
         npt.assert_array_almost_equal(values_ref, values, decimal=12)
 
         x = np.array([0.0])
         y = np.array([0.0])
-        values_ref = self.profile_ref.function(x, y, self.amp, self.sigma_min, self.sigma_width)
+        values_ref = self.profile_ref.function(
+            x, y, self.amp, self.sigma_min, self.sigma_width
+        )
         values = self.profile.function(x, y, self.amp, self.sigma_min, self.sigma_width)
         npt.assert_array_almost_equal(values_ref, values, decimal=12)
 
         x = np.linspace(-50, 50, 100)
         y = np.linspace(-50, 50, 100)
-        values_ref = self.profile_ref.function(x, y, self.amp, self.sigma_min, self.sigma_width)
+        values_ref = self.profile_ref.function(
+            x, y, self.amp, self.sigma_min, self.sigma_width
+        )
         values = self.profile.function(x, y, self.amp, self.sigma_min, self.sigma_width)
         npt.assert_array_almost_equal(values_ref, values, decimal=12)
 
     def test_function_split(self):
         x = np.array([1.2345])
         y = np.array([2.2345123])
-        values_ref = self.profile_ref.function_split(x, y, self.amp, self.sigma_min, self.sigma_width)
-        values = self.profile.function_split(x, y, self.amp, self.sigma_min, self.sigma_width)
+        values_ref = self.profile_ref.function_split(
+            x, y, self.amp, self.sigma_min, self.sigma_width
+        )
+        values = self.profile.function_split(
+            x, y, self.amp, self.sigma_min, self.sigma_width
+        )
         npt.assert_array_almost_equal(values_ref, values, decimal=12)
 
         x = np.array([0.0])
         y = np.array([0.0])
-        values_ref = self.profile_ref.function_split(x, y, self.amp, self.sigma_min, self.sigma_width)
-        values = self.profile.function_split(x, y, self.amp, self.sigma_min, self.sigma_width)
+        values_ref = self.profile_ref.function_split(
+            x, y, self.amp, self.sigma_min, self.sigma_width
+        )
+        values = self.profile.function_split(
+            x, y, self.amp, self.sigma_min, self.sigma_width
+        )
         npt.assert_array_almost_equal(values_ref, values, decimal=12)
 
         x = np.linspace(-50, 50, 100)
         y = np.linspace(-50, 50, 100)
-        values_ref = self.profile_ref.function_split(x, y, self.amp, self.sigma_min, self.sigma_width)
-        values = self.profile.function_split(x, y, self.amp, self.sigma_min, self.sigma_width)
+        values_ref = self.profile_ref.function_split(
+            x, y, self.amp, self.sigma_min, self.sigma_width
+        )
+        values = self.profile.function_split(
+            x, y, self.amp, self.sigma_min, self.sigma_width
+        )
         npt.assert_array_almost_equal(values_ref, values, decimal=12)
 
     def test_total_flux(self):
-        values_ref = self.profile_ref.total_flux(self.amp, self.sigma_min, self.sigma_width)
+        values_ref = self.profile_ref.total_flux(
+            self.amp, self.sigma_min, self.sigma_width
+        )
         values = self.profile.total_flux(self.amp, self.sigma_min, self.sigma_width)
         npt.assert_array_almost_equal(values_ref, values, decimal=12)
         npt.assert_array_almost_equal(np.sum(self.amp), values, decimal=12)
 
     def test_light_3d(self):
         r = np.array([2.0])
-        values_ref = self.profile_ref.light_3d(r, self.amp, self.sigma_min, self.sigma_width)
+        values_ref = self.profile_ref.light_3d(
+            r, self.amp, self.sigma_min, self.sigma_width
+        )
         values = self.profile.light_3d(r, self.amp, self.sigma_min, self.sigma_width)
         npt.assert_array_almost_equal(values_ref, values, decimal=12)
 
         r = np.array([3.534])
-        values_ref = self.profile_ref.light_3d(r, self.amp, self.sigma_min, self.sigma_width)
+        values_ref = self.profile_ref.light_3d(
+            r, self.amp, self.sigma_min, self.sigma_width
+        )
         values = self.profile.light_3d(r, self.amp, self.sigma_min, self.sigma_width)
         npt.assert_array_almost_equal(values_ref, values, decimal=12)
 
         r = np.linspace(-50, 50, 100)
-        values_ref = self.profile_ref.light_3d(r, self.amp, self.sigma_min, self.sigma_width)
+        values_ref = self.profile_ref.light_3d(
+            r, self.amp, self.sigma_min, self.sigma_width
+        )
         values = self.profile.light_3d(r, self.amp, self.sigma_min, self.sigma_width)
         npt.assert_array_almost_equal(values_ref, values, decimal=12)
-
 
 
 class TestMGEEllipse(object):
@@ -94,61 +119,101 @@ class TestMGEEllipse(object):
     def test_function(self):
         x = np.array([1.0])
         y = np.array([2.0])
-        values_ref = self.profile_ref.function(x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
-        values = self.profile.function(x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        values_ref = self.profile_ref.function(
+            x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2
+        )
+        values = self.profile.function(
+            x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2
+        )
         npt.assert_array_almost_equal(values_ref, values, decimal=12)
 
         x = np.array([0.0])
         y = np.array([0.0])
-        values_ref = self.profile_ref.function(x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
-        values = self.profile.function(x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        values_ref = self.profile_ref.function(
+            x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2
+        )
+        values = self.profile.function(
+            x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2
+        )
         npt.assert_array_almost_equal(values_ref, values, decimal=12)
 
         x = np.linspace(-50, 50, 100)
         y = np.linspace(-50, 50, 100)
-        values_ref = self.profile_ref.function(x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
-        values = self.profile.function(x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        values_ref = self.profile_ref.function(
+            x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2
+        )
+        values = self.profile.function(
+            x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2
+        )
         npt.assert_array_almost_equal(values_ref, values, decimal=12)
 
     def test_function_split(self):
         x = np.array([1.2345])
         y = np.array([2.2345123])
-        values_ref = self.profile_ref.function_split(x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
-        values = self.profile.function_split(x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        values_ref = self.profile_ref.function_split(
+            x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2
+        )
+        values = self.profile.function_split(
+            x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2
+        )
         npt.assert_array_almost_equal(values_ref, values, decimal=12)
 
         x = np.array([0.0])
         y = np.array([0.0])
-        values_ref = self.profile_ref.function_split(x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
-        values = self.profile.function_split(x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        values_ref = self.profile_ref.function_split(
+            x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2
+        )
+        values = self.profile.function_split(
+            x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2
+        )
         npt.assert_array_almost_equal(values_ref, values, decimal=12)
 
         x = np.linspace(-50, 50, 100)
         y = np.linspace(-50, 50, 100)
-        values_ref = self.profile_ref.function_split(x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
-        values = self.profile.function_split(x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        values_ref = self.profile_ref.function_split(
+            x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2
+        )
+        values = self.profile.function_split(
+            x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2
+        )
         npt.assert_array_almost_equal(values_ref, values, decimal=12)
 
     def test_total_flux(self):
-        values_ref = self.profile_ref.total_flux(self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
-        values = self.profile.total_flux(self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        values_ref = self.profile_ref.total_flux(
+            self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2
+        )
+        values = self.profile.total_flux(
+            self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2
+        )
         npt.assert_array_almost_equal(values_ref, values, decimal=12)
         npt.assert_array_almost_equal(np.sum(self.amp), values, decimal=12)
 
     def test_light_3d(self):
         r = np.array([2.0])
-        values_ref = self.profile_ref.light_3d(r, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
-        values = self.profile.light_3d(r, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        values_ref = self.profile_ref.light_3d(
+            r, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2
+        )
+        values = self.profile.light_3d(
+            r, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2
+        )
         npt.assert_array_almost_equal(values_ref, values, decimal=12)
 
         r = np.array([3.534])
-        values_ref = self.profile_ref.light_3d(r, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
-        values = self.profile.light_3d(r, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        values_ref = self.profile_ref.light_3d(
+            r, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2
+        )
+        values = self.profile.light_3d(
+            r, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2
+        )
         npt.assert_array_almost_equal(values_ref, values, decimal=12)
 
         r = np.linspace(-50, 50, 100)
-        values_ref = self.profile_ref.light_3d(r, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
-        values = self.profile.light_3d(r, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        values_ref = self.profile_ref.light_3d(
+            r, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2
+        )
+        values = self.profile.light_3d(
+            r, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2
+        )
         npt.assert_array_almost_equal(values_ref, values, decimal=12)
 
 

--- a/test/test_LightModel/test_Profiles/test_mge.py
+++ b/test/test_LightModel/test_Profiles/test_mge.py
@@ -1,0 +1,156 @@
+__author__ = "sibirrer"
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from lenstronomy.LightModel.Profiles.mge_set import MGESet as MGESet_ref
+from lenstronomy.LightModel.Profiles.mge_ellipse import MGEEllipse as MGEEllipse_ref
+
+from jaxtronomy.LightModel.Profiles.mge_set import MGESet
+from jaxtronomy.LightModel.Profiles.mge_ellipse import MGEEllipse
+
+
+class TestMGESet(object):
+    def setup_method(self):
+        self.profile_ref = MGESet_ref(15)
+        self.profile = MGESet(15)
+        self.amp = np.linspace(0.1, 300, 15)
+        self.sigma_min = 0.1
+        self.sigma_width = 121
+
+    def test_function(self):
+        x = np.array([1.0])
+        y = np.array([2.0])
+        values_ref = self.profile_ref.function(x, y, self.amp, self.sigma_min, self.sigma_width)
+        values = self.profile.function(x, y, self.amp, self.sigma_min, self.sigma_width)
+        npt.assert_array_almost_equal(values_ref, values, decimal=12)
+
+        x = np.array([0.0])
+        y = np.array([0.0])
+        values_ref = self.profile_ref.function(x, y, self.amp, self.sigma_min, self.sigma_width)
+        values = self.profile.function(x, y, self.amp, self.sigma_min, self.sigma_width)
+        npt.assert_array_almost_equal(values_ref, values, decimal=12)
+
+        x = np.linspace(-50, 50, 100)
+        y = np.linspace(-50, 50, 100)
+        values_ref = self.profile_ref.function(x, y, self.amp, self.sigma_min, self.sigma_width)
+        values = self.profile.function(x, y, self.amp, self.sigma_min, self.sigma_width)
+        npt.assert_array_almost_equal(values_ref, values, decimal=12)
+
+    def test_function_split(self):
+        x = np.array([1.2345])
+        y = np.array([2.2345123])
+        values_ref = self.profile_ref.function_split(x, y, self.amp, self.sigma_min, self.sigma_width)
+        values = self.profile.function_split(x, y, self.amp, self.sigma_min, self.sigma_width)
+        npt.assert_array_almost_equal(values_ref, values, decimal=12)
+
+        x = np.array([0.0])
+        y = np.array([0.0])
+        values_ref = self.profile_ref.function_split(x, y, self.amp, self.sigma_min, self.sigma_width)
+        values = self.profile.function_split(x, y, self.amp, self.sigma_min, self.sigma_width)
+        npt.assert_array_almost_equal(values_ref, values, decimal=12)
+
+        x = np.linspace(-50, 50, 100)
+        y = np.linspace(-50, 50, 100)
+        values_ref = self.profile_ref.function_split(x, y, self.amp, self.sigma_min, self.sigma_width)
+        values = self.profile.function_split(x, y, self.amp, self.sigma_min, self.sigma_width)
+        npt.assert_array_almost_equal(values_ref, values, decimal=12)
+
+    def test_total_flux(self):
+        values_ref = self.profile_ref.total_flux(self.amp, self.sigma_min, self.sigma_width)
+        values = self.profile.total_flux(self.amp, self.sigma_min, self.sigma_width)
+        npt.assert_array_almost_equal(values_ref, values, decimal=12)
+        npt.assert_array_almost_equal(np.sum(self.amp), values, decimal=12)
+
+    def test_light_3d(self):
+        r = np.array([2.0])
+        values_ref = self.profile_ref.light_3d(r, self.amp, self.sigma_min, self.sigma_width)
+        values = self.profile.light_3d(r, self.amp, self.sigma_min, self.sigma_width)
+        npt.assert_array_almost_equal(values_ref, values, decimal=12)
+
+        r = np.array([3.534])
+        values_ref = self.profile_ref.light_3d(r, self.amp, self.sigma_min, self.sigma_width)
+        values = self.profile.light_3d(r, self.amp, self.sigma_min, self.sigma_width)
+        npt.assert_array_almost_equal(values_ref, values, decimal=12)
+
+        r = np.linspace(-50, 50, 100)
+        values_ref = self.profile_ref.light_3d(r, self.amp, self.sigma_min, self.sigma_width)
+        values = self.profile.light_3d(r, self.amp, self.sigma_min, self.sigma_width)
+        npt.assert_array_almost_equal(values_ref, values, decimal=12)
+
+
+
+class TestMGEEllipse(object):
+    def setup_method(self):
+        self.profile_ref = MGEEllipse_ref(4)
+        self.profile = MGEEllipse(4)
+        self.amp = np.linspace(0.1, 3, 4)
+        self.sigma_min = 43.1
+        self.sigma_width = 0.03
+        self.e1 = 0.3
+        self.e2 = -0.17
+
+    def test_function(self):
+        x = np.array([1.0])
+        y = np.array([2.0])
+        values_ref = self.profile_ref.function(x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        values = self.profile.function(x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        npt.assert_array_almost_equal(values_ref, values, decimal=12)
+
+        x = np.array([0.0])
+        y = np.array([0.0])
+        values_ref = self.profile_ref.function(x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        values = self.profile.function(x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        npt.assert_array_almost_equal(values_ref, values, decimal=12)
+
+        x = np.linspace(-50, 50, 100)
+        y = np.linspace(-50, 50, 100)
+        values_ref = self.profile_ref.function(x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        values = self.profile.function(x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        npt.assert_array_almost_equal(values_ref, values, decimal=12)
+
+    def test_function_split(self):
+        x = np.array([1.2345])
+        y = np.array([2.2345123])
+        values_ref = self.profile_ref.function_split(x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        values = self.profile.function_split(x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        npt.assert_array_almost_equal(values_ref, values, decimal=12)
+
+        x = np.array([0.0])
+        y = np.array([0.0])
+        values_ref = self.profile_ref.function_split(x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        values = self.profile.function_split(x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        npt.assert_array_almost_equal(values_ref, values, decimal=12)
+
+        x = np.linspace(-50, 50, 100)
+        y = np.linspace(-50, 50, 100)
+        values_ref = self.profile_ref.function_split(x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        values = self.profile.function_split(x, y, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        npt.assert_array_almost_equal(values_ref, values, decimal=12)
+
+    def test_total_flux(self):
+        values_ref = self.profile_ref.total_flux(self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        values = self.profile.total_flux(self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        npt.assert_array_almost_equal(values_ref, values, decimal=12)
+        npt.assert_array_almost_equal(np.sum(self.amp), values, decimal=12)
+
+    def test_light_3d(self):
+        r = np.array([2.0])
+        values_ref = self.profile_ref.light_3d(r, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        values = self.profile.light_3d(r, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        npt.assert_array_almost_equal(values_ref, values, decimal=12)
+
+        r = np.array([3.534])
+        values_ref = self.profile_ref.light_3d(r, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        values = self.profile.light_3d(r, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        npt.assert_array_almost_equal(values_ref, values, decimal=12)
+
+        r = np.linspace(-50, 50, 100)
+        values_ref = self.profile_ref.light_3d(r, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        values = self.profile.light_3d(r, self.amp, self.sigma_min, self.sigma_width, self.e1, self.e2)
+        npt.assert_array_almost_equal(values_ref, values, decimal=12)
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/test/test_LightModel/test_light_model.py
+++ b/test/test_LightModel/test_light_model.py
@@ -61,7 +61,11 @@ class TestLightModel(object):
         test_sersic_ellipse_qphi = LightModel(["SERSIC_ELLIPSE_Q_PHI"])
 
     def test_import_profiles(self):
-        lightModel = LightModel(light_model_list=_JAXXED_MODELS)
+        profile_kwargs_list = [{} for _ in range(len(_JAXXED_MODELS))]
+        MGE_indices = [_JAXXED_MODELS.index(model) for model in ["MGE_SET", "MGE_SET_ELLIPSE"]]
+        for index in MGE_indices:
+            profile_kwargs_list[index] = {"n_comp": 5}
+        lightModel = LightModel(light_model_list=_JAXXED_MODELS, profile_kwargs_list=profile_kwargs_list)
 
     def test_check_parameters(self):
         lightModel = LightModel(light_model_list=["GAUSSIAN"])

--- a/test/test_LightModel/test_light_model.py
+++ b/test/test_LightModel/test_light_model.py
@@ -62,10 +62,14 @@ class TestLightModel(object):
 
     def test_import_profiles(self):
         profile_kwargs_list = [{} for _ in range(len(_JAXXED_MODELS))]
-        MGE_indices = [_JAXXED_MODELS.index(model) for model in ["MGE_SET", "MGE_SET_ELLIPSE"]]
+        MGE_indices = [
+            _JAXXED_MODELS.index(model) for model in ["MGE_SET", "MGE_SET_ELLIPSE"]
+        ]
         for index in MGE_indices:
             profile_kwargs_list[index] = {"n_comp": 5}
-        lightModel = LightModel(light_model_list=_JAXXED_MODELS, profile_kwargs_list=profile_kwargs_list)
+        lightModel = LightModel(
+            light_model_list=_JAXXED_MODELS, profile_kwargs_list=profile_kwargs_list
+        )
 
     def test_check_parameters(self):
         lightModel = LightModel(light_model_list=["GAUSSIAN"])

--- a/test/test_LightModel/test_linear_basis.py
+++ b/test/test_LightModel/test_linear_basis.py
@@ -9,11 +9,21 @@ class TestLinearBasis(object):
         n_max = 3
 
         self.linear_basis = LinearBasis(
-            light_model_list=["SERSIC", "MULTI_GAUSSIAN", "SHAPELETS", "MGE_SET_ELLIPSE"],
+            light_model_list=[
+                "SERSIC",
+                "MULTI_GAUSSIAN",
+                "SHAPELETS",
+                "MGE_SET_ELLIPSE",
+            ],
             profile_kwargs_list=[{}, {}, {"n_max": n_max}, {"n_comp": 5}],
         )
         self.linear_basis_ref = LinearBasis_ref(
-            light_model_list=["SERSIC", "MULTI_GAUSSIAN", "SHAPELETS", "MGE_SET_ELLIPSE"],
+            light_model_list=[
+                "SERSIC",
+                "MULTI_GAUSSIAN",
+                "SHAPELETS",
+                "MGE_SET_ELLIPSE",
+            ],
             profile_kwargs_list=[{}, {}, {}, {"n_comp": 5}],
         )
 
@@ -40,9 +50,14 @@ class TestLinearBasis(object):
             "e1": 0.3,
             "e2": -0.45,
             "center_x": 0.1,
-            "center_y": -12.3
+            "center_y": -12.3,
         }
-        self.kwargs_list = [kwargs_sersic, kwargs_multi_gaussian, kwargs_shapelets, kwargs_mge]
+        self.kwargs_list = [
+            kwargs_sersic,
+            kwargs_multi_gaussian,
+            kwargs_shapelets,
+            kwargs_mge,
+        ]
 
     def test_functions_split(self):
         x = np.tile(np.linspace(-5, 5, 50), 50)
@@ -59,10 +74,9 @@ class TestLinearBasis(object):
         param_list_ref = self.linear_basis_ref.num_param_linear_list(self.kwargs_list)
         npt.assert_array_equal(param_list, param_list_ref)
 
-        assert (
-            self.linear_basis.num_param_linear(self.kwargs_list)
-            == self.linear_basis_ref.num_param_linear(self.kwargs_list)
-        )
+        assert self.linear_basis.num_param_linear(
+            self.kwargs_list
+        ) == self.linear_basis_ref.num_param_linear(self.kwargs_list)
 
         param_list = self.linear_basis.num_param_linear(
             self.kwargs_list, list_return=True

--- a/test/test_LightModel/test_linear_basis.py
+++ b/test/test_LightModel/test_linear_basis.py
@@ -9,11 +9,12 @@ class TestLinearBasis(object):
         n_max = 3
 
         self.linear_basis = LinearBasis(
-            light_model_list=["SERSIC", "MULTI_GAUSSIAN", "SHAPELETS"],
-            profile_kwargs_list=[{}, {}, {"n_max": n_max}],
+            light_model_list=["SERSIC", "MULTI_GAUSSIAN", "SHAPELETS", "MGE_SET_ELLIPSE"],
+            profile_kwargs_list=[{}, {}, {"n_max": n_max}, {"n_comp": 5}],
         )
         self.linear_basis_ref = LinearBasis_ref(
-            light_model_list=["SERSIC", "MULTI_GAUSSIAN", "SHAPELETS"]
+            light_model_list=["SERSIC", "MULTI_GAUSSIAN", "SHAPELETS", "MGE_SET_ELLIPSE"],
+            profile_kwargs_list=[{}, {}, {}, {"n_comp": 5}],
         )
 
         kwargs_sersic = {
@@ -33,7 +34,15 @@ class TestLinearBasis(object):
             "center_x": -0.1,
             "center_y": -0.2,
         }
-        self.kwargs_list = [kwargs_sersic, kwargs_multi_gaussian, kwargs_shapelets]
+        kwargs_mge = {
+            "sigma_min": 0.5,
+            "sigma_width": 13.4,
+            "e1": 0.3,
+            "e2": -0.45,
+            "center_x": 0.1,
+            "center_y": -12.3
+        }
+        self.kwargs_list = [kwargs_sersic, kwargs_multi_gaussian, kwargs_shapelets, kwargs_mge]
 
     def test_functions_split(self):
         x = np.tile(np.linspace(-5, 5, 50), 50)
@@ -43,7 +52,7 @@ class TestLinearBasis(object):
             x, y, self.kwargs_list
         )
         npt.assert_allclose(response, response_ref, atol=1e-12, rtol=1e-12)
-        assert n == n_ref == 14
+        assert n == n_ref
 
     def test_num_param_linear(self):
         param_list = self.linear_basis.num_param_linear_list(self.kwargs_list)
@@ -53,7 +62,6 @@ class TestLinearBasis(object):
         assert (
             self.linear_basis.num_param_linear(self.kwargs_list)
             == self.linear_basis_ref.num_param_linear(self.kwargs_list)
-            == 14
         )
 
         param_list = self.linear_basis.num_param_linear(
@@ -65,16 +73,17 @@ class TestLinearBasis(object):
         npt.assert_array_equal(param_list, param_list_ref)
 
     def test_update_linear(self):
-        param = np.arange(1, 15, 1)
+        param = np.arange(1, 20, 1)
         i = 0
         kwargs_list, i_new = self.linear_basis.update_linear(param, i, self.kwargs_list)
         kwargs_list_ref, i_new_ref = self.linear_basis_ref.update_linear(
             param, i, self.kwargs_list
         )
-        assert i_new == i_new_ref == 14
+        assert i_new == i_new_ref
         npt.assert_array_equal(kwargs_list[0]["amp"], kwargs_list_ref[0]["amp"])
         npt.assert_array_equal(kwargs_list[1]["amp"], kwargs_list_ref[1]["amp"])
         npt.assert_array_equal(kwargs_list[2]["amp"], kwargs_list_ref[2]["amp"])
+        npt.assert_array_equal(kwargs_list[3]["amp"], kwargs_list_ref[3]["amp"])
 
     def test_add_fixed_linear(self):
         linear_basis = LinearBasis(light_model_list=["SERSIC", "SERSIC_ELLIPSE"])

--- a/test/test_Sampling/test_likelihood.py
+++ b/test/test_Sampling/test_likelihood.py
@@ -1,6 +1,6 @@
 __author__ = "sibirrer"
 
-from jax import numpy as jnp, grad, jit
+from jax import numpy as jnp, grad, jit, debug_nans
 import pytest
 import numpy as np
 import numpy.testing as npt
@@ -390,28 +390,33 @@ class TestLikelihood(object):
                 **self.kwargs_data_joint,
             )
 
-            kwargs_lens = lensModel.lens_model.func_list[0].lower_limit_default
+            kwargs_lens = lensModel.lens_model.func_list[0].upper_limit_default
             for key, val in kwargs_lens.items():
                 kwargs_lens[key] = float(val)
-            print(kwargs_lens)
+            print("input kwargs:", kwargs_lens)
 
-            # don't care about the return value, just check that this runs
-            test_autodiff = jit(grad(_logL, argnums=1), static_argnums=0)(
-                likelihood, [kwargs_lens], None
-            )
+            # check that everything is differentiable
+            with debug_nans(True):
+                test_autodiff = jit(grad(_logL, argnums=1), static_argnums=0)(
+                    likelihood, [kwargs_lens], None
+                )
+            assert not np.any(np.isnan(np.array(list(test_autodiff[0].values()))))
 
     def test_lightmodel_autodifferentiation(self):
         del self.kwargs_data_joint["ra_image_list"]
         del self.kwargs_data_joint["dec_image_list"]
         for source_profile in JAXXED_SOURCE_PROFILES:
             print(source_profile)
-            # this is just needed to get param names
-            lightModel = LightModel([source_profile])
 
             if source_profile == "SHAPELETS":
                 source_light_profile_kwargs_list = [{"n_max": 1}]
+            elif source_profile in ["MGE_SET", "MGE_SET_ELLIPSE"]:
+                source_light_profile_kwargs_list = [{"n_comp": 5}]
             else:
                 source_light_profile_kwargs_list = [{}]
+
+            # this is just needed to get param names
+            lightModel = LightModel([source_profile], profile_kwargs_list=source_light_profile_kwargs_list)
 
             kwargs_model = {
                 "lens_model_list": [],
@@ -425,22 +430,27 @@ class TestLikelihood(object):
                 linear_solver=True,
             )
 
-            kwargs_source = lightModel.func_list[0].lower_limit_default
+            kwargs_source = lightModel.func_list[0].upper_limit_default
             for key, val in kwargs_source.items():
                 if source_profile in [
                     "MULTI_GAUSSIAN",
                     "MULTI_GAUSSIAN_ELLIPSE",
+                    "MGE_SET",
+                    "MGE_SET_ELLIPSE",
                     "SHAPELETS",
                 ] and key in ["amp", "sigma"]:
                     kwargs_source[key] = [float(val)] * 3
                 else:
                     kwargs_source[key] = float(val)
-            print(kwargs_source)
 
-            # don't care about the return value, just check that this runs
-            test_autodiff = jit(grad(_logL, argnums=2), static_argnums=0)(
-                likelihood, None, [kwargs_source]
-            )
+            print("input kwargs:", kwargs_source)
+            # check that everything is differentiable
+            with debug_nans(True):
+                test_autodiff = jit(grad(_logL, argnums=2), static_argnums=0)(
+                    likelihood, None, [kwargs_source]
+                )
+            for value in list(test_autodiff[0].values()):
+                assert not np.any(np.isnan(np.array(value)))
 
 
 def _logL(imagelikelihood, kwargs_lens, kwargs_source):

--- a/test/test_Sampling/test_likelihood.py
+++ b/test/test_Sampling/test_likelihood.py
@@ -427,7 +427,7 @@ class TestLikelihood(object):
             likelihood = ImageLikelihood(
                 kwargs_model=kwargs_model,
                 **self.kwargs_data_joint,
-                linear_solver=True,
+                linear_solver=False,
             )
 
             kwargs_source = lightModel.func_list[0].upper_limit_default

--- a/test/test_Sampling/test_likelihood.py
+++ b/test/test_Sampling/test_likelihood.py
@@ -416,7 +416,9 @@ class TestLikelihood(object):
                 source_light_profile_kwargs_list = [{}]
 
             # this is just needed to get param names
-            lightModel = LightModel([source_profile], profile_kwargs_list=source_light_profile_kwargs_list)
+            lightModel = LightModel(
+                [source_profile], profile_kwargs_list=source_light_profile_kwargs_list
+            )
 
             kwargs_model = {
                 "lens_model_list": [],


### PR DESCRIPTION
1. This PR addresses issue #66. In general, whenever `jnp.where(bool, branch_1, branch_2)` is executed, both branches are computed and one is discarded depending on the bool. However, when computing gradients, any NaNs that appear in either branch are propagated forwards, even if that branch is discarded.
2. Implements MGE light profiles for dolphin users