### PR TITLE
Accept FITS big-endian byte order

### DIFF
--- a/jaxtronomy/Data/image_noise.py
+++ b/jaxtronomy/Data/image_noise.py
@@ -48,6 +48,9 @@ class ImageNoise(object):
                     "Exposure map has not been specified in Noise() class!"
                 )
         else:
+            # cast to native byte order so big-endian (e.g., FITS >f8) inputs are accepted
+            exposure_time = jnp.asarray(exposure_time, dtype=float)
+
             # make sure no negative exposure values are present no dividing by zero
             self.exposure_map = jnp.where(
                 exposure_time <= 10 ** (-10), 10 ** (-10), exposure_time
@@ -63,12 +66,12 @@ class ImageNoise(object):
         else:
             self.background_rms = background_rms
 
-        self.data = jnp.array(image_data)
+        self.data = jnp.array(image_data, dtype=float)
         self.flux_scaling = flux_scaling
 
         if noise_map is not None:
             assert np.shape(noise_map) == np.shape(image_data)
-            self._noise_map = jnp.array(noise_map)
+            self._noise_map = jnp.array(noise_map, dtype=float)
         else:
             self._noise_map = noise_map
             if background_rms is not None and exposure_time is not None:

--- a/jaxtronomy/Data/imaging_data.py
+++ b/jaxtronomy/Data/imaging_data.py
@@ -144,7 +144,8 @@ class ImageData(PixelGrid, ImageNoise):
             raise ValueError(
                 f"New data shape {image_data.shape} should match old data shape {self.data.shape}"
             )
-        self.data = image_data
+        # cast to native byte order so big-endian (e.g., FITS >f8) inputs are accepted
+        self.data = np.asarray(image_data, dtype=np.float64)
 
         # Recompile the log likelihood functions
         self.log_likelihood = jit(self._log_likelihood)

--- a/test/test_Data/test_image_noise.py
+++ b/test/test_Data/test_image_noise.py
@@ -79,10 +79,8 @@ class Test_ImageNoise_without_noisemap(object):
 
 
 def test_big_endian_image_data():
-    """
-    FITS files store data in big-endian (>f8) byte order which JAX rejects 
-    unless it is converted to native byte order first.
-    """
+    """FITS files store data in big-endian (>f8) byte order which JAX rejects unless it
+    is converted to native byte order first."""
     num_pix = 10
     native = np.ones((num_pix, num_pix), dtype=np.float64)
     big_endian = native.astype(">f8")

--- a/test/test_Data/test_image_noise.py
+++ b/test/test_Data/test_image_noise.py
@@ -78,5 +78,30 @@ class Test_ImageNoise_without_noisemap(object):
         npt.assert_array_almost_equal(c_d, c_d_ref, decimal=6)
 
 
+def test_big_endian_image_data():
+    """
+    FITS files store data in big-endian (>f8) byte order which JAX rejects 
+    unless it is converted to native byte order first.
+    """
+    num_pix = 10
+    native = np.ones((num_pix, num_pix), dtype=np.float64)
+    big_endian = native.astype(">f8")
+
+    # noise-map path: image_data and noise_map both big-endian
+    noise = ImageNoise(
+        image_data=big_endian,
+        noise_map=big_endian.copy(),
+    )
+    npt.assert_array_almost_equal(noise.data, native, decimal=6)
+
+    # exposure-map path: big-endian exposure map flows through jnp.where
+    noise2 = ImageNoise(
+        image_data=big_endian,
+        exposure_time=big_endian.copy(),
+        background_rms=1.103,
+    )
+    npt.assert_array_almost_equal(noise2.data, native, decimal=6)
+
+
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
This PR allows JAXtronomy to handle raw FITS data which uses big-endian byte order.

While modeling JWST strong lenses with dolphin, I got the following error:
```
TypeError: Dtype >f8 is not a valid JAX array type. Only arrays of numeric types are supported by JAX.
```
The fix, `dtype=float`, is a no-op for regular little-endian arrays but will byte-swap big-endian arrays so JAX can handle them.